### PR TITLE
Add VClibs dependency to package manifest

### DIFF
--- a/src/WingetCreatePackage/Package.appxmanifest
+++ b/src/WingetCreatePackage/Package.appxmanifest
@@ -21,6 +21,7 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.25426.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
 
   <Resources>


### PR DESCRIPTION
Fixes #97 

Changes:
- Add Microsoft.VCLibs.140.00.UWPDesktop as a package dependency to WingetCreatePackage/Package.appxmanifest 