### PR TITLE
Handle installers blocked by defender virus scan

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,10 @@ This information will help us triage your report more quickly.
 
 If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
 
+## Virus and Threat Protection
+
+Winget-Create relies on downloading installers and parsing the package for relevant metadata. **Winget-Create does not scan or protect the user from files that may contain viruses.** As with any downloaded file, please verify that the provided installer URL points to a trusted and verified source. If the installer you have provided is blocked due to virus scanning, please take necessary precautions to protect your machine and visit [Virus Threat Protection in Windows Security](https://support.microsoft.com/en-us/windows/virus-threat-protection-in-windows-security-1362f4cd-d71a-b52a-0b66-c2820032b65e) for more details.
+
 ## Preferred Languages
 
 We prefer all communications to be in English.

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -116,9 +116,17 @@ namespace Microsoft.WingetCreateCLI.Commands
                     PackageParser.ParsePackages(packageFiles, this.InstallerUrls, manifests, out List<PackageParser.DetectedArch> detectedArchs);
                     DisplayMismatchedArchitectures(detectedArchs);
                 }
-                catch (ParsePackageException exception)
+                catch (Exception e)
                 {
-                    exception.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
+                    if (e is ParsePackageException exception)
+                    {
+                        exception.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
+                    }
+                    else if (e is IOException)
+                    {
+                        Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
+                    }
+
                     return false;
                 }
 

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -117,25 +117,14 @@ namespace Microsoft.WingetCreateCLI.Commands
                     PackageParser.ParsePackages(packageFiles, this.InstallerUrls, manifests, out List<PackageParser.DetectedArch> detectedArchs);
                     DisplayMismatchedArchitectures(detectedArchs);
                 }
-                catch (Exception e)
+                catch (IOException iOException) when (iOException.HResult == -2147024671)
                 {
-                    if (e is ParsePackageException parsePackageException)
-                    {
-                        parsePackageException.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
-                    }
-                    else if (e is IOException iOException)
-                    {
-                        if (iOException.HResult == -2147024671)
-                        {
-                            // This HResult indicates the installer was blocked by defender scan due to virus detection.
-                            Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
-                        }
-                        else
-                        {
-                            Logger.ErrorLocalized(nameof(Resources.Error_Prefix), iOException.Message);
-                        }
-                    }
-
+                    Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
+                    return false;
+                }
+                catch (ParsePackageException parsePackageException)
+                {
+                    parsePackageException.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
                     return false;
                 }
 

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -253,9 +253,17 @@ namespace Microsoft.WingetCreateCLI.Commands
                 {
                     Logger.ErrorLocalized(nameof(Resources.InstallerCountMustMatch_Error));
                 }
-                else if (e is IOException)
+                else if (e is IOException iOException)
                 {
-                    Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
+                    if (iOException.HResult == -2147024671)
+                    {
+                        // This HResult indicates the installer was blocked by defender scan due to virus detection.
+                        Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
+                    }
+                    else
+                    {
+                        Logger.ErrorLocalized(nameof(Resources.Error_Prefix), iOException.Message);
+                    }
                 }
                 else if (e is ParsePackageException parsePackageException)
                 {

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -247,21 +247,27 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 DisplayMismatchedArchitectures(detectedArchOfInstallers);
             }
-            catch (InvalidOperationException)
+            catch (Exception e)
             {
-                Logger.ErrorLocalized(nameof(Resources.InstallerCountMustMatch_Error));
-                return null;
-            }
-            catch (ParsePackageException parsePackageException)
-            {
-                parsePackageException.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
-                return null;
-            }
-            catch (InstallerMatchException installerMatchException)
-            {
-                Logger.ErrorLocalized(nameof(Resources.NewInstallerUrlMustMatchExisting_Message));
-                installerMatchException.MultipleMatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.UnmatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
-                installerMatchException.UnmatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.MultipleMatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
+                if (e is InvalidOperationException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.InstallerCountMustMatch_Error));
+                }
+                else if (e is IOException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
+                }
+                else if (e is ParsePackageException parsePackageException)
+                {
+                    parsePackageException.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
+                }
+                else if (e is InstallerMatchException installerMatchException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.NewInstallerUrlMustMatchExisting_Message));
+                    installerMatchException.MultipleMatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.UnmatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
+                    installerMatchException.UnmatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.MultipleMatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
+                }
+
                 return null;
             }
 
@@ -433,6 +439,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 else if (!PackageParser.ParsePackageAndUpdateInstallerNode(installer, packageFile, url))
                 {
                     Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), url);
+                    Console.WriteLine();
                 }
                 else
                 {

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -247,35 +247,26 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 DisplayMismatchedArchitectures(detectedArchOfInstallers);
             }
-            catch (Exception e)
+            catch (InvalidOperationException)
             {
-                if (e is InvalidOperationException)
-                {
-                    Logger.ErrorLocalized(nameof(Resources.InstallerCountMustMatch_Error));
-                }
-                else if (e is IOException iOException)
-                {
-                    if (iOException.HResult == -2147024671)
-                    {
-                        // This HResult indicates the installer was blocked by defender scan due to virus detection.
-                        Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
-                    }
-                    else
-                    {
-                        Logger.ErrorLocalized(nameof(Resources.Error_Prefix), iOException.Message);
-                    }
-                }
-                else if (e is ParsePackageException parsePackageException)
-                {
-                    parsePackageException.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
-                }
-                else if (e is InstallerMatchException installerMatchException)
-                {
-                    Logger.ErrorLocalized(nameof(Resources.NewInstallerUrlMustMatchExisting_Message));
-                    installerMatchException.MultipleMatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.UnmatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
-                    installerMatchException.UnmatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.MultipleMatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
-                }
-
+                Logger.ErrorLocalized(nameof(Resources.InstallerCountMustMatch_Error));
+                return null;
+            }
+            catch (IOException iOException) when (iOException.HResult == -2147024671)
+            {
+                Logger.ErrorLocalized(nameof(Resources.DefenderVirus_ErrorMessage));
+                return null;
+            }
+            catch (ParsePackageException parsePackageException)
+            {
+                parsePackageException.ParseFailedInstallerUrls.ForEach(i => Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), i));
+                return null;
+            }
+            catch (InstallerMatchException installerMatchException)
+            {
+                Logger.ErrorLocalized(nameof(Resources.NewInstallerUrlMustMatchExisting_Message));
+                installerMatchException.MultipleMatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.UnmatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
+                installerMatchException.UnmatchedInstallers.ForEach(i => Logger.ErrorLocalized(nameof(Resources.MultipleMatchedInstaller_Error), i.Architecture, i.InstallerType, i.InstallerUrl));
                 return null;
             }
 

--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -199,7 +199,7 @@ namespace Microsoft.WingetCreateCLI
         /// <param name="minimum">Minimum number of entries required for the list.</param>
         /// <param name="validationModel">Object model to be validated against if the target field differs from what is specified in the model (i.e. NewCommand.InstallerUrls).</param>
         /// <param name="validationName">Name of the property field to be used for looking up validation constraints if the target field name differs from what specified in the model.</param>
-        public static void PromptList<T>(string message, object model, string memberName, List<T> instance, int minimum = 0, object validationModel = null, string validationName = null)
+        public static void PromptList<T>(string message, object model, string memberName, IEnumerable<T> instance, int minimum = 0, object validationModel = null, string validationName = null)
         {
             var property = model.GetType().GetProperty(memberName);
             Type instanceType = typeof(T);

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1627,7 +1627,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List of additional package search terms |e.g. Tag1, Tag2, Tag3|.
+        ///   Looks up a localized string similar to List of additional package search terms.
         /// </summary>
         public static string Tags_KeywordDescription {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -304,6 +304,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Operation did not complete successfully because the downloaded file contains a virus or potentially unwanted software. For more information on potentially unwanted software and what options are available, see https://aka.ms/winget-create-security.
+        /// </summary>
+        public static string DefenderVirus_ErrorMessage {
+            get {
+                return ResourceManager.GetString("DefenderVirus_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleting {0}.
         /// </summary>
         public static string DeletingInstaller_Message {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -762,4 +762,7 @@
   <data name="DiscardUpdateAndStartOver_Message" xml:space="preserve">
     <value>Would you like to discard this update and start over?</value>
   </data>
+  <data name="DefenderVirus_ErrorMessage" xml:space="preserve">
+    <value>Operation did not complete successfully because the downloaded file contains a virus or potentially unwanted software. For more information on potentially unwanted software and what options are available, see https://aka.ms/winget-create-security</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -392,7 +392,7 @@
     <value>Collection of installer switches</value>
   </data>
   <data name="Tags_KeywordDescription" xml:space="preserve">
-    <value>List of additional package search terms |e.g. Tag1, Tag2, Tag3|</value>
+    <value>List of additional package search terms</value>
   </data>
   <data name="TokenCommand_HelpText" xml:space="preserve">
     <value>Modifies the GitHub auth token cache</value>

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -294,9 +294,6 @@ namespace Microsoft.WingetCreateCore
         /// <returns>Boolean indicating whether the package parse was successful.</returns>
         public static bool ParsePackageAndUpdateInstallerNode(Installer installer, string path, string url)
         {
-            // Clean out values from installer which could be present from 
-            InstallerType initialInstallerType = installer.InstallerType.Value;
-
             List<Installer> newInstallers = new List<Installer>();
             bool parseResult = ParseExeInstallerType(path, installer, newInstallers) ||
                 ParseMsix(path, installer, null, newInstallers) ||


### PR DESCRIPTION
This PR adds the following changes:

- Additional documentation in the security.md file regarding Virus and Threat Protection
- Catches IOException which is thrown when a downloaded installer is blocked by defender scan.
- Reformatting Exception handling

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/165)