### PR TITLE
Add cache command for managing downloaded installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The **Windows Package Manager Manifest Creator** is available for download from 
 | [Submit](doc/submit.md)  | Command for submitting an existing PR  |
 | [Token](doc/token.md)   | Command for managing cached GitHub personal access tokens |
 | [Settings](doc/settings.md) | Command for editing the settings file configurations |
+| [Cache](doc/cache.md) | Command for managing downloaded installers stored in cache
 | [-?](doc/help.md)      | Displays command line help |
 
 Click on the individual commands to learn more.

--- a/doc/cache.md
+++ b/doc/cache.md
@@ -1,0 +1,17 @@
+# cache command (Winget-Create)
+
+The **cache** command of the [Winget-Create](../README.md) tool is designed to help users manage their downloaded installers. Continued usage of the tool can result in many downloaded installers taking up unnecessary space on your machine. This command can help clean up some of the unneeded files.
+
+## Usage
+
+`WingetCreateCLI.exe cache [\<options>]`
+
+## Arguments
+
+The following arguments are available:
+
+| <div style="width:100px">Argument</div> | Description |
+| --------------------------------------- | ------------|
+| **-c, --clean** | Deletes all downloaded installers in the cache folder |
+| **-l, --list** | Lists out all the downloaded installers stored in cache |
+| **-o, --open** | Opens the cache folder storing the downloaded installers |

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -44,11 +44,6 @@ namespace Microsoft.WingetCreateCLI.Commands
         protected const string ProgramApplicationAlias = "wingetcreate.exe";
 
         /// <summary>
-        /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
-        /// </summary>
-        public virtual string GitHubToken { get; set; }
-
-        /// <summary>
         /// Gets or sets the winget repo owner to use.
         /// </summary>
         public string WingetRepoOwner { get; set; } = UserSettings.WindowsPackageManagerRepositoryOwner ?? DefaultWingetRepoOwner;
@@ -77,97 +72,6 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets the GitHubClient instance to use for interacting with GitHub from the CLI.
         /// </summary>
         protected GitHub GitHubClient { get; private set; }
-
-        /// <summary>
-        /// Validates the GitHubToken provided on the command-line, or if not present, the cached token if one exists.
-        /// Attempts a simple operation against the target repo, and if that fails, then:
-        ///     If token provided on command-line, errors out
-        ///     If not, and cached token was present, then deletes token cache, and starts OAuth flow
-        /// Otherwise, sets the instance variable to hold the validated token.
-        /// If no token is present on command-line or in cache, starts the OAuth flow to retrieve one.
-        /// </summary>
-        /// <param name="cacheToken">Boolean to override default behavior and force caching of token.</param>
-        /// <returns>True if the token is now present and valid, false otherwise.</returns>
-        public async Task<bool> SetAndCheckGitHubToken(bool cacheToken = false)
-        {
-            string cachedToken = null;
-            bool hasPatToken = !string.IsNullOrEmpty(this.GitHubToken);
-            string token = this.GitHubToken;
-
-            if (!hasPatToken)
-            {
-                Logger.Trace("No token parameter, reading cached token");
-                token = cachedToken = GitHubOAuth.ReadTokenCache();
-
-                if (string.IsNullOrEmpty(token))
-                {
-                    Logger.Trace("No cached token found.");
-                    Logger.DebugLocalized(nameof(Resources.GitHubAccountMustBeLinked_Message));
-                    Logger.DebugLocalized(nameof(Resources.ExecutionPaused_Message));
-                    Console.WriteLine();
-                    token = await GitHubOAuthLoginFlow();
-                    if (string.IsNullOrEmpty(token))
-                    {
-                        // User must've cancelled OAuth flow, we can't proceed successfully
-                        Logger.WarnLocalized(nameof(Resources.NoTokenResponse_Message));
-                        return false;
-                    }
-
-                    Logger.DebugLocalized(nameof(Resources.ResumingCommandExecution_Message));
-                }
-                else
-                {
-                    Logger.DebugLocalized(nameof(Resources.UsingTokenFromCache_Message));
-                }
-            }
-
-            this.GitHubClient = new GitHub(token, this.WingetRepoOwner, this.WingetRepo);
-
-            try
-            {
-                Logger.Trace("Checking repo access using OAuth token");
-                await this.GitHubClient.CheckAccess();
-                Logger.Trace("Access check was successful, proceeding");
-                this.GitHubToken = token;
-
-                // Only cache the token if it came from Oauth, instead of PAT parameter or cache
-                if (cacheToken || (!hasPatToken && token != cachedToken))
-                {
-                    try
-                    {
-                        Logger.Trace("Writing token to cache");
-                        GitHubOAuth.WriteTokenCache(token);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Failing to cache the token shouldn't be fatal.
-                        Logger.WarnLocalized(nameof(Resources.WritingCacheTokenFailed_Message), ex.Message);
-                    }
-                }
-
-                return true;
-            }
-            catch (Exception e)
-            {
-                if (token == cachedToken)
-                {
-                    // There's an issue with the cached token, so let's delete it and try again
-                    Logger.WarnLocalized(nameof(Resources.InvalidCachedToken));
-                    GitHubOAuth.DeleteTokenCache();
-                    return await this.SetAndCheckGitHubToken();
-                }
-                else if (e is AuthorizationException)
-                {
-                    Logger.ErrorLocalized(nameof(Resources.Error_Prefix), e.Message);
-                    Logger.ErrorLocalized(nameof(Resources.InvalidTokenError_Message));
-                    return false;
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
 
         /// <summary>
         /// Abstract method executing the command.
@@ -401,6 +305,98 @@ namespace Microsoft.WingetCreateCLI.Commands
             Console.WriteLine(manifests.InstallerManifest.ToYaml());
             Logger.Info(Resources.DefaultLocaleManifestPreview_Message);
             Console.WriteLine(manifests.DefaultLocaleManifest.ToYaml());
+        }
+
+        /// <summary>
+        /// Validates the GitHubToken provided on the command-line, or if not present, the cached token if one exists.
+        /// Attempts a simple operation against the target repo, and if that fails, then:
+        ///     If token provided on command-line, errors out
+        ///     If not, and cached token was present, then deletes token cache, and starts OAuth flow
+        /// Otherwise, sets the instance variable to hold the validated token.
+        /// If no token is present on command-line or in cache, starts the OAuth flow to retrieve one.
+        /// </summary>
+        /// <param name="gitHubToken">GitHub token used to submit a pull request on behalf of the user.</param>
+        /// <param name="cacheToken">Boolean to override default behavior and force caching of token.</param>
+        /// <returns>True if the token is now present and valid, false otherwise.</returns>
+        protected async Task<bool> SetAndCheckGitHubToken(string gitHubToken, bool cacheToken = false)
+        {
+            string cachedToken = null;
+            bool hasPatToken = !string.IsNullOrEmpty(gitHubToken);
+            string token = gitHubToken;
+
+            if (!hasPatToken)
+            {
+                Logger.Trace("No token parameter, reading cached token");
+                token = cachedToken = GitHubOAuth.ReadTokenCache();
+
+                if (string.IsNullOrEmpty(token))
+                {
+                    Logger.Trace("No cached token found.");
+                    Logger.DebugLocalized(nameof(Resources.GitHubAccountMustBeLinked_Message));
+                    Logger.DebugLocalized(nameof(Resources.ExecutionPaused_Message));
+                    Console.WriteLine();
+                    token = await GitHubOAuthLoginFlow();
+                    if (string.IsNullOrEmpty(token))
+                    {
+                        // User must've cancelled OAuth flow, we can't proceed successfully
+                        Logger.WarnLocalized(nameof(Resources.NoTokenResponse_Message));
+                        return false;
+                    }
+
+                    Logger.DebugLocalized(nameof(Resources.ResumingCommandExecution_Message));
+                }
+                else
+                {
+                    Logger.DebugLocalized(nameof(Resources.UsingTokenFromCache_Message));
+                }
+            }
+
+            this.GitHubClient = new GitHub(token, this.WingetRepoOwner, this.WingetRepo);
+
+            try
+            {
+                Logger.Trace("Checking repo access using OAuth token");
+                await this.GitHubClient.CheckAccess();
+                Logger.Trace("Access check was successful, proceeding");
+                gitHubToken = token;
+
+                // Only cache the token if it came from Oauth, instead of PAT parameter or cache
+                if (cacheToken || (!hasPatToken && token != cachedToken))
+                {
+                    try
+                    {
+                        Logger.Trace("Writing token to cache");
+                        GitHubOAuth.WriteTokenCache(token);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Failing to cache the token shouldn't be fatal.
+                        Logger.WarnLocalized(nameof(Resources.WritingCacheTokenFailed_Message), ex.Message);
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                if (token == cachedToken)
+                {
+                    // There's an issue with the cached token, so let's delete it and try again
+                    Logger.WarnLocalized(nameof(Resources.InvalidCachedToken));
+                    GitHubOAuth.DeleteTokenCache();
+                    return await this.SetAndCheckGitHubToken(gitHubToken);
+                }
+                else if (e is AuthorizationException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.Error_Prefix), e.Message);
+                    Logger.ErrorLocalized(nameof(Resources.InvalidTokenError_Message));
+                    return false;
+                }
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         /// <summary>

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -47,8 +47,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
-        [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public string GitHubToken { get; set; }
+        public virtual string GitHubToken { get; set; }
 
         /// <summary>
         /// Gets or sets the winget repo owner to use.

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -9,7 +9,6 @@ namespace Microsoft.WingetCreateCLI.Commands
     using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using CommandLine;
     using Microsoft.WingetCreateCLI.Logging;
     using Microsoft.WingetCreateCLI.Properties;
     using Microsoft.WingetCreateCLI.Telemetry;

--- a/src/WingetCreateCLI/Commands/CacheCommand.cs
+++ b/src/WingetCreateCLI/Commands/CacheCommand.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI.Commands
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Threading.Tasks;
+    using CommandLine;
+    using Microsoft.WingetCreateCLI.Logging;
+    using Microsoft.WingetCreateCLI.Properties;
+    using Microsoft.WingetCreateCLI.Telemetry;
+    using Microsoft.WingetCreateCLI.Telemetry.Events;
+    using Microsoft.WingetCreateCore;
+
+    /// <summary>
+    /// Command to manage downloaded installers found in the %TEMP%/wingetcreate folder.
+    /// </summary>
+    [Verb("cache", HelpText = "CacheCommand_HelpText", ResourceType = typeof(Resources))]
+    public class CacheCommand : BaseCommand
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to clear the cached GitHub token.
+        /// </summary>
+        [Option('c', "clean", SetName = nameof(Clean), Required = true, HelpText = "Clean_HelpText", ResourceType = typeof(Resources))]
+        public bool Clean { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to set the cached GitHub token.
+        /// </summary>
+        [Option('l', "list", Required = true, SetName = nameof(List), HelpText = "List_HelpText", ResourceType = typeof(Resources))]
+        public bool List { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to open the folder containing the cached downloaded installers.
+        /// </summary>
+        [Option('o', "open", Required = true, SetName = nameof(Open), HelpText = "Open_HelpText", ResourceType = typeof(Resources))]
+        public bool Open { get; set; }
+
+        /// <summary>
+        /// Executes the cache command flow.
+        /// </summary>
+        /// <returns>Boolean representing success or fail of the command.</returns>
+        public override Task<bool> Execute()
+        {
+            CommandExecutedEvent commandEvent = new CommandExecutedEvent
+            {
+                Command = nameof(CacheCommand),
+            };
+
+            try
+            {
+                if (!Directory.Exists(PackageParser.InstallerDownloadPath))
+                {
+                    Directory.CreateDirectory(PackageParser.InstallerDownloadPath);
+                }
+
+                if (this.Clean)
+                {
+                    Logger.Info($"Cleaning up installers in {PackageParser.InstallerDownloadPath}");
+                    Directory.Delete(PackageParser.InstallerDownloadPath, true);
+                    commandEvent.IsSuccessful = true;
+                }
+                else if (this.List)
+                {
+                    string[] files = Directory.GetFiles(PackageParser.InstallerDownloadPath);
+                    Logger.Info($"{files.Length} installers found in {PackageParser.InstallerDownloadPath}");
+                    Console.WriteLine();
+
+                    foreach (string file in files)
+                    {
+                        Logger.Info(Path.GetFileName(file));
+                    }
+                }
+                else if (this.Open)
+                {
+                    Process.Start(new ProcessStartInfo()
+                    {
+                        FileName = PackageParser.InstallerDownloadPath,
+                        UseShellExecute = true,
+                    });
+                }
+
+                return Task.FromResult(commandEvent.IsSuccessful);
+            }
+            finally
+            {
+                TelemetryManager.Log.WriteEvent(commandEvent);
+            }
+        }
+    }
+}

--- a/src/WingetCreateCLI/Commands/CacheCommand.cs
+++ b/src/WingetCreateCLI/Commands/CacheCommand.cs
@@ -58,15 +58,19 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 if (this.Clean)
                 {
-                    Logger.InfoLocalized(nameof(Resources.CleaningInstallers_Message), PackageParser.InstallerDownloadPath);
                     DirectoryInfo dir = new DirectoryInfo(PackageParser.InstallerDownloadPath);
+                    var files = dir.GetFiles();
+                    Logger.InfoLocalized(nameof(Resources.InstallersFound_Message), files.Length, PackageParser.InstallerDownloadPath);
+                    Console.WriteLine();
 
-                    foreach (FileInfo file in dir.GetFiles())
+                    foreach (FileInfo file in files)
                     {
+                        Logger.WarnLocalized(nameof(Resources.DeletingInstaller_Message), file.Name);
                         file.Delete();
                     }
 
-                    commandEvent.IsSuccessful = true;
+                    Console.WriteLine();
+                    Logger.InfoLocalized(nameof(Resources.InstallerCacheCleaned_Message));
                 }
                 else if (this.List)
                 {
@@ -88,7 +92,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     });
                 }
 
-                return Task.FromResult(commandEvent.IsSuccessful);
+                return Task.FromResult(commandEvent.IsSuccessful = true);
             }
             finally
             {

--- a/src/WingetCreateCLI/Commands/CacheCommand.cs
+++ b/src/WingetCreateCLI/Commands/CacheCommand.cs
@@ -80,7 +80,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                     foreach (string file in files)
                     {
-                        Logger.Info(Path.GetFileName(file));
+                        Logger.Debug(Path.GetFileName(file));
                     }
                 }
                 else if (this.Open)

--- a/src/WingetCreateCLI/Commands/CacheCommand.cs
+++ b/src/WingetCreateCLI/Commands/CacheCommand.cs
@@ -21,19 +21,19 @@ namespace Microsoft.WingetCreateCLI.Commands
     public class CacheCommand : BaseCommand
     {
         /// <summary>
-        /// Gets or sets a value indicating whether to clear the cached GitHub token.
+        /// Gets or sets a value indicating whether to delete all downloaded installers found in cached.
         /// </summary>
         [Option('c', "clean", SetName = nameof(Clean), Required = true, HelpText = "Clean_HelpText", ResourceType = typeof(Resources))]
         public bool Clean { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to set the cached GitHub token.
+        /// Gets or sets a value indicating whether to list all downloaded installers found in cache.
         /// </summary>
         [Option('l', "list", Required = true, SetName = nameof(List), HelpText = "List_HelpText", ResourceType = typeof(Resources))]
         public bool List { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to open the folder containing the cached downloaded installers.
+        /// Gets or sets a value indicating whether to open the cache folder containing all the downloaded installers.
         /// </summary>
         [Option('o', "open", Required = true, SetName = nameof(Open), HelpText = "Open_HelpText", ResourceType = typeof(Resources))]
         public bool Open { get; set; }
@@ -58,14 +58,20 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 if (this.Clean)
                 {
-                    Logger.Info($"Cleaning up installers in {PackageParser.InstallerDownloadPath}");
-                    Directory.Delete(PackageParser.InstallerDownloadPath, true);
+                    Logger.InfoLocalized(nameof(Resources.CleaningInstallers_Message), PackageParser.InstallerDownloadPath);
+                    DirectoryInfo dir = new DirectoryInfo(PackageParser.InstallerDownloadPath);
+
+                    foreach (FileInfo file in dir.GetFiles())
+                    {
+                        file.Delete();
+                    }
+
                     commandEvent.IsSuccessful = true;
                 }
                 else if (this.List)
                 {
                     string[] files = Directory.GetFiles(PackageParser.InstallerDownloadPath);
-                    Logger.Info($"{files.Length} installers found in {PackageParser.InstallerDownloadPath}");
+                    Logger.InfoLocalized(nameof(Resources.InstallersFound_Message), files.Length, PackageParser.InstallerDownloadPath);
                     Console.WriteLine();
 
                     foreach (string file in files)

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public string GitHubToken { get; set; }
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
         /// Executes the new command flow.
@@ -161,7 +161,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 if (isManifestValid && Prompt.Confirm(Resources.ConfirmGitHubSubmitManifest_Message))
                 {
-                    if (await this.SetAndCheckGitHubToken(this.GitHubToken))
+                    if (await this.SetAndCheckGitHubToken())
                     {
                         return commandEvent.IsSuccessful = await this.GitHubSubmitManifests(manifests, this.GitHubToken);
                     }
@@ -381,7 +381,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             if (!string.IsNullOrEmpty(this.GitHubToken))
             {
-                if (!await this.SetAndCheckGitHubToken(this.GitHubToken))
+                if (!await this.SetAndCheckGitHubToken())
                 {
                     return false;
                 }

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+        public string GitHubToken { get; set; }
 
         /// <summary>
         /// Executes the new command flow.
@@ -161,7 +161,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 if (isManifestValid && Prompt.Confirm(Resources.ConfirmGitHubSubmitManifest_Message))
                 {
-                    if (await this.SetAndCheckGitHubToken())
+                    if (await this.SetAndCheckGitHubToken(this.GitHubToken))
                     {
                         return commandEvent.IsSuccessful = await this.GitHubSubmitManifests(manifests, this.GitHubToken);
                     }
@@ -381,7 +381,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             if (!string.IsNullOrEmpty(this.GitHubToken))
             {
-                if (!await this.SetAndCheckGitHubToken())
+                if (!await this.SetAndCheckGitHubToken(this.GitHubToken))
                 {
                     return false;
                 }

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -73,6 +73,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public string OutputDir { get; set; }
 
         /// <summary>
+        /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
+        /// </summary>
+        [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+
+        /// <summary>
         /// Executes the new command flow.
         /// </summary>
         /// <returns>Boolean representing success or fail of the command.</returns>

--- a/src/WingetCreateCLI/Commands/SubmitCommand.cs
+++ b/src/WingetCreateCLI/Commands/SubmitCommand.cs
@@ -44,6 +44,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public string Path { get; set; }
 
         /// <summary>
+        /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
+        /// </summary>
+        [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+
+        /// <summary>
         /// Gets or sets the unbound arguments that exist after the first positional parameter.
         /// </summary>
         [Value(1, Hidden = true)]

--- a/src/WingetCreateCLI/Commands/SubmitCommand.cs
+++ b/src/WingetCreateCLI/Commands/SubmitCommand.cs
@@ -47,7 +47,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public string GitHubToken { get; set; }
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
         /// Gets or sets the unbound arguments that exist after the first positional parameter.
@@ -76,7 +76,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return false;
                 }
 
-                if (!await this.SetAndCheckGitHubToken(this.GitHubToken))
+                if (!await this.SetAndCheckGitHubToken())
                 {
                     return false;
                 }

--- a/src/WingetCreateCLI/Commands/SubmitCommand.cs
+++ b/src/WingetCreateCLI/Commands/SubmitCommand.cs
@@ -47,7 +47,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+        public string GitHubToken { get; set; }
 
         /// <summary>
         /// Gets or sets the unbound arguments that exist after the first positional parameter.
@@ -76,7 +76,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return false;
                 }
 
-                if (!await this.SetAndCheckGitHubToken())
+                if (!await this.SetAndCheckGitHubToken(this.GitHubToken))
                 {
                     return false;
                 }

--- a/src/WingetCreateCLI/Commands/TokenCommand.cs
+++ b/src/WingetCreateCLI/Commands/TokenCommand.cs
@@ -29,6 +29,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public bool Store { get; set; }
 
         /// <summary>
+        /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
+        /// </summary>
+        [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+
+        /// <summary>
         /// Executes the token command flow.
         /// </summary>
         /// <returns>Boolean representing success or fail of the command.</returns>

--- a/src/WingetCreateCLI/Commands/TokenCommand.cs
+++ b/src/WingetCreateCLI/Commands/TokenCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public string GitHubToken { get; set; }
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
         /// Executes the token command flow.
@@ -57,7 +57,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 else if (this.Store)
                 {
                     Logger.InfoLocalized(nameof(Resources.StoreToken_Message));
-                    return commandEvent.IsSuccessful = await this.SetAndCheckGitHubToken(this.GitHubToken, true);
+                    return commandEvent.IsSuccessful = await this.SetAndCheckGitHubToken(true);
                 }
 
                 return false;

--- a/src/WingetCreateCLI/Commands/TokenCommand.cs
+++ b/src/WingetCreateCLI/Commands/TokenCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+        public string GitHubToken { get; set; }
 
         /// <summary>
         /// Executes the token command flow.
@@ -57,7 +57,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 else if (this.Store)
                 {
                     Logger.InfoLocalized(nameof(Resources.StoreToken_Message));
-                    return commandEvent.IsSuccessful = await this.SetAndCheckGitHubToken(true);
+                    return commandEvent.IsSuccessful = await this.SetAndCheckGitHubToken(this.GitHubToken, true);
                 }
 
                 return false;

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -72,7 +72,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public string GitHubToken { get; set; }
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
         /// Gets or sets the new value(s) used to update the manifest installer elements.
@@ -114,7 +114,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 if (!string.IsNullOrEmpty(this.GitHubToken))
                 {
-                    if (!await this.SetAndCheckGitHubToken(this.GitHubToken))
+                    if (!await this.SetAndCheckGitHubToken())
                     {
                         return false;
                     }
@@ -291,7 +291,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                         return false;
                     }
 
-                    return await this.SetAndCheckGitHubToken(this.GitHubToken)
+                    return await this.SetAndCheckGitHubToken()
                         ? (commandEvent.IsSuccessful = await this.GitHubSubmitManifests(updatedManifests, this.GitHubToken))
                         : false;
                 }

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -72,7 +72,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
-        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+        public string GitHubToken { get; set; }
 
         /// <summary>
         /// Gets or sets the new value(s) used to update the manifest installer elements.
@@ -114,7 +114,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 if (!string.IsNullOrEmpty(this.GitHubToken))
                 {
-                    if (!await this.SetAndCheckGitHubToken())
+                    if (!await this.SetAndCheckGitHubToken(this.GitHubToken))
                     {
                         return false;
                     }
@@ -291,7 +291,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                         return false;
                     }
 
-                    return await this.SetAndCheckGitHubToken()
+                    return await this.SetAndCheckGitHubToken(this.GitHubToken)
                         ? (commandEvent.IsSuccessful = await this.GitHubSubmitManifests(updatedManifests, this.GitHubToken))
                         : false;
                 }

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -69,6 +69,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public bool SubmitToGitHub { get; set; }
 
         /// <summary>
+        /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
+        /// </summary>
+        [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
+        public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
+
+        /// <summary>
         /// Gets or sets the new value(s) used to update the manifest installer elements.
         /// </summary>
         [Option('u', "urls", Required = false, HelpText = "InstallerUrl_HelpText", ResourceType = typeof(Resources))]

--- a/src/WingetCreateCLI/Common.cs
+++ b/src/WingetCreateCLI/Common.cs
@@ -15,9 +15,13 @@ namespace Microsoft.WingetCreateCLI
         private const string ModuleName = "WindowsPackageManagerManifestCreator";
 
         private static readonly Lazy<string> AppStatePathLazy = new(() =>
-            IsRunningAsUwp()
-            ? ApplicationData.Current.LocalFolder.Path
-            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", ModuleName));
+        {
+            string path = IsRunningAsUwp()
+                ? ApplicationData.Current.LocalFolder.Path
+                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", ModuleName);
+            Directory.CreateDirectory(path);
+            return path;
+        });
 
         /// <summary>
         /// Gets directory path where app should store local state.

--- a/src/WingetCreateCLI/Models/SettingsModel.cs
+++ b/src/WingetCreateCLI/Models/SettingsModel.cs
@@ -39,7 +39,7 @@ namespace Microsoft.WingetCreateCLI.Models.Settings
     {
         /// <summary>The settings json schema</summary>
         [Newtonsoft.Json.JsonProperty("$schema", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Schema { get; set; } = "https://aka.ms/wingetcreate-settings.schema.json";
+        public string Schema { get; set; } = "https://aka.ms/wingetcreate-settings.schema.0.1.json";
     
         [Newtonsoft.Json.JsonProperty("Telemetry", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -38,7 +38,7 @@ namespace Microsoft.WingetCreateCLI
 
             Parser myParser = new Parser(config => config.HelpWriter = null);
 
-            var types = GetVerbs();
+            var types = new Type[] { typeof(NewCommand), typeof(UpdateCommand), typeof(SubmitCommand), typeof(SettingsCommand), typeof(CacheCommand) };
             var parserResult = myParser.ParseArguments(args, types);
 
             BaseCommand command = parserResult.MapResult(c => c as BaseCommand, err => null);
@@ -66,12 +66,6 @@ namespace Microsoft.WingetCreateCLI
                 Logger.Error(ex.ToString());
                 return 1;
             }
-        }
-
-        private static Type[] GetVerbs()
-        {
-            return Assembly.GetExecutingAssembly().GetTypes()
-                .Where(types => types.GetCustomAttribute<VerbAttribute>() != null).ToArray();
         }
 
         private static void DisplayHelp(NotParsed<object> result)

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -4,9 +4,7 @@
 namespace Microsoft.WingetCreateCLI
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
     using System.Threading.Tasks;
     using CommandLine;
     using CommandLine.Text;
@@ -38,7 +36,7 @@ namespace Microsoft.WingetCreateCLI
 
             Parser myParser = new Parser(config => config.HelpWriter = null);
 
-            var types = new Type[] { typeof(NewCommand), typeof(UpdateCommand), typeof(SubmitCommand), typeof(SettingsCommand), typeof(CacheCommand) };
+            var types = new Type[] { typeof(NewCommand), typeof(UpdateCommand), typeof(SubmitCommand), typeof(SettingsCommand), typeof(TokenCommand), typeof(CacheCommand) };
             var parserResult = myParser.ParseArguments(args, types);
 
             BaseCommand command = parserResult.MapResult(c => c as BaseCommand, err => null);

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -20,11 +20,6 @@ namespace Microsoft.WingetCreateCLI
     /// </summary>
     internal class Program
     {
-        /// <summary>
-        /// Program name of the app.
-        /// </summary>
-        private const string ProgramName = "wingetcreate";
-
         private static async Task<int> Main(string[] args)
         {
             Logger.Initialize();
@@ -50,7 +45,7 @@ namespace Microsoft.WingetCreateCLI
 
             try
             {
-                WingetCreateCore.Serialization.ProducedBy = string.Join(" ", ProgramName, Utils.GetEntryAssemblyVersion());
+                WingetCreateCore.Serialization.ProducedBy = string.Join(" ", Constants.ProgramName, Utils.GetEntryAssemblyVersion());
                 return await command.Execute() ? 0 : 1;
             }
             catch (Exception ex)
@@ -95,8 +90,6 @@ namespace Microsoft.WingetCreateCLI
         {
             var builder = SentenceBuilder.Create();
             var errorMessages = HelpText.RenderParsingErrorsTextAsLines(result, builder.FormatError, builder.FormatMutuallyExclusiveSetErrors, 1);
-
-            var excList = errorMessages.Select(msg => new ArgumentException(msg)).ToList();
 
             foreach (var error in errorMessages)
             {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to List or clean out any downloaded installers in cache.
+        /// </summary>
+        public static string CacheCommand_HelpText {
+            get {
+                return ResourceManager.GetString("CacheCommand_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to List of MSIX capabilities.
         /// </summary>
         public static string Capabilities_KeywordDescription {
@@ -147,6 +156,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string Channel_KeywordDescription {
             get {
                 return ResourceManager.GetString("Channel_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deletes all downloaded installers in the cache folder.
+        /// </summary>
+        public static string Clean_HelpText {
+            get {
+                return ResourceManager.GetString("Clean_HelpText", resourceCulture);
             }
         }
         
@@ -736,6 +754,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lists out all the downloaded installers stored in cache.
+        /// </summary>
+        public static string List_HelpText {
+            get {
+                return ResourceManager.GetString("List_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loaded settings from backup file..
         /// </summary>
         public static string LoadSettingsFromBackup_Message {
@@ -966,6 +993,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string OctokitNotFound_Error {
             get {
                 return ResourceManager.GetString("OctokitNotFound_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Opens the cache folder storing the downloaded installers.
+        /// </summary>
+        public static string Open_HelpText {
+            get {
+                return ResourceManager.GetString("Open_HelpText", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -169,15 +169,6 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cleaning up installers in {0}.
-        /// </summary>
-        public static string CleaningInstallers_Message {
-            get {
-                return ResourceManager.GetString("CleaningInstallers_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Clear the cached GitHub token.
         /// </summary>
         public static string Clear_HelpText {
@@ -273,6 +264,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string DefaultLocaleManifestPreview_Message {
             get {
                 return ResourceManager.GetString("DefaultLocaleManifestPreview_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting {0}.
+        /// </summary>
+        public static string DeletingInstaller_Message {
+            get {
+                return ResourceManager.GetString("DeletingInstaller_Message", resourceCulture);
             }
         }
         
@@ -570,6 +570,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string InstallerBinaryMismatch_Message {
             get {
                 return ResourceManager.GetString("InstallerBinaryMismatch_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installer cache cleaned..
+        /// </summary>
+        public static string InstallerCacheCleaned_Message {
+            get {
+                return ResourceManager.GetString("InstallerCacheCleaned_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List or clean out any downloaded installers in cache.
+        ///   Looks up a localized string similar to Manage downloaded installers stored in cache.
         /// </summary>
         public static string CacheCommand_HelpText {
             get {
@@ -165,6 +165,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string Clean_HelpText {
             get {
                 return ResourceManager.GetString("Clean_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cleaning up installers in {0}.
+        /// </summary>
+        public static string CleaningInstallers_Message {
+            get {
+                return ResourceManager.GetString("CleaningInstallers_Message", resourceCulture);
             }
         }
         
@@ -606,6 +615,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string Installers_KeywordDescription {
             get {
                 return ResourceManager.GetString("Installers_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} installers found in {1}.
+        /// </summary>
+        public static string InstallersFound_Message {
+            get {
+                return ResourceManager.GetString("InstallersFound_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -634,4 +634,16 @@
     <comment>{0} - will be replaced with the owner name of the Windows Package Manager repository
 {1} - will be replaced with the name of the Windows Package Manager repository</comment>
   </data>
+  <data name="CacheCommand_HelpText" xml:space="preserve">
+    <value>List or clean out any downloaded installers in cache</value>
+  </data>
+  <data name="Clean_HelpText" xml:space="preserve">
+    <value>Deletes all downloaded installers in the cache folder</value>
+  </data>
+  <data name="List_HelpText" xml:space="preserve">
+    <value>Lists out all the downloaded installers stored in cache</value>
+  </data>
+  <data name="Open_HelpText" xml:space="preserve">
+    <value>Opens the cache folder storing the downloaded installers</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -635,7 +635,7 @@
 {1} - will be replaced with the name of the Windows Package Manager repository</comment>
   </data>
   <data name="CacheCommand_HelpText" xml:space="preserve">
-    <value>List or clean out any downloaded installers in cache</value>
+    <value>Manage downloaded installers stored in cache</value>
   </data>
   <data name="Clean_HelpText" xml:space="preserve">
     <value>Deletes all downloaded installers in the cache folder</value>
@@ -645,5 +645,14 @@
   </data>
   <data name="Open_HelpText" xml:space="preserve">
     <value>Opens the cache folder storing the downloaded installers</value>
+  </data>
+  <data name="CleaningInstallers_Message" xml:space="preserve">
+    <value>Cleaning up installers in {0}</value>
+    <comment>{0} - Will be replaced with the path to the downloaded installer cache folder</comment>
+  </data>
+  <data name="InstallersFound_Message" xml:space="preserve">
+    <value>{0} installers found in {1}</value>
+    <comment>{0} - Will be replaced with the number of installers found in the cache folder
+{1} - Will be replaced with the path to the downloaded installer cache folder</comment>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -646,13 +646,16 @@
   <data name="Open_HelpText" xml:space="preserve">
     <value>Opens the cache folder storing the downloaded installers</value>
   </data>
-  <data name="CleaningInstallers_Message" xml:space="preserve">
-    <value>Cleaning up installers in {0}</value>
-    <comment>{0} - Will be replaced with the path to the downloaded installer cache folder</comment>
-  </data>
   <data name="InstallersFound_Message" xml:space="preserve">
     <value>{0} installers found in {1}</value>
     <comment>{0} - Will be replaced with the number of installers found in the cache folder
 {1} - Will be replaced with the path to the downloaded installer cache folder</comment>
+  </data>
+  <data name="DeletingInstaller_Message" xml:space="preserve">
+    <value>Deleting {0}</value>
+    <comment>{0} - Will be replaced with the name of the installer to be deleted.</comment>
+  </data>
+  <data name="InstallerCacheCleaned_Message" xml:space="preserve">
+    <value>Installer cache cleaned.</value>
   </data>
 </root>

--- a/src/WingetCreateCore/Common/Constants.cs
+++ b/src/WingetCreateCore/Common/Constants.cs
@@ -27,5 +27,10 @@ namespace Microsoft.WingetCreateCore.Common
         /// App Id for the Winget-Create GitHub App.
         /// </summary>
         public const int GitHubAppId = 100205;
+
+        /// <summary>
+        /// Program name of the app.
+        /// </summary>
+        public const string ProgramName = "wingetcreate";
     }
 }

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -38,6 +38,11 @@ namespace Microsoft.WingetCreateCore
         /// </summary>
         public record DetectedArch(string Url, InstallerArchitecture? UrlArch, InstallerArchitecture BinaryArch);
 
+        /// <summary>
+        /// Gets the path in the %TEMP% directory where installers are downloaded to.
+        /// </summary>
+        public static readonly string InstallerDownloadPath = Path.Combine(Path.GetTempPath(), "wingetcreate");
+
         private const string InvalidCharacters = "©|®";
 
         private static readonly string[] KnownInstallerResourceNames = new[]
@@ -124,7 +129,7 @@ namespace Microsoft.WingetCreateCore
 
             string urlFile = Path.GetFileName(url.Split('?').Last());
             string contentDispositionFile = response.Content.Headers.ContentDisposition?.FileName?.Trim('"');
-            string targetFile = Path.Combine(Path.GetTempPath(), contentDispositionFile ?? urlFile);
+            string targetFile = Path.Combine(InstallerDownloadPath, contentDispositionFile ?? urlFile);
             long? downloadSize = response.Content.Headers.ContentLength;
 
             if (downloadSize > maxDownloadSize)

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -129,6 +129,12 @@ namespace Microsoft.WingetCreateCore
 
             string urlFile = Path.GetFileName(url.Split('?').Last());
             string contentDispositionFile = response.Content.Headers.ContentDisposition?.FileName?.Trim('"');
+
+            if (!Directory.Exists(InstallerDownloadPath))
+            {
+                Directory.CreateDirectory(InstallerDownloadPath);
+            }
+
             string targetFile = Path.Combine(InstallerDownloadPath, contentDispositionFile ?? urlFile);
             long? downloadSize = response.Content.Headers.ContentLength;
 

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -39,9 +39,9 @@ namespace Microsoft.WingetCreateCore
         public record DetectedArch(string Url, InstallerArchitecture? UrlArch, InstallerArchitecture BinaryArch);
 
         /// <summary>
-        /// Gets the path in the %TEMP% directory where installers are downloaded to.
+        /// The default path where downloaded installers are stored.
         /// </summary>
-        public static readonly string InstallerDownloadPath = Path.Combine(Path.GetTempPath(), "wingetcreate");
+        public static readonly string DefaultInstallerDownloadPath = Path.Combine(Path.GetTempPath(), Constants.ProgramName);
 
         private const string InvalidCharacters = "©|®";
 
@@ -58,6 +58,11 @@ namespace Microsoft.WingetCreateCore
             X86 = 0x014c,
             X64 = 0x8664,
         }
+
+        /// <summary>
+        /// Gets or sets the path in the %TEMP% directory where installers are downloaded to.
+        /// </summary>
+        public static string InstallerDownloadPath { get; set; } = DefaultInstallerDownloadPath;
 
         /// <summary>
         /// Sets the HttpMessageHandler used for the static HttpClient.

--- a/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
+++ b/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
@@ -100,5 +100,18 @@ namespace Microsoft.WingetCreateTests
         {
             return Path.Combine(Environment.CurrentDirectory, "Resources", fileName);
         }
+
+        /// <summary>
+        /// Sets up mocking and downloads the given filename.
+        /// </summary>
+        /// <param name="filename">Filename to be mock downloaded.</param>
+        /// <returns>Path to the mock downloaded file.</returns>
+        public static string MockDownloadFile(string filename)
+        {
+            string url = $"https://fakedomain.com/{filename}";
+            SetMockHttpResponseContent(filename);
+            string downloadedPath = PackageParser.DownloadFileAsync(url).Result;
+            return downloadedPath;
+        }
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateUnitTests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.WingetCreateCLI;
+    using Microsoft.WingetCreateCLI.Commands;
+    using Microsoft.WingetCreateCLI.Logging;
+    using Microsoft.WingetCreateCLI.Models.Settings;
+    using Microsoft.WingetCreateCLI.Properties;
+    using Microsoft.WingetCreateCore;
+    using Microsoft.WingetCreateTests;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Unit test class for the Settings Command.
+    /// </summary>
+    public class CacheCommandTests
+    {
+        /// <summary>
+        /// OneTimeSetup method for the settings command unit tests.
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Logger.Initialize();
+            TestUtils.InitializeMockDownload();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestUtils.MockDownloadFile(TestConstants.TestMsiInstaller);
+        }
+
+        /// <summary>
+        /// Verifies that if the List flag is present, shows the downloaded installer present in the cache folder.
+        /// </summary>
+        [Test]
+        public void ListCachedInstallers()
+        {
+            StringWriter sw = new StringWriter();
+            System.Console.SetOut(sw);
+            CacheCommand command = new CacheCommand() { List = true };
+            command.Execute();
+            string result = sw.ToString();
+
+            Assert.That(result, Does.Contain(string.Format(Resources.InstallersFound_Message, 1, PackageParser.InstallerDownloadPath)));
+            Assert.That(result, Does.Contain(TestConstants.TestMsiInstaller));
+        }
+
+        /// <summary>
+        /// Verifies that if the Clean flag is present, deletes all downloaded installers present in the cache folder.
+        /// </summary>
+        [Test]
+        public void CleanCachedInstallers()
+        {
+            CacheCommand command = new CacheCommand() { Clean = true };
+            command.Execute();
+            var installerFiles = Directory.GetFiles(PackageParser.InstallerDownloadPath);
+            Assert.IsTrue(installerFiles.Length == 0, "Cached installers were not deleted.");
+        }
+    }
+}

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
@@ -3,14 +3,11 @@
 
 namespace Microsoft.WingetCreateUnitTests
 {
-    using System.Collections.Generic;
+    using System;
     using System.IO;
-    using System.Linq;
     using System.Threading.Tasks;
-    using Microsoft.WingetCreateCLI;
     using Microsoft.WingetCreateCLI.Commands;
     using Microsoft.WingetCreateCLI.Logging;
-    using Microsoft.WingetCreateCLI.Models.Settings;
     using Microsoft.WingetCreateCLI.Properties;
     using Microsoft.WingetCreateCore;
     using Microsoft.WingetCreateTests;
@@ -31,6 +28,9 @@ namespace Microsoft.WingetCreateUnitTests
             TestUtils.InitializeMockDownload();
         }
 
+        /// <summary>
+        /// Setup method for the cache command unit tests.
+        /// </summary>
         [SetUp]
         public void SetUp()
         {
@@ -40,27 +40,29 @@ namespace Microsoft.WingetCreateUnitTests
         /// <summary>
         /// Verifies that if the List flag is present, shows the downloaded installer present in the cache folder.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        public void ListCachedInstallers()
+        public async Task ListCachedInstallers()
         {
             StringWriter sw = new StringWriter();
-            System.Console.SetOut(sw);
+            Console.SetOut(sw);
             CacheCommand command = new CacheCommand() { List = true };
-            command.Execute();
+            await command.Execute();
             string result = sw.ToString();
-
-            Assert.That(result, Does.Contain(string.Format(Resources.InstallersFound_Message, 1, PackageParser.InstallerDownloadPath)));
+            int installerCount = Directory.GetFiles(PackageParser.InstallerDownloadPath).Length;
+            Assert.That(result, Does.Contain(string.Format(Resources.InstallersFound_Message, installerCount, PackageParser.InstallerDownloadPath)));
             Assert.That(result, Does.Contain(TestConstants.TestMsiInstaller));
         }
 
         /// <summary>
         /// Verifies that if the Clean flag is present, deletes all downloaded installers present in the cache folder.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        public void CleanCachedInstallers()
+        public async Task CleanCachedInstallers()
         {
             CacheCommand command = new CacheCommand() { Clean = true };
-            command.Execute();
+            await command.Execute();
             var installerFiles = Directory.GetFiles(PackageParser.InstallerDownloadPath);
             Assert.IsTrue(installerFiles.Length == 0, "Cached installers were not deleted.");
         }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
@@ -19,13 +19,23 @@ namespace Microsoft.WingetCreateUnitTests
     public class CacheCommandTests
     {
         /// <summary>
-        /// OneTimeSetup method for the settings command unit tests.
+        /// OneTimeSetup method for the cache command unit tests.
         /// </summary>
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
             Logger.Initialize();
             TestUtils.InitializeMockDownload();
+            PackageParser.InstallerDownloadPath = Path.Combine(Path.GetTempPath(), "wingetcreatetests");
+        }
+
+        /// <summary>
+        /// OneTimeTearDown method for the cache command unit tests.
+        /// </summary>
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            PackageParser.InstallerDownloadPath = PackageParser.DefaultInstallerDownloadPath;
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/CacheCommandTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.WingetCreateUnitTests
             CacheCommand command = new CacheCommand() { Clean = true };
             await command.Execute();
             var installerFiles = Directory.GetFiles(PackageParser.InstallerDownloadPath);
-            Assert.IsTrue(installerFiles.Length == 0, "Cached installers were not deleted.");
+            Assert.AreEqual(0, installerFiles.Length, "Cached installers were not deleted.");
         }
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/PackageParserTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/PackageParserTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.WingetCreateUnitTests
         [Test]
         public void ParseExeInstallerFile()
         {
-            var testExeInstallerPath = MockDownloadFile(TestConstants.TestExeInstaller);
+            var testExeInstallerPath = TestUtils.MockDownloadFile(TestConstants.TestExeInstaller);
             Assert.That(testExeInstallerPath, Is.Not.Null.And.Not.Empty);
 
             Manifests manifests = new Manifests();
@@ -63,7 +63,7 @@ namespace Microsoft.WingetCreateUnitTests
         [Test]
         public void ParseMsiInstallerFile()
         {
-            var testMsiInstallerPath = MockDownloadFile(TestConstants.TestMsiInstaller);
+            var testMsiInstallerPath = TestUtils.MockDownloadFile(TestConstants.TestMsiInstaller);
             Assert.That(testMsiInstallerPath, Is.Not.Null.And.Not.Empty);
 
             Manifests manifests = new Manifests();
@@ -82,7 +82,7 @@ namespace Microsoft.WingetCreateUnitTests
         [Test]
         public void ParseMsixInstallerFile()
         {
-            var testMsixInstallerPath = MockDownloadFile(TestConstants.TestMsixInstaller);
+            var testMsixInstallerPath = TestUtils.MockDownloadFile(TestConstants.TestMsixInstaller);
             Assert.That(testMsixInstallerPath, Is.Not.Null.And.Not.Empty);
 
             Manifests manifests = new Manifests();
@@ -102,11 +102,11 @@ namespace Microsoft.WingetCreateUnitTests
         [Test]
         public void ParseMultipleInstallers()
         {
-            var testMsiInstallerPath = MockDownloadFile(TestConstants.TestMsiInstaller);
+            var testMsiInstallerPath = TestUtils.MockDownloadFile(TestConstants.TestMsiInstaller);
             Assert.That(testMsiInstallerPath, Is.Not.Null.And.Not.Empty);
-            var testExeInstallerPath = MockDownloadFile(TestConstants.TestExeInstaller);
+            var testExeInstallerPath = TestUtils.MockDownloadFile(TestConstants.TestExeInstaller);
             Assert.That(testExeInstallerPath, Is.Not.Null.And.Not.Empty);
-            var testMsixInstallerPath = MockDownloadFile(TestConstants.TestMsixInstaller);
+            var testMsixInstallerPath = TestUtils.MockDownloadFile(TestConstants.TestMsixInstaller);
             Assert.That(testMsixInstallerPath, Is.Not.Null.And.Not.Empty);
 
             Manifests manifests = new Manifests();
@@ -128,14 +128,6 @@ namespace Microsoft.WingetCreateUnitTests
             Assert.AreEqual(InstallerType.Msi, manifests.InstallerManifest.Installers.Skip(1).First().InstallerType);
             Assert.AreEqual(InstallerType.Msix, manifests.InstallerManifest.Installers.Skip(2).First().InstallerType);
             Assert.AreEqual(InstallerType.Msix, manifests.InstallerManifest.Installers.Skip(3).First().InstallerType);
-        }
-
-        private static string MockDownloadFile(string filename)
-        {
-            string url = $"https://fakedomain.com/{filename}";
-            TestUtils.SetMockHttpResponseContent(filename);
-            string downloadedPath = PackageParser.DownloadFileAsync(url).Result;
-            return downloadedPath;
         }
     }
 }


### PR DESCRIPTION
This pull request resolves #62  

Changes:
- Change installer download path from %temp% -> %temp%/wingetcreate
- Created a cache command that opens the cache folder, lists downloaded installers, and cleans out all downloaded installers
- Changed basecommand.githubtoken to be a virtual property that can be overrided so that commands like settings and cache don't inherit the --token option
- Removes GetVerbs() from program.cs as this was displaying commands in alphabetical order. Reverted to listing out the commands in an array to have an ordering based on usage.
- Added cache command documentation

Testing:
- Added unit tests for the cache command

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/119)