### PR TITLE
Removing BOM prefix from manifest content

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -307,7 +307,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             VersionManifest versionManifest = manifests.VersionManifest;
             versionManifest.PackageIdentifier = PromptProperty(versionManifest, versionManifest.PackageIdentifier, nameof(versionManifest.PackageIdentifier));
 
-            GitHub client = new GitHub(null, this.WingetRepoOwner, this.WingetRepo);
+            GitHub client = new GitHub(this.GitHubToken, this.WingetRepoOwner, this.WingetRepo);
 
             string exactMatch = await client.FindPackageId(versionManifest.PackageIdentifier);
             if (!string.IsNullOrEmpty(exactMatch))

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -97,7 +97,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             {
                 Logger.DebugLocalized(nameof(Resources.RetrievingManifest_Message), this.Id);
 
-                GitHub client = new GitHub(null, this.WingetRepoOwner, this.WingetRepo);
+                GitHub client = new GitHub(this.GitHubToken, this.WingetRepoOwner, this.WingetRepo);
                 string exactId = await client.FindPackageId(this.Id);
 
                 if (!string.IsNullOrEmpty(exactId))

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -146,29 +146,42 @@ namespace Microsoft.WingetCreateCore
         {
             foreach (string content in manifestContents)
             {
-                ManifestTypeBase baseType = Serialization.DeserializeFromString<ManifestTypeBase>(content);
+                string trimmedContent = RemoveBom(content);
+
+                ManifestTypeBase baseType = Serialization.DeserializeFromString<ManifestTypeBase>(trimmedContent);
 
                 if (baseType.ManifestType == "singleton")
                 {
-                    manifests.SingletonManifest = Serialization.DeserializeFromString<SingletonManifest>(content);
+                    manifests.SingletonManifest = Serialization.DeserializeFromString<SingletonManifest>(trimmedContent);
                 }
                 else if (baseType.ManifestType == "version")
                 {
-                    manifests.VersionManifest = Serialization.DeserializeFromString<VersionManifest>(content);
+                    manifests.VersionManifest = Serialization.DeserializeFromString<VersionManifest>(trimmedContent);
                 }
                 else if (baseType.ManifestType == "defaultLocale")
                 {
-                    manifests.DefaultLocaleManifest = Serialization.DeserializeFromString<DefaultLocaleManifest>(content);
+                    manifests.DefaultLocaleManifest = Serialization.DeserializeFromString<DefaultLocaleManifest>(trimmedContent);
                 }
                 else if (baseType.ManifestType == "locale")
                 {
-                    manifests.LocaleManifests.Add(Serialization.DeserializeFromString<LocaleManifest>(content));
+                    manifests.LocaleManifests.Add(Serialization.DeserializeFromString<LocaleManifest>(trimmedContent));
                 }
                 else if (baseType.ManifestType == "installer")
                 {
-                    manifests.InstallerManifest = Serialization.DeserializeFromString<InstallerManifest>(content);
+                    manifests.InstallerManifest = Serialization.DeserializeFromString<InstallerManifest>(trimmedContent);
                 }
             }
+        }
+
+        /// <summary>
+        /// Removes Byte Order Marker (BOM) prefix if exists in string.
+        /// </summary>
+        /// <param name="value">String to fix.</param>
+        /// <returns>String without BOM prefix.</returns>
+        private static string RemoveBom(string value)
+        {
+            string bomMarkUtf8 = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
+            return value.StartsWith(bomMarkUtf8, StringComparison.OrdinalIgnoreCase) ? value.Remove(0, bomMarkUtf8.Length) : value;
         }
 
         private class YamlStringEnumConverter : IYamlTypeConverter


### PR DESCRIPTION
Fixes #90

Also modifying temporary GitHub clients used by the New and Update commands to use the passed-in GitHub token if present. the GitHub API has throttling which users may hit sometimes (I did when testing this fix), and we should have a way for users to get around that by specifying a token on the command line

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/91)