### PR TITLE
Add interactive update feature

### DIFF
--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -74,7 +74,6 @@ namespace Microsoft.WingetCreateCLI
                 .Select(property => property.Name)
                 .Where(pName => !NonEditableOptionalFields.Any(field => field == pName)).ToList();
 
-
             var installerTypeProperty = model.GetType().GetProperty(nameof(InstallerType));
             if (installerTypeProperty != null)
             {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -349,6 +349,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Would you like to discard this update and start over?.
+        /// </summary>
+        public static string DiscardUpdateAndStartOver_Message {
+            get {
+                return ResourceManager.GetString("DiscardUpdateAndStartOver_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DISPLAY PREVIEW.
         /// </summary>
         public static string DisplayPreview_MenuItem {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -835,7 +835,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Boolean value for making the update command interactive. If true,  the user will be prompted for input to resolve any conflicts. Default is false..
+        ///   Looks up a localized string similar to Boolean value for making the update command interactive. If true, the user will be prompted for input to resolve any conflicts. Default is false..
         /// </summary>
         public static string InteractiveUpdate_HelpText {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -826,6 +826,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Boolean value for making the update command interactive. If true,  the user will be prompted for input to resolve any conflicts. Default is false..
+        /// </summary>
+        public static string InteractiveUpdate_HelpText {
+            get {
+                return ResourceManager.GetString("InteractiveUpdate_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Token was invalid. Please generate a new GitHub token and try again..
         /// </summary>
         public static string InvalidGitHubToken_Message {
@@ -867,6 +876,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string LaunchBrowser_Message {
             get {
                 return ResourceManager.GetString("LaunchBrowser_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to match the installers. WingetCreate will now launch an interactive menu for manually matching installers..
+        /// </summary>
+        public static string LaunchInteractiveUpdate_Warning {
+            get {
+                return ResourceManager.GetString("LaunchInteractiveUpdate_Warning", resourceCulture);
             }
         }
         
@@ -1294,6 +1312,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Press any key to continue....
+        /// </summary>
+        public static string PressKeyToContinue_Message {
+            get {
+                return ResourceManager.GetString("PressKeyToContinue_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Privacy statement: https://aka.ms/privacy.
         /// </summary>
         public static string PrivacyStatement_HelpText {
@@ -1443,6 +1470,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string SelectAction_Message {
             get {
                 return ResourceManager.GetString("SelectAction_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the new installer URL that you would like to update the above installer with..
+        /// </summary>
+        public static string SelectInstallerForUpdate_Message {
+            get {
+                return ResourceManager.GetString("SelectInstallerForUpdate_Message", resourceCulture);
             }
         }
         
@@ -1650,6 +1686,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string TokenExpired_Message {
             get {
                 return ResourceManager.GetString("TokenExpired_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type to filter installers.
+        /// </summary>
+        public static string TypeToFilterInstallers_Message {
+            get {
+                return ResourceManager.GetString("TypeToFilterInstallers_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -781,6 +781,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Installer updated successfully!.
+        /// </summary>
+        public static string InstallerUpdatedSuccessfully_Message {
+            get {
+                return ResourceManager.GetString("InstallerUpdatedSuccessfully_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Installer Url(s) used to extract relevant metadata for generating a manifest.
         /// </summary>
         public static string InstallerUrl_HelpText {
@@ -876,15 +885,6 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string LaunchBrowser_Message {
             get {
                 return ResourceManager.GetString("LaunchBrowser_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to match the installers. WingetCreate will now launch an interactive menu for manually matching installers..
-        /// </summary>
-        public static string LaunchInteractiveUpdate_Warning {
-            get {
-                return ResourceManager.GetString("LaunchInteractiveUpdate_Warning", resourceCulture);
             }
         }
         
@@ -1110,6 +1110,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string NewCommand_HelpText {
             get {
                 return ResourceManager.GetString("NewCommand_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to What is the new installer url?.
+        /// </summary>
+        public static string NewInstallerUrl_Message {
+            get {
+                return ResourceManager.GetString("NewInstallerUrl_Message", resourceCulture);
             }
         }
         
@@ -1474,15 +1483,6 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select the new installer URL that you would like to update the above installer with..
-        /// </summary>
-        public static string SelectInstallerForUpdate_Message {
-            get {
-                return ResourceManager.GetString("SelectInstallerForUpdate_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Which installer would you like to edit?.
         /// </summary>
         public static string SelectInstallerToEdit_Message {
@@ -1690,15 +1690,6 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type to filter installers.
-        /// </summary>
-        public static string TypeToFilterInstallers_Message {
-            get {
-                return ResourceManager.GetString("TypeToFilterInstallers_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The following unbound argument(s) were detected: &quot;{0}&quot;.
         /// </summary>
         public static string UnboundArguments_Message {
@@ -1749,6 +1740,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string UpdateCommand_HelpText {
             get {
                 return ResourceManager.GetString("UpdateCommand_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Updating {0} of {1} installers:.
+        /// </summary>
+        public static string UpdatingInstallerOutOfTotal_Message {
+            get {
+                return ResourceManager.GetString("UpdatingInstallerOutOfTotal_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -835,7 +835,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Boolean value for making the update command interactive. If true, the user will be prompted for input to resolve any conflicts. Default is false..
+        ///   Looks up a localized string similar to Boolean value for making the update command interactive. If true, the tool will prompt the user for input. Default is false..
         /// </summary>
         public static string InteractiveUpdate_HelpText {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -746,4 +746,20 @@
   <data name="SelectPropertyToEdit_Message" xml:space="preserve">
     <value>Which property would you like to edit?</value>
   </data>
+  <data name="InteractiveUpdate_HelpText" xml:space="preserve">
+    <value>Boolean value for making the update command interactive. If true,  the user will be prompted for input to resolve any conflicts. Default is false.</value>
+  </data>
+  <data name="LaunchInteractiveUpdate_Warning" xml:space="preserve">
+    <value>Failed to match the installers. WingetCreate will now launch an interactive menu for manually matching installers.</value>
+    <comment>`WingetCreate` refers to the name of the tool.</comment>
+  </data>
+  <data name="PressKeyToContinue_Message" xml:space="preserve">
+    <value>Press any key to continue...</value>
+  </data>
+  <data name="SelectInstallerForUpdate_Message" xml:space="preserve">
+    <value>Select the new installer URL that you would like to update the above installer with.</value>
+  </data>
+  <data name="TypeToFilterInstallers_Message" xml:space="preserve">
+    <value>Type to filter installers</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -743,7 +743,7 @@
     <value>Which property would you like to edit?</value>
   </data>
   <data name="InteractiveUpdate_HelpText" xml:space="preserve">
-    <value>Boolean value for making the update command interactive. If true, the user will be prompted for input to resolve any conflicts. Default is false.</value>
+    <value>Boolean value for making the update command interactive. If true, the tool will prompt the user for input. Default is false.</value>
   </data>
   <data name="InstallerUpdatedSuccessfully_Message" xml:space="preserve">
     <value>Installer updated successfully!</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -759,4 +759,7 @@
     <comment>{0} - represents the current installer index that is being updated
 {1} - represents the total number of installers to be updated</comment>
   </data>
+  <data name="DiscardUpdateAndStartOver_Message" xml:space="preserve">
+    <value>Would you like to discard this update and start over?</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -747,7 +747,7 @@
     <value>Which property would you like to edit?</value>
   </data>
   <data name="InteractiveUpdate_HelpText" xml:space="preserve">
-    <value>Boolean value for making the update command interactive. If true,  the user will be prompted for input to resolve any conflicts. Default is false.</value>
+    <value>Boolean value for making the update command interactive. If true, the user will be prompted for input to resolve any conflicts. Default is false.</value>
   </data>
   <data name="InstallerUpdatedSuccessfully_Message" xml:space="preserve">
     <value>Installer updated successfully!</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -749,17 +749,18 @@
   <data name="InteractiveUpdate_HelpText" xml:space="preserve">
     <value>Boolean value for making the update command interactive. If true,  the user will be prompted for input to resolve any conflicts. Default is false.</value>
   </data>
-  <data name="LaunchInteractiveUpdate_Warning" xml:space="preserve">
-    <value>Failed to match the installers. WingetCreate will now launch an interactive menu for manually matching installers.</value>
-    <comment>`WingetCreate` refers to the name of the tool.</comment>
+  <data name="InstallerUpdatedSuccessfully_Message" xml:space="preserve">
+    <value>Installer updated successfully!</value>
+  </data>
+  <data name="NewInstallerUrl_Message" xml:space="preserve">
+    <value>What is the new installer url?</value>
   </data>
   <data name="PressKeyToContinue_Message" xml:space="preserve">
     <value>Press any key to continue...</value>
   </data>
-  <data name="SelectInstallerForUpdate_Message" xml:space="preserve">
-    <value>Select the new installer URL that you would like to update the above installer with.</value>
-  </data>
-  <data name="TypeToFilterInstallers_Message" xml:space="preserve">
-    <value>Type to filter installers</value>
+  <data name="UpdatingInstallerOutOfTotal_Message" xml:space="preserve">
+    <value>Updating {0} of {1} installers:</value>
+    <comment>{0} - represents the current installer index that is being updated
+{1} - represents the total number of installers to be updated</comment>
   </data>
 </root>

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -375,6 +375,32 @@ namespace Microsoft.WingetCreateCore
             }
         }
 
+        // Method for parsing a package and updating the installer node. 
+        public static bool ParsePackageAndUpdateInstallerNode(Installer installer, string path, string url)
+        {
+            // check parsing first to see if its a valid installer.
+            List<Installer> installers = new List<Installer>();
+            bool parseMsixResult = false;
+            bool parseResult = ParseExeInstallerType(path, installer, installers) ||
+                (parseMsixResult = ParseMsix(path, installer, null, installers)) ||
+                ParseMsi(path, installer, null, installers);
+
+            if (!parseResult)
+            {
+                return false;
+            }
+
+            installer.InstallerUrl = url;
+            installer.InstallerSha256 = GetFileHash(path);
+
+            if (parseMsixResult)
+            {
+                installer.SignatureSha256 = installers.First().SignatureSha256;
+            }
+
+            return true;
+        }
+
         private static bool ParsePackageAndGenerateInstallerNodes(
             string path,
             string url,

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -179,6 +179,7 @@ namespace Microsoft.WingetCreateCore
         /// <param name="installerUrls">InstallerUrls where installers can be downloaded.</param>
         /// <param name="paths">Paths to packages to extract metadata from.</param>
         /// <param name="detectedArchOfInstallers">List of DetectedArch objects that represent each installers detected architectures.</param>
+        /// <param name="newInstallers">List of newly parsed installer nodes.</param>
         public static void UpdateInstallerNodesAsync(
             InstallerManifest installerManifest,
             IEnumerable<string> installerUrls,
@@ -266,14 +267,6 @@ namespace Microsoft.WingetCreateCore
                     installerMatchDict.Add(matchingExistingInstaller, newInstaller); // add the match to the map.
                     existingInstallers.Remove(matchingExistingInstaller);
                 }
-
-                //matchingExistingInstaller.InstallerUrl = newInstaller.InstallerUrl;
-                //matchingExistingInstaller.InstallerSha256 = newInstaller.InstallerSha256;
-                //matchingExistingInstaller.SignatureSha256 = newInstaller.SignatureSha256;
-                //matchingExistingInstaller.ProductCode = newInstaller.ProductCode;
-                //matchingExistingInstaller.MinimumOSVersion = newInstaller.MinimumOSVersion;
-                //matchingExistingInstaller.PackageFamilyName = newInstaller.PackageFamilyName;
-                //matchingExistingInstaller.Platform = newInstaller.Platform;
             }
 
             if (unmatchedInstallers.Any() || multipleMatchedInstallers.Any())
@@ -289,6 +282,11 @@ namespace Microsoft.WingetCreateCore
             }
         }
 
+        /// <summary>
+        /// Updates the metadata from an existing installer node with the metadata from a new installer node.
+        /// </summary>
+        /// <param name="existingInstaller">Existing installer node.</param>
+        /// <param name="newInstaller">New installer node.</param>
         public static void UpdateInstallerNode(Installer existingInstaller, Installer newInstaller)
         {
             existingInstaller.InstallerUrl = newInstaller.InstallerUrl;

--- a/src/WingetCreateCore/Models/Manifests.cs
+++ b/src/WingetCreateCore/Models/Manifests.cs
@@ -39,5 +39,37 @@ namespace Microsoft.WingetCreateCore.Models
         /// Gets or sets the list of locale manifest object models.
         /// </summary>
         public List<LocaleManifest> LocaleManifests { get; set; } = new List<LocaleManifest>();
+
+        public List<Installer.Installer> CloneInstallers()
+        {
+            List<Installer.Installer> deepCopy = new List<Installer.Installer>();
+
+            this.InstallerManifest.Installers.ForEach(
+                i => deepCopy.Add(
+                    new Installer.Installer {
+                        InstallerLocale = i.InstallerLocale,
+                        Platform = i.Platform,
+                        MinimumOSVersion = i.MinimumOSVersion,
+                        Architecture = i.Architecture,
+                        InstallerType = i.InstallerType,
+                        Scope = i.Scope,
+                        InstallerUrl = i.InstallerUrl,
+                        InstallerSha256 = i.InstallerSha256,
+                        SignatureSha256 = i.SignatureSha256,
+                        InstallModes = i.InstallModes,
+                        InstallerSwitches = i.InstallerSwitches,
+                        InstallerSuccessCodes = i.InstallerSuccessCodes,
+                        UpgradeBehavior = i.UpgradeBehavior,
+                        Commands = i.Commands,
+                        Protocols = i.Protocols,
+                        FileExtensions = i.FileExtensions,
+                        PackageFamilyName = i.PackageFamilyName,
+                        ProductCode = i.ProductCode,
+                        Capabilities = i.Capabilities,
+                        RestrictedCapabilities = i.RestrictedCapabilities,
+                    }));
+
+            return deepCopy;
+        } 
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
+++ b/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.WingetCreateTests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Net;
     using System.Net.Http;
@@ -99,6 +100,18 @@ namespace Microsoft.WingetCreateTests
         public static string GetTestFile(string fileName)
         {
             return Path.Combine(Environment.CurrentDirectory, "Resources", fileName);
+        }
+
+        /// <summary>
+        /// Obtains the initial manifest content string from the provided manifest file name.
+        /// </summary>
+        /// <param name="manifestFileName">Manifest file name string.</param>
+        /// <returns>List of manifest content strings.</returns>
+        public static List<string> GetInitialManifestContent(string manifestFileName)
+        {
+            string testFilePath = GetTestFile(manifestFileName);
+            var initialManifestContent = new List<string> { File.ReadAllText(testFilePath) };
+            return initialManifestContent;
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.WingetCreateUnitTests
         {
             string version = "1.2.3.4";
             (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData(TestConstants.TestPackageIdentifier, version, this.tempPath, null);
-
             var updatedManifests = await command.ExecuteManifestUpdate(initialManifestContent, this.testCommandEvent);
             Assert.IsTrue(updatedManifests, "Command should have succeeded");
 
@@ -149,7 +148,6 @@ namespace Microsoft.WingetCreateUnitTests
         {
             TestUtils.InitializeMockDownloads(TestConstants.TestMsixInstaller);
             (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData(TestConstants.TestMultipleInstallerPackageIdentifier, null, this.tempPath, new[] { "fakeurl" });
-            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
             var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
             Assert.IsNull(updatedManifests, "Command should have failed");
             string result = this.sw.ToString();
@@ -165,7 +163,6 @@ namespace Microsoft.WingetCreateUnitTests
         {
             TestUtils.InitializeMockDownloads(TestConstants.TestMsixInstaller);
             (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.SingleMsixInExistingBundle", null, this.tempPath, null);
-            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
             var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
             Assert.IsNull(updatedManifests, "Command should have failed");
             string result = this.sw.ToString();
@@ -185,7 +182,7 @@ namespace Microsoft.WingetCreateUnitTests
             var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
             Assert.IsNull(updatedManifests, "Command should have failed");
             string result = this.sw.ToString();
-            Assert.That(result, Does.Contain(Resources.InstallerCountMustMatch_Error), "Installer must have match error should be thrown");
+            Assert.That(result, Does.Contain(Resources.NewInstallerUrlMustMatchExisting_Message), "New installer must match error should be thrown");
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -253,13 +253,6 @@ namespace Microsoft.WingetCreateUnitTests
             Assert.That(result, Does.Contain(Resources.NoChangeDetectedInUpdatedManifest_Message), "Failed to block manifests without updates from submitting.");
         }
 
-        private static List<string> GetInitialManifestContent(string manifestFileName)
-        {
-            string testFilePath = TestUtils.GetTestFile(manifestFileName);
-            var initialManifestContent = new List<string> { File.ReadAllText(testFilePath) };
-            return initialManifestContent;
-        }
-
         private static (UpdateCommand UpdateCommand, List<string> InitialManifestContent) GetUpdateCommandAndManifestData(string id, string version, string outputDir, IEnumerable<string> installerUrls)
         {
             var updateCommand = new UpdateCommand
@@ -274,7 +267,7 @@ namespace Microsoft.WingetCreateUnitTests
                 updateCommand.InstallerUrls = installerUrls;
             }
 
-            var initialManifestContent = GetInitialManifestContent($"{id}.yaml");
+            var initialManifestContent = TestUtils.GetInitialManifestContent($"{id}.yaml");
 
             return (updateCommand, initialManifestContent);
         }


### PR DESCRIPTION
Resolves #118 
Resolves #120 
Resolves #142 

This PR adds the following changes:
- Adds an --interactive flag to allow users to interactively specify which installer they want to update. 
- This feature is not autonomously and not meant to be used in a CI/CD scenario, but rather as a way to handle any update mismatches.
- Refactored update flow in preparation for any additional changes to the interactive flow.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/149)