### PR TITLE
Ignore NoVerbSelected commandline parsing error

### DIFF
--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -108,10 +108,9 @@ namespace Microsoft.WingetCreateCLI
             Console.WriteLine();
         }
 
-        private static void DisplayParsingErrors<T>(ParserResult<T> result)
+        private static void DisplayParsingErrors<T>(NotParsed<T> result)
         {
-            NotParsed<object> notParsed = result as NotParsed<object>;
-            if (!notParsed.Errors.Any(e => e is NoVerbSelectedError))
+            if (!result.Errors.Any(e => e is NoVerbSelectedError))
             {
                 var builder = SentenceBuilder.Create();
                 var errorMessages = HelpText.RenderParsingErrorsTextAsLines(result, builder.FormatError, builder.FormatMutuallyExclusiveSetErrors, 1);

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -110,12 +110,16 @@ namespace Microsoft.WingetCreateCLI
 
         private static void DisplayParsingErrors<T>(ParserResult<T> result)
         {
-            var builder = SentenceBuilder.Create();
-            var errorMessages = HelpText.RenderParsingErrorsTextAsLines(result, builder.FormatError, builder.FormatMutuallyExclusiveSetErrors, 1);
-
-            foreach (var error in errorMessages)
+            NotParsed<object> notParsed = result as NotParsed<object>;
+            if (!notParsed.Errors.Any(e => e is NoVerbSelectedError))
             {
-                Logger.Warn(error);
+                var builder = SentenceBuilder.Create();
+                var errorMessages = HelpText.RenderParsingErrorsTextAsLines(result, builder.FormatError, builder.FormatMutuallyExclusiveSetErrors, 1);
+
+                foreach (var error in errorMessages)
+                {
+                    Logger.Warn(error);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #136 

When running `wingetcreate` with no verb, the tool will display a warning stating a NoVerbSelected error. 

This PR adds changes to ignore that specific parsing error as a user should not be shown a warning for not selecting a verb and should instead be shown the help screen.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/135)