### PR TITLE
Fixing msixbundle signing

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -137,7 +137,7 @@ jobs:
           ConnectedServiceName: "PeetPackageEs2"
           FolderPath: $(appxPackageDir)
           Pattern: |
-            $(appxBundleFile),
+            **/$(appxBundleFile),
             **/WingetCreateCLI.exe
           UseMinimatch: true
           signConfigType: inlineSignParams

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -137,7 +137,7 @@ jobs:
           ConnectedServiceName: "PeetPackageEs2"
           FolderPath: $(appxPackageDir)
           Pattern: |
-            **/$(appxBundleFile),
+            **/$(appxBundleFile)
             **/WingetCreateCLI.exe
           UseMinimatch: true
           signConfigType: inlineSignParams


### PR DESCRIPTION
Adding exe signing broke the msixbundle signing, due to an errant comma

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/85)