### PR TITLE
Fix new command bug when prompting for installer urls

### DIFF
--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -199,7 +199,7 @@ namespace Microsoft.WingetCreateCLI
         /// <param name="minimum">Minimum number of entries required for the list.</param>
         /// <param name="validationModel">Object model to be validated against if the target field differs from what is specified in the model (i.e. NewCommand.InstallerUrls).</param>
         /// <param name="validationName">Name of the property field to be used for looking up validation constraints if the target field name differs from what specified in the model.</param>
-        public static void PromptList<T>(string message, object model, string memberName, List<T> instance, int minimum = 0, object validationModel = null, string validationName = null)
+        public static void PromptList<T>(string message, object model, string memberName, IEnumerable<T> instance, int minimum = 0, object validationModel = null, string validationName = null)
         {
             var property = model.GetType().GetProperty(memberName);
             Type instanceType = typeof(T);

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1627,7 +1627,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List of additional package search terms |e.g. Tag1, Tag2, Tag3|.
+        ///   Looks up a localized string similar to List of additional package search terms.
         /// </summary>
         public static string Tags_KeywordDescription {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -392,7 +392,7 @@
     <value>Collection of installer switches</value>
   </data>
   <data name="Tags_KeywordDescription" xml:space="preserve">
-    <value>List of additional package search terms |e.g. Tag1, Tag2, Tag3|</value>
+    <value>List of additional package search terms</value>
   </data>
   <data name="TokenCommand_HelpText" xml:space="preserve">
     <value>Modifies the GitHub auth token cache</value>


### PR DESCRIPTION
Fixes the following argument type exception when the new command prompts for multiple installer urls:


![image](https://user-images.githubusercontent.com/69221034/132745899-42d6ca7f-ca2d-4525-a2da-45b728c2f340.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/161)