### PR TITLE
Validate manifest in interactive menu

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -392,8 +392,8 @@ namespace Microsoft.WingetCreateCLI.Commands
                 }
 
                 selectionList.Add(Resources.Done_MenuItem);
+                ValidateManifestsInTempDir(manifests);
                 var selectedItem = Prompt.Select(Resources.SelectManifestToEdit_Message, selectionList);
-
                 if (selectedItem == versionManifestMenuItem)
                 {
                     PromptHelper.PromptPropertiesWithMenu(manifests.VersionManifest, Resources.SaveAndExit_MenuItem, versionFileName);

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -394,6 +394,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 selectionList.Add(Resources.Done_MenuItem);
                 ValidateManifestsInTempDir(manifests);
                 var selectedItem = Prompt.Select(Resources.SelectManifestToEdit_Message, selectionList);
+
                 if (selectedItem == versionManifestMenuItem)
                 {
                     PromptHelper.PromptPropertiesWithMenu(manifests.VersionManifest, Resources.SaveAndExit_MenuItem, versionFileName);


### PR DESCRIPTION
Resolves #172 

Changes:
- Adds an extra validate manifest step prior to showing the menu selection of manifests. This informs the user if there's anything invalid and needs to be fixed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/174)