### PR TITLE
Adding parsing logic for Burn installerType

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -38,7 +38,6 @@ namespace Microsoft.WingetCreateCore
         private static readonly string[] KnownInstallerResourceNames = new[]
         {
             "inno",
-            "wix",
             "nullsoft",
         };
 
@@ -254,7 +253,20 @@ namespace Microsoft.WingetCreateCore
                     .Split(' ').First()
                     .ToLowerInvariant();
 
-                installer.InstallerType = KnownInstallerResourceNames.Contains(installerType) ? installerType.ToEnumOrDefault<InstallerType>() : InstallerType.Exe;
+                if (installerType.EqualsIC("wix"))
+                {
+                    // See https://github.com/microsoft/winget-create/issues/26, a Burn installer is an exe-installer produced by the WiX toolset.
+                    installer.InstallerType = InstallerType.Burn;
+                }
+                else if (KnownInstallerResourceNames.Contains(installerType))
+                {
+                    // If it's a known exe installer type, set as appropriately
+                    installer.InstallerType = installerType.ToEnumOrDefault<InstallerType>();
+                }
+                else
+                {
+                    installer.InstallerType = InstallerType.Exe;
+                }
 
                 return true;
             }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----
Fixes #26

A Burn installer is an exe installer generated by the WiX toolset. A true "wix" installer is an MSI, but there's currently no need to generate between one of those and another MSI type

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/73)