### PR TITLE
Fix pass by reference bug when applying changes to all installers

### DIFF
--- a/src/WingetCreateCore/Common/Extensions.cs
+++ b/src/WingetCreateCore/Common/Extensions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.WingetCreateCore.Common
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Runtime.Serialization;
 
@@ -102,6 +103,43 @@ namespace Microsoft.WingetCreateCore.Common
         public static bool IsEmptyObject(this object o)
         {
             return !o.GetType().GetProperties().Select(pi => pi.GetValue(o)).Where(value => !value.IsDictionary() && value != null).Any();
+        }
+
+        /// <summary>
+        /// Creates a new List object that is a deep clone copy of the current list object instance.
+        /// </summary>
+        /// <param name="list">List object to be cloned.</param>
+        /// <returns>New List object that is a copy of this instance.</returns>
+        public static IList DeepClone(this IList list)
+        {
+            if (list == null)
+            {
+                return null;
+            }
+
+            Type elementType = list.GetType().GetGenericArguments()[0];
+            Type listType = typeof(List<>).MakeGenericType(elementType);
+            var newList = (IList)Activator.CreateInstance(listType);
+            foreach (var item in list)
+            {
+                object toAdd;
+                if (item.GetType().IsValueType)
+                {
+                    toAdd = item;
+                }
+                else if (item is ICloneable clonableItem)
+                {
+                    toAdd = clonableItem.Clone();
+                }
+                else
+                {
+                    throw new InvalidDataException();
+                }
+
+                newList.Add(toAdd);
+            }
+
+            return newList;
         }
     }
 }

--- a/src/WingetCreateCore/Models/Partials.cs
+++ b/src/WingetCreateCore/Models/Partials.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCore.Models.Installer
+{
+    using System;
+
+    /// <summary>
+    /// Partial class that implements cloning functionality to the PackageDependencies class.
+    /// </summary>
+    public partial class PackageDependencies : ICloneable
+    {
+        /// <summary>
+        /// Creates a new PackageDependencies object that is a copy of the current instance.
+        /// </summary>
+        /// <returns>A new PackageDependencies object that is a copy of the current instance.</returns>
+        public object Clone()
+        {
+            return new PackageDependencies { MinimumVersion = this.MinimumVersion, PackageIdentifier = this.PackageIdentifier };
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a bug where List objects passed by reference were causing errors when serializing the manifest as seen in the image below (InstallerSuccessCodes produces weird characters):

![MicrosoftTeams-image](https://user-images.githubusercontent.com/69221034/132909175-0877fcd9-073c-488f-8d92-3ae9d6b82231.png)


The fix was to assign the object by value rather than by reference which requires creating new instances of the edited values



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/164)