### PR TITLE
Modifying logging to only call string.Format if there are format arguments

### DIFF
--- a/src/WingetCreateCLI/Logger/Logger.cs
+++ b/src/WingetCreateCLI/Logger/Logger.cs
@@ -130,7 +130,7 @@ namespace Microsoft.WingetCreateCLI.Logging
         /// <param name="args">Arguments to replace formatted items in message.</param>
         private static void Log(LogLevel level, string format, params object[] args)
         {
-            string message = string.Format(format, args);
+            string message = args.Length > 0 ? string.Format(format, args) : format;
 
             LogEventInfo logEventFile = new LogEventInfo(level, loggerFile.Name, message);
             loggerFile.Log(typeof(Logger), logEventFile);


### PR DESCRIPTION
Fixes #49

We were always calling string.Format, which is usually innocuous unless the format string has an invalid formatter, like "{version}". In that case, we'd get:

    System.FormatException: Input string was not in a correct format.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/58)