### PR TITLE
Clarify Path for Submit Command

### DIFF
--- a/doc/submit.md
+++ b/doc/submit.md
@@ -13,7 +13,7 @@ The following arguments are available:
 
 | <div style="width:100px">Argument</div>| Description |
 |----------------  |-------------|
-| **-p, --path**   |     Required. Path to a manifest file or directory to submit to the Windows Package Manager repo
+| **-p, --path**   |     Required. Path to a manifest file or directory containing the manifests that you want to submit to the Windows Package Manager repo
 | **-t, --token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.
 
 If you have provided your [GitHub token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) on the command line along with the **--submit** command and the device is registered with Github, **WingetCreate** will submit your PR to [Windows Package Manager repo](https://docs.microsoft.com/en-us/windows/package-manager/).  

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -925,7 +925,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path to a manifest file or directory to submit to the Windows Package Manager repo.
+        ///   Looks up a localized string similar to Path to a manifest file or directory containing the manifests that you want to submit to the Windows Package Manager repo.
         /// </summary>
         public static string Path_HelpText {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -221,7 +221,7 @@
     <value>Path does not exist</value>
   </data>
   <data name="Path_HelpText" xml:space="preserve">
-    <value>Path to a manifest file or directory to submit to the Windows Package Manager repo</value>
+    <value>Path to a manifest file or directory containing the manifests that you want to submit to the Windows Package Manager repo</value>
   </data>
   <data name="GitHubFailedAuthorization_Message" xml:space="preserve">
     <value>GitHub authorization failed: {0} - {1}</value>


### PR DESCRIPTION
Modify help text to explicitly state that the submit path for manifest is the directory containing the manifests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/8)