### PR TITLE
Add modify feature to interactive update

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -148,7 +148,6 @@ namespace Microsoft.WingetCreateCLI.Commands
             DefaultLocaleManifest defaultLocaleManifest = manifests.DefaultLocaleManifest;
             List<LocaleManifest> localeManifests = manifests.LocaleManifests;
 
-            string defaultPackageLocale = defaultLocaleManifest.PackageLocale;
             string version = versionManifest.PackageVersion;
             string packageId = versionManifest.PackageIdentifier;
             string manifestDir = Utils.GetAppManifestDirPath(packageId, version);
@@ -167,9 +166,9 @@ namespace Microsoft.WingetCreateCLI.Commands
                 fullDirPath = Path.Combine(outputDir, manifestDir);
             }
 
-            string versionManifestFileName = $"{packageId}.yaml";
-            string installerManifestFileName = $"{packageId}.installer.yaml";
-            string defaultLocaleManifestFileName = $"{packageId}.locale.{defaultPackageLocale}.yaml";
+            string versionManifestFileName = Manifests.GetFileName(manifests.VersionManifest);
+            string installerManifestFileName = Manifests.GetFileName(manifests.InstallerManifest);
+            string defaultLocaleManifestFileName = Manifests.GetFileName(manifests.DefaultLocaleManifest);
 
             File.WriteAllText(Path.Combine(fullDirPath, versionManifestFileName), versionManifest.ToYaml());
             File.WriteAllText(Path.Combine(fullDirPath, installerManifestFileName), installerManifest.ToYaml());
@@ -177,7 +176,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             foreach (LocaleManifest localeManifest in localeManifests)
             {
-                string localeManifestFileName = $"{packageId}.locale.{localeManifest.PackageLocale}.yaml";
+                string localeManifestFileName = Manifests.GetFileName(localeManifest);
                 File.WriteAllText(Path.Combine(fullDirPath, localeManifestFileName), localeManifest.ToYaml());
             }
 
@@ -195,11 +194,9 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <returns>A boolean value indicating whether validation of the manifests was successful.</returns>
         protected static bool ValidateManifestsInTempDir(Manifests manifests)
         {
-            string packageId = manifests.VersionManifest.PackageIdentifier;
-            string defaultPackageLocale = manifests.DefaultLocaleManifest.PackageLocale;
-            string versionManifestFileName = $"{packageId}.yaml";
-            string installerManifestFileName = $"{packageId}.installer.yaml";
-            string defaultLocaleManifestFileName = $"{packageId}.locale.{defaultPackageLocale}.yaml";
+            string versionManifestFileName = Manifests.GetFileName(manifests.VersionManifest);
+            string installerManifestFileName = Manifests.GetFileName(manifests.InstallerManifest);
+            string defaultLocaleManifestFileName = Manifests.GetFileName(manifests.DefaultLocaleManifest);
 
             string randomDirPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(randomDirPath);

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -255,7 +255,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// Displays all installers from an Installer manifest as a selection menu.
         /// </summary>
-        private static void DisplayInstallersAsMenuSelection(InstallerManifest installerManifest)
+        public static void DisplayInstallersAsMenuSelection(InstallerManifest installerManifest)
         {
             Console.Clear();
 

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -16,7 +16,6 @@ namespace Microsoft.WingetCreateCLI.Commands
     using Microsoft.WingetCreateCLI.Telemetry;
     using Microsoft.WingetCreateCLI.Telemetry.Events;
     using Microsoft.WingetCreateCore;
-    using Microsoft.WingetCreateCore.Common;
     using Microsoft.WingetCreateCore.Common.Exceptions;
     using Microsoft.WingetCreateCore.Models;
     using Microsoft.WingetCreateCore.Models.DefaultLocale;

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -405,7 +405,6 @@ namespace Microsoft.WingetCreateCLI.Commands
                 else if (selectedItem == defaultLocaleMenuItem)
                 {
                     PromptHelper.PromptPropertiesWithMenu(manifests.DefaultLocaleManifest, Resources.SaveAndExit_MenuItem, Manifests.GetFileName(manifests.DefaultLocaleManifest));
-
                 }
                 else if (selectedItem == Resources.Done_MenuItem)
                 {

--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -22,6 +22,14 @@ namespace Microsoft.WingetCreateCLI
     /// </summary>
     public static class PromptHelper
     {
+        private static readonly string[] NonEditableRequiredFields = new[]
+        {
+            nameof(InstallerManifest.PackageIdentifier),
+            nameof(InstallerManifest.PackageVersion),
+            nameof(InstallerManifest.ManifestType),
+            nameof(InstallerManifest.ManifestVersion),
+        };
+
         /// <summary>
         /// List of strings representing the optional fields that should not be editable.
         /// </summary>
@@ -72,8 +80,9 @@ namespace Microsoft.WingetCreateCLI
 
             var fieldList = properties
                 .Select(property => property.Name)
-                .Where(pName => !NonEditableOptionalFields.Any(field => field == pName)).ToList();
+                .Where(pName => !NonEditableOptionalFields.Any(field => field == pName) && !NonEditableRequiredFields.Any(field => field == pName)).ToList();
 
+            // Filter out fields if an installerType is present
             var installerTypeProperty = model.GetType().GetProperty(nameof(InstallerType));
             if (installerTypeProperty != null)
             {
@@ -106,8 +115,16 @@ namespace Microsoft.WingetCreateCLI
                     break;
                 }
 
-                var selectedProperty = properties.First(p => p.Name == selectedField);
-                PromptPropertyAndSetValue(model, selectedField, selectedProperty.GetValue(model));
+                if (selectedField == nameof(InstallerManifest.Installers))
+                {
+                    Commands.NewCommand.DisplayInstallersAsMenuSelection(model as InstallerManifest);
+                }
+                else
+                {
+
+                    var selectedProperty = properties.First(p => p.Name == selectedField);
+                    PromptPropertyAndSetValue(model, selectedField, selectedProperty.GetValue(model));
+                }
             }
         }
 

--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -69,37 +69,15 @@ namespace Microsoft.WingetCreateCLI
         /// <typeparam name="T">Model type.</typeparam>
         /// <param name="model">Instance of object model.</param>
         /// <param name="exitMenuWord">Exit keyword to be shown to the user to exit the navigational menu.</param>
-        public static void PromptPropertiesWithMenu<T>(T model, string exitMenuWord)
+        /// <param name="modelName">If a non-null string is provided, a menu item to display a preview of the model will be added to the selection list</param>
+        public static void PromptPropertiesWithMenu<T>(T model, string exitMenuWord, string modelName = null)
         {
             Console.Clear();
-
-            var properties = model.GetType().GetProperties().ToList();
-            var optionalProperties = properties.Where(p =>
-                p.GetCustomAttribute<RequiredAttribute>() == null &&
-                p.GetCustomAttribute<JsonPropertyAttribute>() != null).ToList();
-
-            var fieldList = properties
-                .Select(property => property.Name)
-                .Where(pName => !NonEditableOptionalFields.Any(field => field == pName) && !NonEditableRequiredFields.Any(field => field == pName)).ToList();
-
-            // Filter out fields if an installerType is present
-            var installerTypeProperty = model.GetType().GetProperty(nameof(InstallerType));
-            if (installerTypeProperty != null)
+            var properties = model.GetType().GetProperties();
+            var fieldList = FilterRestrictedFields(model, properties);
+            if (!string.IsNullOrEmpty(modelName))
             {
-                var installerTypeValue = installerTypeProperty.GetValue(model);
-                if (installerTypeValue != null)
-                {
-                    var installerType = (InstallerType)installerTypeValue;
-                    if (installerType == InstallerType.Msi || installerType == InstallerType.Exe)
-                    {
-                        fieldList.Add(nameof(Installer.ProductCode));
-                    }
-                    else if (installerType == InstallerType.Msix || installerType == InstallerType.Appx)
-                    {
-                        fieldList = fieldList.Where(pName => !MsixExclusionList.Any(field => field == pName)).ToList();
-                        fieldList.AddRange(MsixInclusionList);
-                    }
-                }
+                fieldList.Add(Resources.DisplayPreview_MenuItem);
             }
 
             fieldList.Add(exitMenuWord);
@@ -114,16 +92,61 @@ namespace Microsoft.WingetCreateCLI
                 {
                     break;
                 }
-
-                if (selectedField == nameof(InstallerManifest.Installers))
+                else if (selectedField == Resources.DisplayPreview_MenuItem)
                 {
-                    Commands.NewCommand.DisplayInstallersAsMenuSelection(model as InstallerManifest);
+                    Console.Clear();
+                    Console.WriteLine();
+                    Logger.InfoLocalized(nameof(Resources.DisplayPreviewOfItems), modelName);
+                    Console.WriteLine(Serialization.Serialize(model));
+                    Console.WriteLine();
+                }
+                else if (selectedField == nameof(InstallerManifest.Installers))
+                {
+                    DisplayInstallersAsMenuSelection(model as InstallerManifest);
                 }
                 else
                 {
-
                     var selectedProperty = properties.First(p => p.Name == selectedField);
                     PromptPropertyAndSetValue(model, selectedField, selectedProperty.GetValue(model));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Displays all installers from an Installer manifest as a selection menu.
+        /// </summary>
+        /// <param name="installerManifest">Installer manifest model.</param>
+        public static void DisplayInstallersAsMenuSelection(InstallerManifest installerManifest)
+        {
+            Console.Clear();
+
+            while (true)
+            {
+                List<string> selectionList = GenerateInstallerSelectionList(installerManifest.Installers, out Dictionary<string, Installer> installerSelectionMap);
+                var selectedItem = Prompt.Select(Resources.SelectInstallerToEdit_Message, selectionList);
+
+                if (selectedItem == Resources.SaveAndExit_MenuItem)
+                {
+                    break;
+                }
+                else if (selectedItem == Resources.AllInstallers_MenuItem)
+                {
+                    Installer installerCopy = new Installer();
+                    PromptPropertiesWithMenu(installerCopy, Resources.SaveAndExit_MenuItem);
+                    ApplyChangesToIndividualInstallers(installerCopy, installerManifest.Installers);
+                }
+                else if (selectedItem == Resources.DisplayPreview_MenuItem)
+                {
+                    Console.Clear();
+                    Console.WriteLine();
+                    Logger.InfoLocalized(nameof(Resources.DisplayPreviewOfSelectedInstaller_Message));
+                    Console.WriteLine(Serialization.Serialize(installerManifest));
+                    Console.WriteLine();
+                }
+                else
+                {
+                    Installer selectedInstaller = installerSelectionMap[selectedItem];
+                    PromptPropertiesWithMenu(selectedInstaller, Resources.SaveAndExit_MenuItem, selectedItem.Split(':')[0]);
                 }
             }
         }
@@ -286,6 +309,119 @@ namespace Microsoft.WingetCreateCLI
             }
         }
 
+        private static List<string> FilterRestrictedFields<T>(T model, PropertyInfo[] properties)
+        {
+            var fieldList = properties
+                .Select(property => property.Name)
+                .Where(pName =>
+                    !NonEditableOptionalFields.Any(field => field == pName) &&
+                    !NonEditableRequiredFields.Any(field => field == pName)).ToList();
+
+            // Filter out fields if an installerType is present
+            var installerTypeProperty = model.GetType().GetProperty(nameof(InstallerType));
+            if (installerTypeProperty != null)
+            {
+                var installerTypeValue = installerTypeProperty.GetValue(model);
+                if (installerTypeValue != null)
+                {
+                    var installerType = (InstallerType)installerTypeValue;
+                    if (installerType == InstallerType.Msi || installerType == InstallerType.Exe)
+                    {
+                        fieldList.Add(nameof(Installer.ProductCode));
+                    }
+                    else if (installerType == InstallerType.Msix || installerType == InstallerType.Appx)
+                    {
+                        fieldList = fieldList.Where(pName => !MsixExclusionList.Any(field => field == pName)).ToList();
+                        fieldList.AddRange(MsixInclusionList);
+                    }
+                }
+            }
+
+            return fieldList;
+        }
+
+        private static List<string> GenerateInstallerSelectionList(List<Installer> installers, out Dictionary<string, Installer> installerSelectionMap)
+        {
+            installerSelectionMap = new Dictionary<string, Installer>();
+            int index = 1;
+            foreach (Installer installer in installers)
+            {
+                var installerTuple = string.Join(" | ", new[]
+                    {
+                        installer.Architecture.ToEnumAttributeValue(),
+                        installer.InstallerType.ToEnumAttributeValue(),
+                        installer.Scope?.ToEnumAttributeValue(),
+                        installer.InstallerLocale,
+                        installer.InstallerUrl,
+                    }.Where(s => !string.IsNullOrEmpty(s)));
+
+                var installerMenuItem = string.Format(Resources.InstallerSelection_MenuItem, index, installerTuple);
+                installerSelectionMap.Add(installerMenuItem, installer);
+                index++;
+            }
+
+            List<string> selectionList = new List<string>() { Resources.AllInstallers_MenuItem };
+            selectionList.AddRange(installerSelectionMap.Keys);
+            selectionList.AddRange(new[] { Resources.DisplayPreview_MenuItem, Resources.SaveAndExit_MenuItem });
+            return selectionList;
+        }
+
+        private static void ApplyChangesToIndividualInstallers(Installer installerCopy, List<Installer> installers)
+        {
+            // Skip architecture as the default value when instantiated is x86.
+            var modifiedFields = installerCopy.GetType().GetProperties()
+                .Select(prop => prop)
+                .Where(pi =>
+                    pi.GetValue(installerCopy) != null &&
+                    pi.Name != nameof(Installer.Architecture) &&
+                    pi.Name != nameof(Installer.AdditionalProperties));
+
+            foreach (var field in modifiedFields)
+            {
+                foreach (Installer installer in installers)
+                {
+                    var fieldValue = field.GetValue(installerCopy);
+                    var prop = installer.GetType().GetProperty(field.Name);
+                    if (prop.PropertyType.IsValueType)
+                    {
+                        prop.SetValue(installer, fieldValue);
+                    }
+                    else if (fieldValue is IList list)
+                    {
+                        prop.SetValue(installer, list.DeepClone());
+                    }
+                    else if (fieldValue is Dependencies dependencies)
+                    {
+                        ApplyDependencyChangesToInstaller(dependencies, installer);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clones any non-null property values of the dependencies object and assigns them to the provided installer object.
+        /// </summary>
+        /// <param name="dependencies">Dependencies object with new values.</param>
+        /// <param name="installer">Installer object to assign new changes to.</param>
+        private static void ApplyDependencyChangesToInstaller(Dependencies dependencies, Installer installer)
+        {
+            var modifiedFields = dependencies.GetType().GetProperties()
+                .Select(prop => prop)
+                .Where(pi => pi.GetValue(dependencies) != null);
+
+            foreach (var field in modifiedFields.Where(f => f.Name != nameof(Installer.AdditionalProperties)))
+            {
+                var fieldValue = field.GetValue(dependencies);
+                installer.Dependencies ??= new Dependencies();
+                var prop = installer.Dependencies.GetType().GetProperty(field.Name);
+
+                if (fieldValue is IList list)
+                {
+                    prop.SetValue(installer.Dependencies, list.DeepClone());
+                }
+            }
+        }
+
         private static void PromptEnum(object model, PropertyInfo property, Type enumType, bool required, string message, string defaultValue = null)
         {
             var enumList = Enum.GetNames(enumType);
@@ -305,7 +441,6 @@ namespace Microsoft.WingetCreateCLI
         private static void PromptForItemList<T>(List<T> items)
             where T : new()
         {
-            var serializer = Serialization.CreateSerializer();
             string selection = string.Empty;
             while (selection != Resources.Back_MenuItem)
             {
@@ -313,7 +448,7 @@ namespace Microsoft.WingetCreateCLI
                 if (items.Any())
                 {
                     Logger.InfoLocalized(nameof(Resources.DisplayPreviewOfItems), typeof(T).Name);
-                    string serializedString = serializer.Serialize(items);
+                    string serializedString = Serialization.Serialize(items);
                     Console.WriteLine(serializedString);
                     Console.WriteLine();
                 }
@@ -345,7 +480,7 @@ namespace Microsoft.WingetCreateCLI
 
         private static void PromptSubfieldProperties<T>(T field, PropertyInfo property, object model)
         {
-            PromptPropertiesWithMenu(field, Resources.None_MenuItem);
+            PromptPropertiesWithMenu(field, Resources.SaveAndExit_MenuItem);
             if (field.IsEmptyObject())
             {
                 property.SetValue(model, null);

--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -74,7 +74,7 @@ namespace Microsoft.WingetCreateCLI
         {
             Console.Clear();
             var properties = model.GetType().GetProperties();
-            var fieldList = FilterRestrictedFields(model, properties);
+            var fieldList = FilterPropertiesAndCreateSelectionList(model, properties);
             if (!string.IsNullOrEmpty(modelName))
             {
                 fieldList.Add(Resources.DisplayPreview_MenuItem);
@@ -309,7 +309,15 @@ namespace Microsoft.WingetCreateCLI
             }
         }
 
-        private static List<string> FilterRestrictedFields<T>(T model, PropertyInfo[] properties)
+        /// <summary>
+        /// Creates a filtered list of strings representing the fields to be shown in a selection menu. Filters out
+        /// non-editable fields as well as fields that are not relevant based on the installer type if present.
+        /// </summary>
+        /// <typeparam name="T">Object type.</typeparam>
+        /// <param name="model">Object model.</param>
+        /// <param name="properties">Array of model properties.</param>
+        /// <returns>List of strings representing the properties to be shown in the selection menu.</returns>
+        private static List<string> FilterPropertiesAndCreateSelectionList<T>(T model, PropertyInfo[] properties)
         {
             var fieldList = properties
                 .Select(property => property.Name)
@@ -340,6 +348,12 @@ namespace Microsoft.WingetCreateCLI
             return fieldList;
         }
 
+        /// <summary>
+        /// Creates a list of strings representing the installer nodes to be shown in a selection menu.
+        /// </summary>
+        /// <param name="installers">List of installers.</param>
+        /// <param name="installerSelectionMap">Installer dictionary that maps the installer menu item string to the installer object model.</param>
+        /// <returns>List of strings representing the installers to be shown in the selection menu. </returns>
         private static List<string> GenerateInstallerSelectionList(List<Installer> installers, out Dictionary<string, Installer> installerSelectionMap)
         {
             installerSelectionMap = new Dictionary<string, Installer>();
@@ -366,6 +380,11 @@ namespace Microsoft.WingetCreateCLI
             return selectionList;
         }
 
+        /// <summary>
+        /// Applies all installerCopy changes to each installer in the List of installers.
+        /// </summary>
+        /// <param name="installerCopy">Installer object model with new changes.</param>
+        /// <param name="installers">List of installers receiving the new changes.</param>
         private static void ApplyChangesToIndividualInstallers(Installer installerCopy, List<Installer> installers)
         {
             // Skip architecture as the default value when instantiated is x86.

--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.WingetCreateCLI
         /// <typeparam name="T">Model type.</typeparam>
         /// <param name="model">Instance of object model.</param>
         /// <param name="exitMenuWord">Exit keyword to be shown to the user to exit the navigational menu.</param>
-        /// <param name="modelName">If a non-null string is provided, a menu item to display a preview of the model will be added to the selection list</param>
+        /// <param name="modelName">If a non-null string is provided, a menu item to display a preview of the model will be added to the selection list.</param>
         public static void PromptPropertiesWithMenu<T>(T model, string exitMenuWord, string modelName = null)
         {
             Console.Clear();

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -439,6 +439,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Would you like to edit your manifests?.
+        /// </summary>
+        public static string EditManifests_Message {
+            get {
+                return ResourceManager.GetString("EditManifests_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please enter values for the following fields:.
         /// </summary>
         public static string EnterFollowingFields_Message {
@@ -1492,6 +1501,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SAVE AND EXIT.
+        /// </summary>
+        public static string SaveAndExit_MenuItem {
+            get {
+                return ResourceManager.GetString("SaveAndExit_MenuItem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This is an enumeration of install scope (“User”, “System”).
         /// </summary>
         public static string Scope_KeywordDescription {
@@ -1515,6 +1533,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string SelectInstallerToEdit_Message {
             get {
                 return ResourceManager.GetString("SelectInstallerToEdit_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Which manifest do you want to edit?.
+        /// </summary>
+        public static string SelectManifestToEdit_Message {
+            get {
+                return ResourceManager.GetString("SelectManifestToEdit_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -774,4 +774,13 @@
     <comment>{0} - represents the installer index number
 {1} - represents the associated installer metadata</comment>
   </data>
+  <data name="EditManifests_Message" xml:space="preserve">
+    <value>Would you like to edit your manifests?</value>
+  </data>
+  <data name="SaveAndExit_MenuItem" xml:space="preserve">
+    <value>SAVE AND EXIT</value>
+  </data>
+  <data name="SelectManifestToEdit_Message" xml:space="preserve">
+    <value>Which manifest do you want to edit?</value>
+  </data>
 </root>

--- a/src/WingetCreateCore/Common/Extensions.cs
+++ b/src/WingetCreateCore/Common/Extensions.cs
@@ -9,10 +9,6 @@ namespace Microsoft.WingetCreateCore.Common
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization;
-    using Microsoft.WingetCreateCore.Models.DefaultLocale;
-    using Microsoft.WingetCreateCore.Models.Installer;
-    using Microsoft.WingetCreateCore.Models.Locale;
-    using Microsoft.WingetCreateCore.Models.Version;
 
     /// <summary>
     /// Functionality for manipulating data related to the Manifest object model.
@@ -144,30 +140,6 @@ namespace Microsoft.WingetCreateCore.Common
             }
 
             return newList;
-        }
-
-        public static string GetFileName(this object o)
-        {
-            string fileName = null;
-
-            if (o is InstallerManifest installerManifest)
-            {
-                fileName = $"{installerManifest.PackageIdentifier}.installer.yaml";
-            }
-            else if (o is VersionManifest versionManifest)
-            {
-                fileName = $"{versionManifest.PackageIdentifier}.yaml";
-            }
-            else if (o is DefaultLocaleManifest defaultLocaleManifest)
-            {
-                fileName = $"{defaultLocaleManifest.PackageIdentifier}.locale.{defaultLocaleManifest.PackageLocale}.yaml";
-            }
-            else if (o is LocaleManifest localeManifest)
-            {
-                fileName = $"{localeManifest.PackageIdentifier}.locale.{localeManifest.PackageLocale}.yaml";
-            }
-
-            return fileName;
         }
     }
 }

--- a/src/WingetCreateCore/Common/Extensions.cs
+++ b/src/WingetCreateCore/Common/Extensions.cs
@@ -9,6 +9,10 @@ namespace Microsoft.WingetCreateCore.Common
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization;
+    using Microsoft.WingetCreateCore.Models.DefaultLocale;
+    using Microsoft.WingetCreateCore.Models.Installer;
+    using Microsoft.WingetCreateCore.Models.Locale;
+    using Microsoft.WingetCreateCore.Models.Version;
 
     /// <summary>
     /// Functionality for manipulating data related to the Manifest object model.
@@ -140,6 +144,30 @@ namespace Microsoft.WingetCreateCore.Common
             }
 
             return newList;
+        }
+
+        public static string GetFileName(this object o)
+        {
+            string fileName = null;
+
+            if (o is InstallerManifest installerManifest)
+            {
+                fileName = $"{installerManifest.PackageIdentifier}.installer.yaml";
+            }
+            else if (o is VersionManifest versionManifest)
+            {
+                fileName = $"{versionManifest.PackageIdentifier}.yaml";
+            }
+            else if (o is DefaultLocaleManifest defaultLocaleManifest)
+            {
+                fileName = $"{defaultLocaleManifest.PackageIdentifier}.locale.{defaultLocaleManifest.PackageLocale}.yaml";
+            }
+            else if (o is LocaleManifest localeManifest)
+            {
+                fileName = $"{localeManifest.PackageIdentifier}.locale.{localeManifest.PackageLocale}.yaml";
+            }
+
+            return fileName;
         }
     }
 }

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -313,7 +313,7 @@ namespace Microsoft.WingetCreateCore
             }
             else
             {
-                // For a single installer, detect the architecture. If no architecture is found, default to architecture from existing manifest.
+                // For a single installer, detect the architecture. If no architecture is detected, default to architecture from existing manifest.
                 newInstaller.Architecture = GetArchFromUrl(url) ?? GetMachineType(path)?.ToString().ToEnumOrDefault<InstallerArchitecture>() ?? installer.Architecture;
             }
 

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -305,9 +305,20 @@ namespace Microsoft.WingetCreateCore
             }
 
             Installer newInstaller = newInstallers.First();
+
+            if (newInstallers.Count > 1)
+            {
+                // For multiple installers in an AppxBundle, use the existing architecture to avoid matching conflicts.
+                newInstaller.Architecture = installer.Architecture;
+            }
+            else
+            {
+                // For a single installer, detect the architecture. If no architecture is found, default to architecture from existing manifest.
+                newInstaller.Architecture = GetArchFromUrl(url) ?? GetMachineType(path)?.ToString().ToEnumOrDefault<InstallerArchitecture>() ?? installer.Architecture;
+            }
+
             newInstaller.InstallerUrl = url;
             newInstaller.InstallerSha256 = GetFileHash(path);
-
             UpdateInstallerMetadata(installer, newInstallers.First());
             return true;
         }
@@ -330,6 +341,7 @@ namespace Microsoft.WingetCreateCore
         /// <param name="newInstaller">New installer node.</param>
         private static void UpdateInstallerMetadata(Installer existingInstaller, Installer newInstaller)
         {
+            existingInstaller.Architecture = newInstaller.Architecture;
             existingInstaller.InstallerUrl = newInstaller.InstallerUrl;
             existingInstaller.InstallerSha256 = newInstaller.InstallerSha256;
             existingInstaller.SignatureSha256 = newInstaller.SignatureSha256;

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -313,6 +313,17 @@ namespace Microsoft.WingetCreateCore
         }
 
         /// <summary>
+        /// Creates a new Installer object that is a copy of the provided Installer.
+        /// </summary>
+        /// <param name="installer">Installer object to be cloned.</param>
+        /// <returns>A new cloned Installer object.</returns>
+        public static Installer CloneInstaller(Installer installer)
+        {
+            string json = JsonConvert.SerializeObject(installer);
+            return JsonConvert.DeserializeObject<Installer>(json);
+        }
+
+        /// <summary>
         /// Updates the metadata from an existing installer node with the metadata from a new installer node.
         /// </summary>
         /// <param name="existingInstaller">Existing installer node.</param>
@@ -452,7 +463,6 @@ namespace Microsoft.WingetCreateCore
 
             return archMatches.Count == 1 ? archMatches.Single() : null;
         }
-
 
         /// <summary>
         /// Computes the SHA256 hash value for the specified byte array.
@@ -648,12 +658,6 @@ namespace Microsoft.WingetCreateCore
             }
 
             return null;
-        }
-
-        private static Installer CloneInstaller(Installer installer)
-        {
-            string json = JsonConvert.SerializeObject(installer);
-            return JsonConvert.DeserializeObject<Installer>(json);
         }
 
         private static void SetInstallerPropertiesFromAppxMetadata(AppxMetadata appxMetadata, Installer installer, InstallerManifest installerManifest)

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -140,10 +140,9 @@ namespace Microsoft.WingetCreateCore
         /// <summary>
         /// Serializes the provided object and returns the serialized string.
         /// </summary>
-        /// <typeparam name="T">Object type.</typeparam>
         /// <param name="value">Object to be serialized.</param>
         /// <returns>Serialized string.</returns>
-        public static string Serialize<T>(T value)
+        public static string Serialize(object value)
         {
             var serializer = CreateSerializer();
             return serializer.Serialize(value);

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -138,6 +138,18 @@ namespace Microsoft.WingetCreateCore
         }
 
         /// <summary>
+        /// Serializes the provided object and returns the serialized string.
+        /// </summary>
+        /// <typeparam name="T">Object type.</typeparam>
+        /// <param name="value">Object to be serialized.</param>
+        /// <returns>Serialized string.</returns>
+        public static string Serialize<T>(T value)
+        {
+            var serializer = CreateSerializer();
+            return serializer.Serialize(value);
+        }
+
+        /// <summary>
         /// Deserializes a list of manifest strings into their appropriate object models.
         /// </summary>
         /// <param name="manifestContents">List of manifest string contents.</param>

--- a/src/WingetCreateCore/Models/Manifests.cs
+++ b/src/WingetCreateCore/Models/Manifests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.WingetCreateCore.Models
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.WingetCreateCore.Models.DefaultLocale;
     using Microsoft.WingetCreateCore.Models.Installer;
@@ -48,61 +49,25 @@ namespace Microsoft.WingetCreateCore.Models
         /// <returns>File name string of manifest.</returns>
         public static string GetFileName<T>(T manifest)
         {
-            string fileName = null;
-
-            if (manifest is InstallerManifest installerManifest)
+            return manifest switch
             {
-                fileName = $"{installerManifest.PackageIdentifier}.installer.yaml";
-            }
-            else if (manifest is VersionManifest versionManifest)
-            {
-                fileName = $"{versionManifest.PackageIdentifier}.yaml";
-            }
-            else if (manifest is DefaultLocaleManifest defaultLocaleManifest)
-            {
-                fileName = $"{defaultLocaleManifest.PackageIdentifier}.locale.{defaultLocaleManifest.PackageLocale}.yaml";
-            }
-            else if (manifest is LocaleManifest localeManifest)
-            {
-                fileName = $"{localeManifest.PackageIdentifier}.locale.{localeManifest.PackageLocale}.yaml";
-            }
-            else if (manifest is SingletonManifest singletonManifest)
-            {
-                fileName = $"{singletonManifest.PackageIdentifier}.yaml";
-            }
-
-            return fileName;
+                InstallerManifest installerManifest => $"{installerManifest.PackageIdentifier}.installer.yaml",
+                VersionManifest versionManifest => $"{versionManifest.PackageIdentifier}.yaml",
+                DefaultLocaleManifest defaultLocaleManifest => $"{defaultLocaleManifest.PackageIdentifier}.locale.{defaultLocaleManifest.PackageLocale}.yaml",
+                LocaleManifest localeManifest => $"{localeManifest.PackageIdentifier}.locale.{localeManifest.PackageLocale}.yaml",
+                SingletonManifest singletonManifest => $"{singletonManifest.PackageIdentifier}.yaml",
+                _ => throw new ArgumentException(nameof(manifest)),
+            };
         }
 
+        /// <summary>
+        /// Creates a new cloned list of Installers that is a copy of the current list of installers.
+        /// </summary>
+        /// <returns>A new cloned list of Installers.</returns>
         public List<Installer.Installer> CloneInstallers()
         {
             List<Installer.Installer> deepCopy = new List<Installer.Installer>();
-
-            this.InstallerManifest.Installers.ForEach(
-                i => deepCopy.Add(
-                    new Installer.Installer {
-                        InstallerLocale = i.InstallerLocale,
-                        Platform = i.Platform,
-                        MinimumOSVersion = i.MinimumOSVersion,
-                        Architecture = i.Architecture,
-                        InstallerType = i.InstallerType,
-                        Scope = i.Scope,
-                        InstallerUrl = i.InstallerUrl,
-                        InstallerSha256 = i.InstallerSha256,
-                        SignatureSha256 = i.SignatureSha256,
-                        InstallModes = i.InstallModes,
-                        InstallerSwitches = i.InstallerSwitches,
-                        InstallerSuccessCodes = i.InstallerSuccessCodes,
-                        UpgradeBehavior = i.UpgradeBehavior,
-                        Commands = i.Commands,
-                        Protocols = i.Protocols,
-                        FileExtensions = i.FileExtensions,
-                        PackageFamilyName = i.PackageFamilyName,
-                        ProductCode = i.ProductCode,
-                        Capabilities = i.Capabilities,
-                        RestrictedCapabilities = i.RestrictedCapabilities,
-                    }));
-
+            this.InstallerManifest.Installers.ForEach(i => deepCopy.Add(PackageParser.CloneInstaller(i)));
             return deepCopy;
         }
     }

--- a/src/WingetCreateCore/Models/Manifests.cs
+++ b/src/WingetCreateCore/Models/Manifests.cs
@@ -40,6 +40,40 @@ namespace Microsoft.WingetCreateCore.Models
         /// </summary>
         public List<LocaleManifest> LocaleManifests { get; set; } = new List<LocaleManifest>();
 
+        /// <summary>
+        /// Generates the proper file name for the given manifest.
+        /// </summary>
+        /// <typeparam name="T">Manifest type.</typeparam>
+        /// <param name="manifest">Manifest object model.</param>
+        /// <returns>File name string of manifest.</returns>
+        public static string GetFileName<T>(T manifest)
+        {
+            string fileName = null;
+
+            if (manifest is InstallerManifest installerManifest)
+            {
+                fileName = $"{installerManifest.PackageIdentifier}.installer.yaml";
+            }
+            else if (manifest is VersionManifest versionManifest)
+            {
+                fileName = $"{versionManifest.PackageIdentifier}.yaml";
+            }
+            else if (manifest is DefaultLocaleManifest defaultLocaleManifest)
+            {
+                fileName = $"{defaultLocaleManifest.PackageIdentifier}.locale.{defaultLocaleManifest.PackageLocale}.yaml";
+            }
+            else if (manifest is LocaleManifest localeManifest)
+            {
+                fileName = $"{localeManifest.PackageIdentifier}.locale.{localeManifest.PackageLocale}.yaml";
+            }
+            else if (manifest is SingletonManifest singletonManifest)
+            {
+                fileName = $"{singletonManifest.PackageIdentifier}.yaml";
+            }
+
+            return fileName;
+        }
+
         public List<Installer.Installer> CloneInstallers()
         {
             List<Installer.Installer> deepCopy = new List<Installer.Installer>();
@@ -70,6 +104,6 @@ namespace Microsoft.WingetCreateCore.Models
                     }));
 
             return deepCopy;
-        } 
+        }
     }
 }


### PR DESCRIPTION
This PR resolves #111 

Changes:
- Added navigational menu for interactive update scenario. You can now navigate and select the manifest you want to edit and modify the fields as needed.
- Moved shared methods from NewCommand.cs to PromptHelper.cs 
- Changed the "NONE" exit keyword to "SAVE AND EXIT"

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/171)