### PR TITLE
Add index prefix to installer menu item

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -295,7 +295,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         private static List<string> GenerateInstallerSelectionList(List<Installer> installers, out Dictionary<string, Installer> installerSelectionMap)
         {
             installerSelectionMap = new Dictionary<string, Installer>();
-
+            int index = 1;
             foreach (Installer installer in installers)
             {
                 var installerTuple = string.Join(" | ", new[]
@@ -307,7 +307,9 @@ namespace Microsoft.WingetCreateCLI.Commands
                         installer.InstallerUrl,
                     }.Where(s => !string.IsNullOrEmpty(s)));
 
-                installerSelectionMap.Add(installerTuple, installer);
+                var installerMenuItem = string.Format(Resources.InstallerSelection_MenuItem, index, installerTuple);
+                installerSelectionMap.Add(installerMenuItem, installer);
+                index++;
             }
 
             List<string> selectionList = new List<string>() { Resources.AllInstallers_MenuItem };

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -745,6 +745,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to INSTALLER {0}: {1}.
+        /// </summary>
+        public static string InstallerSelection_MenuItem {
+            get {
+                return ResourceManager.GetString("InstallerSelection_MenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} installers found in {1}.
         /// </summary>
         public static string InstallersFound_Message {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -769,4 +769,9 @@
   <data name="DefenderVirus_ErrorMessage" xml:space="preserve">
     <value>Operation did not complete successfully because the downloaded file contains a virus or potentially unwanted software. For more information on potentially unwanted software and what options are available, see https://aka.ms/winget-create-security</value>
   </data>
+  <data name="InstallerSelection_MenuItem" xml:space="preserve">
+    <value>INSTALLER {0}: {1}</value>
+    <comment>{0} - represents the installer index number
+{1} - represents the associated installer metadata</comment>
+  </data>
 </root>


### PR DESCRIPTION
Changes:

- Prepends "INSTALLER {index}: " to each installer node in order to make them unique. This fixes a bug that occurs when a user uses the new command to create a new manifest with 2 identical installer URLs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/169)