### PR TITLE
Display installers with mismatched detected arch for successful updates

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -245,6 +245,8 @@ namespace Microsoft.WingetCreateCLI.Commands
                 return null;
             }
 
+            DisplayMismatchedArchitectures(detectedArchOfInstallers);
+
             return manifests;
         }
 

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -246,7 +246,6 @@ namespace Microsoft.WingetCreateCLI.Commands
             }
 
             DisplayMismatchedArchitectures(detectedArchOfInstallers);
-
             return manifests;
         }
 


### PR DESCRIPTION
Fixes a bug where the installers with mismatched detected architectures were not being displayed for successful updates

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/114)