### PR TITLE
Omitting resource type packages, and prompting for architecture in some cases

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -40,7 +40,7 @@ jobs:
     dependsOn: GetVersion
     variables:
       majorMinorBuildVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorBuildVersion']]
-      revision: $[counter(format('{0}.{1}', '2', variables['majorMinorBuildVersion']), 1)]
+      revision: $[counter(format('{0}.{1}', '3', variables['majorMinorBuildVersion']), 1)]
 
       version: "$(majorMinorBuildVersion).$(revision)"
       appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
@@ -211,5 +211,5 @@ jobs:
           # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
 
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          wingetcreate.exe update -i Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT)
+          wingetcreate.exe update -i Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
         displayName: Update package manifest in the OWC

--- a/src/WingetCreateCLI/Commands/SubmitCommand.cs
+++ b/src/WingetCreateCLI/Commands/SubmitCommand.cs
@@ -51,7 +51,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         {
             CommandExecutedEvent commandEvent = new CommandExecutedEvent
             {
-                Command = "Submit",
+                Command = nameof(SubmitCommand),
                 HasGitHubToken = !string.IsNullOrEmpty(this.GitHubToken),
             };
 

--- a/src/WingetCreateCLI/Commands/TokenCommand.cs
+++ b/src/WingetCreateCLI/Commands/TokenCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         {
             CommandExecutedEvent commandEvent = new CommandExecutedEvent
             {
-                Command = "Token",
+                Command = nameof(TokenCommand),
                 HasGitHubToken = !string.IsNullOrEmpty(this.GitHubToken),
             };
 

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -85,7 +85,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         {
             CommandExecutedEvent commandEvent = new CommandExecutedEvent
             {
-                Command = "update",
+                Command = nameof(UpdateCommand),
                 InstallerUrl = this.InstallerUrl,
                 Id = this.Id,
                 Version = this.Version,

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -399,9 +399,10 @@ namespace Microsoft.WingetCreateCore
                     IAppxFile signatureFile = bundle.AppxBundleReader.GetFootprintFile(APPX_BUNDLE_FOOTPRINT_FILE_TYPE.APPX_BUNDLE_FOOTPRINT_FILE_TYPE_SIGNATURE);
                     signatureSha256 = HashAppxFile(signatureFile);
 
-                    foreach (var appxName in bundle.InternalAppxPackagesRelativePaths)
+                    // Only create installer nodes for non-resource packages
+                    foreach (var childPackage in bundle.ChildAppxPackages.Where(p => p.PackageType == PackageType.Application))
                     {
-                        var appxFile = bundle.AppxBundleReader.GetPayloadPackage(appxName);
+                        var appxFile = bundle.AppxBundleReader.GetPayloadPackage(childPackage.RelativeFilePath);
                         appxMetadatas.Add(new AppxMetadata(appxFile.GetStream()));
                     }
                 }

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -17,12 +17,12 @@
   <ItemGroup>
     <PackageReference Include="jose-jwt" Version="3.1.1" />
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
-    <PackageReference Include="Microsoft.Msix.Utils" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.0" />
     <!--https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#generatepathproperty-->
     <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="0.2.8" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="NLog" Version="4.7.9" />
-    <PackageReference Include="NSwag.MSBuild" Version="13.10.9">
+    <PackageReference Include="NSwag.MSBuild" Version="13.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes #12, Fixes #13 

* Adds filtering to ensure we don't generate installer nodes for resource msix packages
* Adds logic to prompt for Architecture when we can't trust that we got it right
* Adds --submit option to wingetcreate command in release pipeline
* Standardizes the command name in the CommandExecutedEvents

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/14)