### PR TITLE
Rename WindowsPackageManagerRepository setting and Add Documentation

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -5,7 +5,7 @@ You can configure Winget-Create by editing the `settings.json` file. Running `wi
 
 ## Telemetry
 
-The `telemetry` settings control whether Winget-Create writes ETW events that may be sent to Microsoft on a default installation of Windows.
+The `Telemetry` settings control whether Winget-Create writes ETW events that may be sent to Microsoft on a default installation of Windows.
 
 See [details on telemetry](https://github.com/microsoft/winget-create#datatelemetry), and our [primary privacy statement](../PRIVACY.md).
 
@@ -18,3 +18,22 @@ See [details on telemetry](https://github.com/microsoft/winget-create#datateleme
 ```
 
 If set to true, the `telemetry.disable` setting will prevent any event from being written by the program.
+
+## WindowsPackageManagerRepository
+
+The `WindowsPackageManagerRepository` setting specifies which repository Winget-Create targets. By default, this setting targets the main [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) repository but can be changed to target a forked copy of the main repository like a [test](https://github.com/microsoft/winget-pkgs-submission-test) or private production repository. 
+
+### Owner
+The `owner` setting specifies who owns the targeted GitHub repository. By default, this is set to `microsoft`.
+
+
+### Name
+The `name` setting specifies the name of the targeted GitHub repository. By default, this is set to `winget-pkgs`.
+
+```json
+  "WindowsPackageManagerRepository": {
+    "owner": "microsoft",
+    "name": "winget-pkgs"
+  }
+```
+

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -53,12 +53,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// Gets or sets the winget repo owner to use.
         /// </summary>
-        public string WingetRepoOwner { get; set; } = UserSettings.WingetPkgsRepoOwner ?? DefaultWingetRepoOwner;
+        public string WingetRepoOwner { get; set; } = UserSettings.WindowsPackageManagerRepositoryOwner ?? DefaultWingetRepoOwner;
 
         /// <summary>
         /// Gets or sets the winget repo to use.
         /// </summary>
-        public string WingetRepo { get; set; } = UserSettings.WingetPkgsRepoName ?? DefaultWingetRepo;
+        public string WingetRepo { get; set; } = UserSettings.WindowsPackageManagerRepositoryName ?? DefaultWingetRepo;
 
         /// <summary>
         /// Gets or sets the most recent pull request id associated with the command.

--- a/src/WingetCreateCLI/Models/SettingsModel.cs
+++ b/src/WingetCreateCLI/Models/SettingsModel.cs
@@ -19,15 +19,15 @@ namespace Microsoft.WingetCreateCLI.Models.Settings
     
     }
     
-    /// <summary>Winget-Pkgs Repository Settings</summary>
+    /// <summary>Windows Package Manager Repository settings</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
-    public partial class WingetPkgsRepo 
+    public partial class WindowsPackageManagerRepository 
     {
-        /// <summary>Specifies the name of the Winget-Pkgs repository owner</summary>
+        /// <summary>Specifies the name of the Windows Package Manager Repository owner</summary>
         [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Owner { get; set; } = "microsoft";
     
-        /// <summary>Specifies the name of the Winget-Pkgs repository</summary>
+        /// <summary>Specifies the name of the Windows Package Manager Repository</summary>
         [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Name { get; set; } = "winget-pkgs";
     
@@ -45,9 +45,9 @@ namespace Microsoft.WingetCreateCLI.Models.Settings
         [System.ComponentModel.DataAnnotations.Required]
         public Telemetry Telemetry { get; set; } = new Telemetry();
     
-        [Newtonsoft.Json.JsonProperty("WingetPkgsRepo", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("WindowsPackageManagerRepository", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]
-        public WingetPkgsRepo WingetPkgsRepo { get; set; } = new WingetPkgsRepo();
+        public WindowsPackageManagerRepository WindowsPackageManagerRepository { get; set; } = new WindowsPackageManagerRepository();
     
     
     }

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1177,7 +1177,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repository &quot;{0}/{1}&quot; not found. Please verify the WingetPkgsRepoOwner and WingetPkgsRepoName in your settings file..
+        ///   Looks up a localized string similar to Repository &quot;{0}/{1}&quot; not found. Please verify the Windows Package Manager repository owner and name in your settings file..
         /// </summary>
         public static string RepositoryNotFound_Error {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -630,8 +630,8 @@
 {1} - Architecture determined from the installer binary</comment>
   </data>
   <data name="RepositoryNotFound_Error" xml:space="preserve">
-    <value>Repository "{0}/{1}" not found. Please verify the WingetPkgsRepoOwner and WingetPkgsRepoName in your settings file.</value>
-    <comment>{0} - will be replaced with the owner name of the winget-pkgs repository
-{1} - will be replaced with the name of the winget-pkgs repository</comment>
+    <value>Repository "{0}/{1}" not found. Please verify the Windows Package Manager repository owner and name in your settings file.</value>
+    <comment>{0} - will be replaced with the owner name of the Windows Package Manager repository
+{1} - will be replaced with the name of the Windows Package Manager repository</comment>
   </data>
 </root>

--- a/src/WingetCreateCLI/Schemas/settings.schema.0.1.json
+++ b/src/WingetCreateCLI/Schemas/settings.schema.0.1.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://aka.ms/wingetcreate-settings.schema.json",
+  "$id": "https://aka.ms/wingetcreate-settings.schema.0.1.json",
   "$schema": "https://json-schema.org/draft/2019-09/schema#",
   "title": "Microsoft's Windows Package Manager Manifest Creator Settings Profile Schema",
   "definitions": {
@@ -15,17 +15,17 @@
       },
       "additionalProperties": false
     },
-    "WingetPkgsRepo": {
-      "description": "Winget-Pkgs Repository Settings",
+    "WindowsPackageManagerRepository": {
+      "description": "Windows Package Manager Repository settings",
       "type": "object",
       "properties": {
         "owner": {
-          "description": "Specifies the name of the Winget-Pkgs repository owner",
+          "description": "Specifies the name of the Windows Package Manager Repository owner",
           "type": "string",
           "default": "microsoft"
         },
         "name": {
-          "description": "Specifies the name of the Winget-Pkgs repository",
+          "description": "Specifies the name of the Windows Package Manager Repository",
           "type": "string",
           "default": "winget-pkgs"
         }
@@ -38,14 +38,14 @@
     "$schema": {
       "description": "The settings json schema",
       "type": "string",
-      "default": "https://aka.ms/wingetcreate-settings.schema.json"
+      "default": "https://aka.ms/wingetcreate-settings.schema.0.1.json"
     },
     "Telemetry": { "$ref": "#/definitions/Telemetry" },
-    "WingetPkgsRepo": { "$ref": "#/definitions/WingetPkgsRepo" }
+    "WindowsPackageManagerRepository": { "$ref": "#/definitions/WindowsPackageManagerRepository" }
   },
   "required": [
     "Telemetry",
-    "WingetPkgsRepo"
+    "WindowsPackageManagerRepository"
   ],
   "additionalProperties": false
 }

--- a/src/WingetCreateCLI/UserSettings.cs
+++ b/src/WingetCreateCLI/UserSettings.cs
@@ -53,13 +53,13 @@ namespace Microsoft.WingetCreateCLI
         /// <summary>
         /// Gets or sets the owner of the winget-pkgs repository.
         /// </summary>
-        public static string WingetPkgsRepoOwner
+        public static string WindowsPackageManagerRepositoryOwner
         {
-            get => Settings.WingetPkgsRepo.Owner;
+            get => Settings.WindowsPackageManagerRepository.Owner;
 
             set
             {
-                Settings.WingetPkgsRepo.Owner = value;
+                Settings.WindowsPackageManagerRepository.Owner = value;
                 SaveSettings();
             }
         }
@@ -67,13 +67,13 @@ namespace Microsoft.WingetCreateCLI
         /// <summary>
         /// Gets or sets the name of the winget-pkgs repository.
         /// </summary>
-        public static string WingetPkgsRepoName
+        public static string WindowsPackageManagerRepositoryName
         {
-            get => Settings.WingetPkgsRepo.Name;
+            get => Settings.WindowsPackageManagerRepository.Name;
 
             set
             {
-                Settings.WingetPkgsRepo.Name = value;
+                Settings.WindowsPackageManagerRepository.Name = value;
                 SaveSettings();
             }
         }
@@ -169,7 +169,7 @@ namespace Microsoft.WingetCreateCLI
                 Settings = new SettingsManifest
                 {
                     Telemetry = new Models.Settings.Telemetry(),
-                    WingetPkgsRepo = new WingetPkgsRepo(),
+                    WindowsPackageManagerRepository = new WindowsPackageManagerRepository(),
                 };
             }
         }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/SettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/SettingsCommandTests.cs
@@ -44,8 +44,8 @@ namespace Microsoft.WingetCreateUnitTests
         [TearDown]
         public void TearDown()
         {
-            UserSettings.WingetPkgsRepoOwner = BaseCommand.DefaultWingetRepoOwner;
-            UserSettings.WingetPkgsRepoName = BaseCommand.DefaultWingetRepo;
+            UserSettings.WindowsPackageManagerRepositoryOwner = BaseCommand.DefaultWingetRepoOwner;
+            UserSettings.WindowsPackageManagerRepositoryName = BaseCommand.DefaultWingetRepo;
         }
 
         /// <summary>
@@ -98,12 +98,12 @@ namespace Microsoft.WingetCreateUnitTests
             string testRepoOwner = "testRepoOwner";
             string testRepoName = "testRepoName";
             UserSettings.TelemetryDisabled = !isDisabled;
-            UserSettings.WingetPkgsRepoOwner = testRepoOwner;
-            UserSettings.WingetPkgsRepoName = testRepoName;
+            UserSettings.WindowsPackageManagerRepositoryOwner = testRepoOwner;
+            UserSettings.WindowsPackageManagerRepositoryName = testRepoName;
             UserSettings.ParseJsonFile(UserSettings.SettingsJsonPath, out SettingsManifest manifest);
             Assert.IsTrue(manifest.Telemetry.Disable == !isDisabled, "Changed Telemetry setting was not reflected in the settings file.");
-            Assert.IsTrue(manifest.WingetPkgsRepo.Owner == testRepoOwner, "Changed WingetPkgsRepo.Owner setting was not reflected in the settings file.");
-            Assert.IsTrue(manifest.WingetPkgsRepo.Name == testRepoName, "Changed WingetPkgsRepo.Name setting was not reflected in the settings file.");
+            Assert.IsTrue(manifest.WindowsPackageManagerRepository.Owner == testRepoOwner, "Changed WindowsPackageManagerRepository.Owner setting was not reflected in the settings file.");
+            Assert.IsTrue(manifest.WindowsPackageManagerRepository.Name == testRepoName, "Changed WindowsPackageManagerRepository.Name setting was not reflected in the settings file.");
         }
 
         /// <summary>
@@ -115,8 +115,8 @@ namespace Microsoft.WingetCreateUnitTests
         {
             string testRepoOwner = "testRepoOwner";
             string testRepoName = "testRepoName";
-            UserSettings.WingetPkgsRepoOwner = testRepoOwner;
-            UserSettings.WingetPkgsRepoName = testRepoName;
+            UserSettings.WindowsPackageManagerRepositoryOwner = testRepoOwner;
+            UserSettings.WindowsPackageManagerRepositoryName = testRepoName;
 
             StringWriter sw = new StringWriter();
             System.Console.SetOut(sw);


### PR DESCRIPTION
This pull requests adds the following changes:

- Renames the `WingetPkgsRepo` setting to `WindowsPackageManagerRepository` for verbosity and clarity
- Adds `WindowsPackageManagerRepository` settings documentation

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/113)