### PR TITLE
Modify telemetry first run experience to be non-blocking

### DIFF
--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -304,15 +304,6 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Would you like to enable telemetry?.
-        /// </summary>
-        public static string EnableTelemetryFirstRun_Message {
-            get {
-                return ResourceManager.GetString("EnableTelemetryFirstRun_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Please enter values for the following fields:.
         /// </summary>
         public static string EnterFollowingFields_Message {
@@ -1353,6 +1344,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string TelemetryAnonymous_Message {
             get {
                 return ResourceManager.GetString("TelemetryAnonymous_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to By default, telemetry is enabled but can be turned off by modifying your settings file..
+        /// </summary>
+        public static string TelemetryEnabledByDefault_Message {
+            get {
+                return ResourceManager.GetString("TelemetryEnabledByDefault_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1447,7 +1447,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The data is collected by Microsoft and is anonymous..
+        ///   Looks up a localized string similar to The data is anonymous and collected only by Microsoft..
         /// </summary>
         public static string TelemetryAnonymous_Message {
             get {
@@ -1456,7 +1456,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to By default, telemetry is enabled but can be disabled by running &apos;wingetcreate settings&apos; and editing your settings file..
+        ///   Looks up a localized string similar to By default, telemetry is enabled but can be disabled by running `wingetcreate settings` and editing your settings file..
         /// </summary>
         public static string TelemetryEnabledByDefault_Message {
             get {
@@ -1564,7 +1564,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If you have the winget client installed, you can update by running the command: &apos;winget upgrade Microsoft.WingetCreate&apos;.
+        ///   Looks up a localized string similar to If you have the winget client installed, you can update by running the command: `winget upgrade Microsoft.WingetCreate`.
         /// </summary>
         public static string UpgradeUsingWinget_Message {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -564,7 +564,7 @@
     <value>Loaded settings from default factory settings.</value>
   </data>
   <data name="TelemetryAnonymous_Message" xml:space="preserve">
-    <value>The data is collected by Microsoft and is anonymous.</value>
+    <value>The data is anonymous and collected only by Microsoft.</value>
   </data>
   <data name="TelemetryJustification_Message" xml:space="preserve">
     <value>The Windows Package Manager Manifest Creator collects usage data in order to improve your experience.</value>
@@ -672,12 +672,13 @@
     <value>This is an older version of Winget-Create and may be missing some critical features.</value>
   </data>
   <data name="UpgradeUsingWinget_Message" xml:space="preserve">
-    <value>If you have the winget client installed, you can update by running the command: 'winget upgrade Microsoft.WingetCreate'</value>
-    <comment>'winget upgrade Microsoft.WingetCreate' refers to a specific command to be executed in order to upgrade the tool to the latest version.
+    <value>If you have the winget client installed, you can update by running the command: `winget upgrade Microsoft.WingetCreate`</value>
+    <comment>`winget upgrade Microsoft.WingetCreate` refers to a specific command to be executed in order to upgrade the tool to the latest version.
 
 "winget" is the proper name of the tool</comment>
   </data>
   <data name="TelemetryEnabledByDefault_Message" xml:space="preserve">
-    <value>By default, telemetry is enabled but can be disabled by running 'wingetcreate settings' and editing your settings file.</value>
+    <value>By default, telemetry is enabled but can be disabled by running `wingetcreate settings` and editing your settings file.</value>
+    <comment>`wingetcreate settings` refers to a specific command to be executed if the user wants to modify their settings.</comment>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -556,9 +556,6 @@
   <data name="PackageIdAlreadyExists_Error" xml:space="preserve">
     <value>We have detected that this package identifier already exists. If you intend to update an existing package, please use the update command.</value>
   </data>
-  <data name="EnableTelemetryFirstRun_Message" xml:space="preserve">
-    <value>Would you like to enable telemetry?</value>
-  </data>
   <data name="SettingsCommand_HelpText" xml:space="preserve">
     <value>Open settings</value>
   </data>
@@ -633,5 +630,8 @@
     <value>Repository "{0}/{1}" not found. Please verify the Windows Package Manager repository owner and name in your settings file.</value>
     <comment>{0} - will be replaced with the owner name of the Windows Package Manager repository
 {1} - will be replaced with the name of the Windows Package Manager repository</comment>
+  </data>
+  <data name="TelemetryEnabledByDefault_Message" xml:space="preserve">
+    <value>By default, telemetry is enabled but can be turned off by modifying your settings file.</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/UserSettings.cs
+++ b/src/WingetCreateCLI/UserSettings.cs
@@ -118,13 +118,13 @@ namespace Microsoft.WingetCreateCLI
         {
             if (!File.Exists(SettingsJsonPath))
             {
-                Prompt.Symbols.Done = new Symbol(string.Empty, string.Empty);
-                Prompt.Symbols.Prompt = new Symbol(string.Empty, string.Empty);
                 Console.WriteLine(Resources.TelemetrySettings_Message);
                 Console.WriteLine("------------------");
                 Console.WriteLine(Resources.TelemetryJustification_Message);
                 Console.WriteLine(Resources.TelemetryAnonymous_Message);
-                TelemetryDisabled = !Prompt.Confirm(Resources.EnableTelemetryFirstRun_Message);
+                Console.WriteLine(Resources.TelemetryEnabledByDefault_Message);
+                Console.WriteLine();
+                TelemetryDisabled = true;
             }
         }
 

--- a/src/WingetCreateCLI/UserSettings.cs
+++ b/src/WingetCreateCLI/UserSettings.cs
@@ -10,7 +10,6 @@ namespace Microsoft.WingetCreateCLI
     using Microsoft.WingetCreateCLI.Models.Settings;
     using Microsoft.WingetCreateCLI.Properties;
     using Newtonsoft.Json;
-    using Sharprompt;
 
     /// <summary>
     /// UserSettings configuration class for WingetCreate.

--- a/src/WingetCreateCLI/UserSettings.cs
+++ b/src/WingetCreateCLI/UserSettings.cs
@@ -123,7 +123,7 @@ namespace Microsoft.WingetCreateCLI
                 Console.WriteLine(Resources.TelemetryAnonymous_Message);
                 Console.WriteLine(Resources.TelemetryEnabledByDefault_Message);
                 Console.WriteLine();
-                TelemetryDisabled = true;
+                TelemetryDisabled = false;
             }
         }
 


### PR DESCRIPTION
The first run experience waits for the user the provide their consent, which causes an issue for usage in a CI/CD scenario by creating a blocking event. To resolve this issue, we instead notify users of the default telemetry settings, but provide instructions as to how to turn them off. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/117)