### PR TITLE
Notify users of latest release version

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// Gets the GitHubClient instance to use for interacting with GitHub from the CLI.
         /// </summary>
-        public GitHub GitHubClient { get; private set; }
+        protected GitHub GitHubClient { get; private set; }
 
         /// <summary>
         /// Abstract method executing the command.

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -76,7 +76,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// Gets the GitHubClient instance to use for interacting with GitHub from the CLI.
         /// </summary>
-        protected GitHub GitHubClient { get; private set; }
+        internal GitHub GitHubClient { get; private set; }
 
         /// <summary>
         /// Abstract method executing the command.

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -141,17 +141,10 @@ namespace Microsoft.WingetCreateCLI.Commands
                     if (this.WingetRepoOwner == DefaultWingetRepoOwner &&
                         this.WingetRepo == DefaultWingetRepo)
                     {
-                        if (await this.LoadGitHubClient())
+                        if (!await this.PromptPackageIdentifierAndCheckDuplicates(manifests))
                         {
-                            if (!await this.PromptPackageIdentifierAndCheckDuplicates(manifests))
-                            {
-                                Console.WriteLine();
-                                Logger.ErrorLocalized(nameof(Resources.PackageIdAlreadyExists_Error));
-                                return false;
-                            }
-                        }
-                        else
-                        {
+                            Console.WriteLine();
+                            Logger.ErrorLocalized(nameof(Resources.PackageIdAlreadyExists_Error));
                             return false;
                         }
                     }

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -109,11 +109,6 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return false;
                 }
 
-                if (!await this.LoadGitHubClient())
-                {
-                    return false;
-                }
-
                 Logger.DebugLocalized(nameof(Resources.RetrievingManifest_Message), this.Id);
 
                 string exactId;

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -26,6 +26,14 @@ namespace Microsoft.WingetCreateCLI
             UserSettings.FirstRunTelemetryConsent();
             TelemetryEventListener.EventListener.IsTelemetryEnabled();
 
+            string release = await GitHub.GetLatestRelease();
+            if (!release.Contains(Utils.GetEntryAssemblyVersion()))
+            {
+                Logger.WarnLocalized(nameof(Resources.OutdatedVersionNotice_Message));
+                Logger.WarnLocalized(nameof(Resources.GetLatestVersion_Message), release, "https://github.com/microsoft/winget-create/releases");
+                Console.WriteLine();
+            }
+
             string arguments = string.Join(' ', Environment.GetCommandLineArgs());
             Logger.Trace($"Command line args: {arguments}");
 
@@ -89,6 +97,7 @@ namespace Microsoft.WingetCreateCLI
         private static void DisplayParsingErrors<T>(ParserResult<T> result)
         {
             var builder = SentenceBuilder.Create();
+
             var errorMessages = HelpText.RenderParsingErrorsTextAsLines(result, builder.FormatError, builder.FormatMutuallyExclusiveSetErrors, 1);
 
             foreach (var error in errorMessages)

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -97,7 +97,6 @@ namespace Microsoft.WingetCreateCLI
         private static void DisplayParsingErrors<T>(ParserResult<T> result)
         {
             var builder = SentenceBuilder.Create();
-
             var errorMessages = HelpText.RenderParsingErrorsTextAsLines(result, builder.FormatError, builder.FormatMutuallyExclusiveSetErrors, 1);
 
             foreach (var error in errorMessages)

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -35,6 +35,14 @@ namespace Microsoft.WingetCreateCLI
             var parserResult = myParser.ParseArguments(args, types);
 
             BaseCommand command = parserResult.MapResult(c => c as BaseCommand, err => null);
+
+            if (command == null)
+            {
+                DisplayHelp(parserResult as NotParsed<object>);
+                DisplayParsingErrors(parserResult as NotParsed<object>);
+                return args.Any() ? 1 : 0;
+            }
+
             if (!await command.LoadGitHubClient())
             {
                 return 1;
@@ -55,13 +63,6 @@ namespace Microsoft.WingetCreateCLI
             catch (Exception ex) when (ex is Octokit.ApiException || ex is Octokit.RateLimitExceededException)
             {
                 // Since this is only notifying the user if an update is available, don't block if the token is invalid or a rate limit error is encountered.
-            }
-
-            if (command == null)
-            {
-                DisplayHelp(parserResult as NotParsed<object>);
-                DisplayParsingErrors(parserResult as NotParsed<object>);
-                return args.Any() ? 1 : 0;
             }
 
             try

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -26,11 +26,11 @@ namespace Microsoft.WingetCreateCLI
             UserSettings.FirstRunTelemetryConsent();
             TelemetryEventListener.EventListener.IsTelemetryEnabled();
 
-            string release = await GitHub.GetLatestRelease();
-            if (!release.Contains(Utils.GetEntryAssemblyVersion()))
+            string latestVersion = await GitHub.GetLatestRelease();
+            if (!latestVersion.Contains(Utils.GetEntryAssemblyVersion()))
             {
                 Logger.WarnLocalized(nameof(Resources.OutdatedVersionNotice_Message));
-                Logger.WarnLocalized(nameof(Resources.GetLatestVersion_Message), release, "https://github.com/microsoft/winget-create/releases");
+                Logger.WarnLocalized(nameof(Resources.GetLatestVersion_Message), latestVersion, "https://github.com/microsoft/winget-create/releases");
                 Console.WriteLine();
             }
 

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WingetCreateCLI
 
             try
             {
-                string latestVersion = await GitHub.GetLatestRelease();
+                string latestVersion = await command.GitHubClient.GetLatestRelease();
                 string trimmedVersion = latestVersion.TrimStart('v').Split('-').First();
                 if (trimmedVersion != Utils.GetEntryAssemblyVersion())
                 {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -484,6 +484,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to For the latest version ({0}), go to {1}.
+        /// </summary>
+        public static string GetLatestVersion_Message {
+            get {
+                return ResourceManager.GetString("GetLatestVersion_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A GitHub account or personal access token must be linked in order to continue with this command. .
         /// </summary>
         public static string GitHubAccountMustBeLinked_Message {
@@ -1029,6 +1038,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string Open_HelpText {
             get {
                 return ResourceManager.GetString("Open_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This is an older version of Winget-Create and may be missing some critical features..
+        /// </summary>
+        public static string OutdatedVersionNotice_Message {
+            get {
+                return ResourceManager.GetString("OutdatedVersionNotice_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -658,4 +658,12 @@
   <data name="InstallerCacheCleaned_Message" xml:space="preserve">
     <value>Installer cache cleaned.</value>
   </data>
+  <data name="GetLatestVersion_Message" xml:space="preserve">
+    <value>For the latest version ({0}), go to {1}</value>
+    <comment>{0} - Will be replaced with the latest release version
+{1} - Will be replaced with the URL to the latest version of the tool.</comment>
+  </data>
+  <data name="OutdatedVersionNotice_Message" xml:space="preserve">
+    <value>This is an older version of Winget-Create and may be missing some critical features.</value>
+  </data>
 </root>

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -21,6 +21,7 @@ namespace Microsoft.WingetCreateCore.Common
         private const string HeadMasterRef = "heads/master";
         private const string PRDescriptionRepoPath = ".github/PULL_REQUEST_TEMPLATE.md";
         private const string UserAgentName = "WingetCreate";
+        private static string githubToken;
         private readonly GitHubClient github;
         private readonly string wingetRepoOwner;
         private readonly string wingetRepo;
@@ -39,6 +40,7 @@ namespace Microsoft.WingetCreateCore.Common
             if (githubApiToken != null)
             {
                 this.github.Credentials = new Credentials(githubApiToken, AuthenticationType.Bearer);
+                githubToken = githubApiToken;
             }
         }
 
@@ -65,15 +67,14 @@ namespace Microsoft.WingetCreateCore.Common
         /// <summary>
         /// Gets the latest release tag name of winget-create.
         /// </summary>
-        /// <param name="token">GitHub api token.</param>
         /// <returns>Latest release tag name.</returns>
-        public static async Task<string> GetLatestRelease(string token = null)
+        public static async Task<string> GetLatestRelease()
         {
             var github = new GitHubClient(new ProductHeaderValue(UserAgentName));
 
-            if (!string.IsNullOrEmpty(token))
+            if (!string.IsNullOrEmpty(githubToken))
             {
-                github.Credentials = new Credentials(token, AuthenticationType.Bearer);
+                github.Credentials = new Credentials(githubToken, AuthenticationType.Bearer);
             }
 
             var latestRelease = await github.Repository.Release.GetLatest("microsoft", "winget-create");

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -21,7 +21,6 @@ namespace Microsoft.WingetCreateCore.Common
         private const string HeadMasterRef = "heads/master";
         private const string PRDescriptionRepoPath = ".github/PULL_REQUEST_TEMPLATE.md";
         private const string UserAgentName = "WingetCreate";
-        private static string githubToken;
         private readonly GitHubClient github;
         private readonly string wingetRepoOwner;
         private readonly string wingetRepo;
@@ -40,7 +39,6 @@ namespace Microsoft.WingetCreateCore.Common
             if (githubApiToken != null)
             {
                 this.github.Credentials = new Credentials(githubApiToken, AuthenticationType.Bearer);
-                githubToken = githubApiToken;
             }
         }
 
@@ -62,23 +60,6 @@ namespace Microsoft.WingetCreateCore.Common
             var installation = await github.GitHubApps.GetRepositoryInstallationForCurrent(wingetRepoOwner, wingetRepo);
             var response = await github.GitHubApps.CreateInstallationToken(installation.Id);
             return response.Token;
-        }
-
-        /// <summary>
-        /// Gets the latest release tag name of winget-create.
-        /// </summary>
-        /// <returns>Latest release tag name.</returns>
-        public static async Task<string> GetLatestRelease()
-        {
-            var github = new GitHubClient(new ProductHeaderValue(UserAgentName));
-
-            if (!string.IsNullOrEmpty(githubToken))
-            {
-                github.Credentials = new Credentials(githubToken, AuthenticationType.Bearer);
-            }
-
-            var latestRelease = await github.Repository.Release.GetLatest("microsoft", "winget-create");
-            return latestRelease.TagName;
         }
 
         /// <summary>
@@ -173,6 +154,16 @@ namespace Microsoft.WingetCreateCore.Common
             }
 
             return this.SubmitPRAsync(id, version, contents, submitToFork);
+        }
+
+        /// <summary>
+        /// Gets the latest release tag name of winget-create.
+        /// </summary>
+        /// <returns>Latest release tag name.</returns>
+        public async Task<string> GetLatestRelease()
+        {
+            var latestRelease = await this.github.Repository.Release.GetLatest("microsoft", "winget-create");
+            return latestRelease.TagName;
         }
 
         /// <summary>

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -67,10 +67,15 @@ namespace Microsoft.WingetCreateCore.Common
         /// </summary>
         /// <param name="token">GitHub api token.</param>
         /// <returns>Latest release tag name.</returns>
-        public static async Task<string> GetLatestRelease(string token)
+        public static async Task<string> GetLatestRelease(string token = null)
         {
             var github = new GitHubClient(new ProductHeaderValue(UserAgentName));
-            github.Credentials = new Credentials(token, AuthenticationType.Bearer);
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                github.Credentials = new Credentials(token, AuthenticationType.Bearer);
+            }
+
             var latestRelease = await github.Repository.Release.GetLatest("microsoft", "winget-create");
             return latestRelease.TagName;
         }

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -62,6 +62,18 @@ namespace Microsoft.WingetCreateCore.Common
         }
 
         /// <summary>
+        /// Gets the latest release tag name of winget-create.
+        /// </summary>
+        /// <returns>Latest release tag name.</returns>
+        public static async Task<string> GetLatestRelease()
+        {
+            var github = new GitHubClient(new ProductHeaderValue(UserAgentName));
+            var releases = await github.Repository.Release.GetAll("microsoft", "winget-create");
+            var latest = releases[0];
+            return latest.TagName;
+        }
+
+        /// <summary>
         /// Gets all app manifests in the repo.
         /// </summary>
         /// <returns>A list of <see cref="PublisherAppVersion"/>, each representing a single app manifest version.</returns>

--- a/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
@@ -79,6 +79,7 @@ namespace Microsoft.WingetCreateE2ETests
                 OpenPRInBrowser = false,
             };
 
+            Assert.IsTrue(await updateCommand.LoadGitHubClient(), "Failed to create GitHub client");
             Assert.IsTrue(await updateCommand.Execute(), "Command should execute successfully");
 
             string pathToValidate = Path.Combine(Directory.GetCurrentDirectory(), Utils.GetAppManifestDirPath(packageId, PackageVersion));

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/SettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/SettingsCommandTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.WingetCreateUnitTests
             StringWriter sw = new StringWriter();
             System.Console.SetOut(sw);
             UpdateCommand command = new UpdateCommand { Id = "testId" };
-            await command.Execute();
+            await command.LoadGitHubClient();
             string result = sw.ToString();
             Assert.That(result, Does.Contain(string.Format(Resources.RepositoryNotFound_Error, testRepoOwner, testRepoName)), "Repository not found error should be shown");
         }


### PR DESCRIPTION
This PR resolves #66.

Changes:
- Added a static method in GitHub.cs that retrieves the tag name of the latest release version.
- If the current version of winget-create does not match the latest version, then a warning message appears notifying the user that an update is available.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/121)