### PR TITLE
Fix heading name 

### DIFF
--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -646,7 +646,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows Manifest Creator v{0}.
+        ///   Looks up a localized string similar to Windows Package Manager Manifest Creator v{0}.
         /// </summary>
         public static string Heading {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -231,7 +231,7 @@
     <value>GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.</value>
   </data>
   <data name="Heading" xml:space="preserve">
-    <value>Windows Manifest Creator v{0}</value>
+    <value>Windows Package Manager Manifest Creator v{0}</value>
     <comment>{0} will be replaced with program's semantic version number</comment>
   </data>
   <data name="Homepage_KeywordDescription" xml:space="preserve">


### PR DESCRIPTION
Changes:
- Fixes the heading name from Windows Manifest Creator -> Windows Package Manager Manifest Creator

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/175)