### PR TITLE
Add C++ runtime framework binaries to self-contained exe

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -104,6 +104,15 @@ jobs:
           nugetConfigPath: "nuget.config"
           projects: $(workingDirectory)/**/*.csproj
 
+      - task: CopyFiles@2
+        displayName: 'Copy Binaries from Visual Studio Package'
+        inputs:
+          Contents: |
+            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\MSVCP140.dll
+            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll
+            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'          
+
       - task: DotNetCoreCLI@2
         displayName: Build standalone, framework-dependent exe
         inputs:

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -56,18 +56,17 @@ jobs:
       - checkout: self
         lfs: "true"     
 
-      - script: dir
-        workingDirectory: 'C:\Program Files\WindowsApps\'
-        displayName: List contents of a folder
+      - powershell: |
+        iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
+        Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
-      # - task: CopyFiles@2
-      #   displayName: 'Copy Binaries from Visual Studio Package 2'
-      #   inputs:
-      #     Contents: |
-      #       '%ProgramFiles%\WindowsApps\Microsoft.VCLibs*\MSVCP140.dll'
-      #       'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140.dll'
-      #       'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140_1.dll'
-      #     TargetFolder: '$(Build.ArtifactStagingDirectory)'    
+
+      - task: CopyFiles@2
+        displayName: 'Copy Binaries from Visual Studio Package 2'
+        inputs:
+          Contents: |
+            'C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'    
 
   #     - powershell: |
   #         echo $(version)

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -34,6 +34,7 @@ jobs:
           echo "##vso[task.setvariable variable=majorMinorBuildVersion;isOutput=true]$version"
         name: GetVersionStep
         displayName: Get version from CLI project
+
   - job: Build
     displayName: Build
     dependsOn: GetVersion
@@ -70,6 +71,7 @@ jobs:
           [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
           $manifest.Package.Identity.Version = "$(version)"
           $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
+
           [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
           @($project.Project.PropertyGroup)[0].Version = "$(version)"
           $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
@@ -90,12 +92,11 @@ jobs:
 
       # Copies binary dependencies from VCLibs package to be included in standalone exe     
       - task: PowerShell@2
-        displayName: Download and install VCLibs package
+        displayName: Download VCLibs package
         inputs:
           targetType: 'inline'
           script: | 
             iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
-            Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
       - task: ExtractFiles@1
         displayName: Extract files from VCLibs appx
@@ -103,7 +104,7 @@ jobs:
           archiveFilePatterns: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
           destinationFolder: '$(workingDirectory)\WingetCreateCLI'
           cleanDestinationFolder: false
-          overwriteExistingFiles: false        
+          overwriteExistingFiles: false                 
 
       # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
       - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
@@ -181,6 +182,7 @@ jobs:
                   "ToolVersion" : "1.0"
               }
             ]
+
       - powershell: |
           ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
           ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
@@ -188,6 +190,7 @@ jobs:
           (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
           (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
         displayName: "Create hash files"
+
       - task: CopyFiles@2
         displayName: Copy files to be published to staging directory
         inputs:
@@ -200,6 +203,7 @@ jobs:
             $(exePathSelfContained).txt
             $(appxBundlePath)
             $(appxBundlePath).txt
+
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: wingetcreate
         displayName: Publish appx, exe, and hash files
@@ -245,12 +249,15 @@ jobs:
           # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
           # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
           # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+
           # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
           # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
           # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
+
           # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
           # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
           # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
+
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
         displayName: Update package manifest in the OWC

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -54,16 +54,27 @@ jobs:
 
     steps:
       - checkout: self
-        lfs: "true"          
+        lfs: "true"     
 
-      - task: CopyFiles@2
-        displayName: 'Copy Binaries from Visual Studio Package 2'
+      - task: PowerShell@2
+        displayName: Install Tests Dependencies
         inputs:
-          Contents: |
-            'C:\Program Files\WindowsApps\Microsoft.VCLibs*\MSVCP140.dll'
-            'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140.dll'
-            'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140_1.dll'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'    
+          targetType: 'inline'
+          script: |
+            Add-AppxPackage %ProgramFiles(x86)%\Microsoft SDKs\Windows Kits\10\ExtensionSDKs\Microsoft.VCLibs.Desktop\14.0\Appx\Retail\x64\Microsoft.VCLibs.x64.14.00.Desktop.appx
+
+      - script: dir
+        workingDirectory: 'C:\Program Files\WindowsApps\'
+        displayName: List contents of a folder
+
+      # - task: CopyFiles@2
+      #   displayName: 'Copy Binaries from Visual Studio Package 2'
+      #   inputs:
+      #     Contents: |
+      #       '%ProgramFiles%\WindowsApps\Microsoft.VCLibs*\MSVCP140.dll'
+      #       'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140.dll'
+      #       'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140_1.dll'
+      #     TargetFolder: '$(Build.ArtifactStagingDirectory)'    
 
   #     - powershell: |
   #         echo $(version)

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -56,201 +56,210 @@ jobs:
       - checkout: self
         lfs: "true"
 
-      - powershell: |
-          echo $(version)
-          echo $(appxBundlePath)
-          echo $(appxBundleFile)
-          echo $(exePathSelfContained)
-          echo $(exePathFrameworkDependent)
-          echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
-          echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
-        name: OutputVersionStep
-        displayName: Set output variables for UpdateManifest job
-
-      - powershell: |
-          [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
-          $manifest.Package.Identity.Version = "$(version)"
-          $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
-
-          [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
-          @($project.Project.PropertyGroup)[0].Version = "$(version)"
-          $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
-        displayName: "Update cli and package manifest version"
-
-      - task: DeleteFiles@1
-        displayName: "Delete existing stubbed TelemetryEventSources.cs. Not necessary, but will cause build to fail if fetch fails."
-        inputs:
-          Contents: '$(workingDirectory)\WingetCreateCLI\Telemetry\TelemetryEventSource.cs'
-
-      - task: PkgESGitFetch@10
-        displayName: "Fetch TelemetryEventSource.cs from OS repo and overwrite stubbed version"
-        inputs:
-          repository: "https://microsoft.visualstudio.com/os/_git/os.2020"
-          branch: official/main
-          source: 'minkernel\published\internal\telemetry\TelemetryEventSource.cs'
-          destination: '$(workingDirectory)\WingetCreateCLI\Telemetry\'
-
-      # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
-      - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-        displayName: Restore Packages
-        inputs:
-          restoreSolution: "$(solution)"
-
-      - task: DotNetCoreCLI@2
-        displayName: Restore
-        inputs:
-          command: restore
-          feedsToUse: config
-          nugetConfigPath: "nuget.config"
-          projects: $(workingDirectory)/**/*.csproj
-
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package'
         inputs:
+          SourceFolder: 'C:\Program Files\'
           Contents: |
-            C:\Program Files\WindowsApps\**\MSVCP140.dll
-            C:\Program Files\WindowsApps\**\VCRUNTIME140.dll
-            C:\Program Files\WindowsApps\**\VCRUNTIME140_1.dll
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'          
-
-      - task: DotNetCoreCLI@2
-        displayName: Build standalone, framework-dependent exe
-        inputs:
-          command: publish
-          publishWebProjects: false
-          zipAfterPublish: false
-          projects: $(workingDirectory)/**/WingetCreateCLI.csproj
-          arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
-
-      - task: DotNetCoreCLI@2
-        displayName: Build standalone, self-contained exe
-        inputs:
-          command: publish
-          publishWebProjects: false
-          zipAfterPublish: false
-          projects: $(workingDirectory)/**/WingetCreateCLI.csproj
-          arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
-
-      - task: MSBuild@1
-        displayName: Build Solution
-        inputs:
-          platform: "$(buildPlatform)"
-          solution: "$(solution)"
-          configuration: "$(buildConfiguration)"
-          msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
-            /p:AppxBundle=Always
-            /p:UapAppxPackageBuildMode=SideloadOnly
-            /p:AppxPackageSigningEnabled=false'
-
-      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-        displayName: "ESRP CodeSigning"
-        inputs:
-          ConnectedServiceName: "PeetPackageEs2"
-          FolderPath: $(appxPackageDir)
-          Pattern: |
-            $(appxBundleFile)
-            **/WingetCreateCLI.exe
-          UseMinimatch: true
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-              {
-                  "KeyCode" : "CP-230012",
-                  "OperationCode" : "SigntoolSign",
-                  "Parameters" : {
-                      "OpusName" : "Microsoft",
-                      "OpusInfo" : "http://www.microsoft.com",
-                      "FileDigest" : "/fd \"SHA256\"",
-                      "PageHash" : "/NPH",
-                      "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                  },
-                  "ToolName" : "sign",
-                  "ToolVersion" : "1.0"
-              },
-              {
-                  "KeyCode" : "CP-230012",
-                  "OperationCode" : "SigntoolVerify",
-                  "Parameters" : {},
-                  "ToolName" : "sign",
-                  "ToolVersion" : "1.0"
-              }
-            ]
-
-      - powershell: |
-          ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
-          ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
-          (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
-          (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
-          (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
-        displayName: "Create hash files"
+            'WindowsApps\**\MSVCP140.dll'
+            'WindowsApps\**\VCRUNTIME140.dll'
+            'WindowsApps\**\VCRUNTIME140_1.dll'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'           
 
       - task: CopyFiles@2
-        displayName: Copy files to be published to staging directory
+        displayName: 'Copy Binaries from Visual Studio Package 2'
         inputs:
-          targetFolder: $(Build.ArtifactStagingDirectory)
-          flattenFolders: true
-          contents: |
-            $(exePathFrameworkDependent)
-            $(exePathSelfContained)
-            $(exePathFrameworkDependent).txt
-            $(exePathSelfContained).txt
-            $(appxBundlePath)
-            $(appxBundlePath).txt
+          Contents: |
+            'C:\Program Files\WindowsApps\Microsoft.VCLibs*\MSVCP140.dll'
+            'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140.dll'
+            'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140_1.dll'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'       
+  #     - powershell: |
+  #         echo $(version)
+  #         echo $(appxBundlePath)
+  #         echo $(appxBundleFile)
+  #         echo $(exePathSelfContained)
+  #         echo $(exePathFrameworkDependent)
+  #         echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
+  #         echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
+  #       name: OutputVersionStep
+  #       displayName: Set output variables for UpdateManifest job
 
-      - publish: $(Build.ArtifactStagingDirectory)
-        artifact: wingetcreate
-        displayName: Publish appx, exe, and hash files
+  #     - powershell: |
+  #         [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
+  #         $manifest.Package.Identity.Version = "$(version)"
+  #         $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
 
-      - task: GitHubRelease@1
-        displayName: Create GitHub release
-        inputs:
-          gitHubConnection: github
-          repositoryName: $(Build.Repository.Name)
-          tagSource: userSpecifiedTag
-          tag: v$(version)-preview
-          isPreRelease: true
-          isDraft: true # After running this step, visit the new draft release, edit, and publish.
-          assets: $(Build.ArtifactStagingDirectory)/*
+  #         [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
+  #         @($project.Project.PropertyGroup)[0].Version = "$(version)"
+  #         $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
+  #       displayName: "Update cli and package manifest version"
 
-  - job: Wait
-    displayName: Wait for vanity URL to be manually updated
-    dependsOn: Build
-    pool: server
-    timeoutInMinutes: 1440 # job times out in 1 day
-    steps:
-      - task: ManualValidation@0
-        timeoutInMinutes: 1440 # task times out in 1 day
-        inputs:
-          instructions: "Please update aka.ms vanity URLs for latest release"
+  #     - task: DeleteFiles@1
+  #       displayName: "Delete existing stubbed TelemetryEventSources.cs. Not necessary, but will cause build to fail if fetch fails."
+  #       inputs:
+  #         Contents: '$(workingDirectory)\WingetCreateCLI\Telemetry\TelemetryEventSource.cs'
 
-  - job: UpdateManifest
-    dependsOn:
-      - Build
-      - Wait
-    pool:
-      vmImage: $(vmImageName)
-    variables:
-      runCodesignValidationInjection: ${{ false }}
-      skipComponentGovernanceDetection: ${{ true }}
-      manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
-      appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
-    steps:
-      - checkout: none
+  #     - task: PkgESGitFetch@10
+  #       displayName: "Fetch TelemetryEventSource.cs from OS repo and overwrite stubbed version"
+  #       inputs:
+  #         repository: "https://microsoft.visualstudio.com/os/_git/os.2020"
+  #         branch: official/main
+  #         source: 'minkernel\published\internal\telemetry\TelemetryEventSource.cs'
+  #         destination: '$(workingDirectory)\WingetCreateCLI\Telemetry\'
 
-      - powershell: |
-          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
-          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+  #     # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
+  #     - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  #       displayName: Restore Packages
+  #       inputs:
+  #         restoreSolution: "$(solution)"
 
-          # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
-          # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
-          # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
+  #     - task: DotNetCoreCLI@2
+  #       displayName: Restore
+  #       inputs:
+  #         command: restore
+  #         feedsToUse: config
+  #         nugetConfigPath: "nuget.config"
+  #         projects: $(workingDirectory)/**/*.csproj      
 
-          # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
-          # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
-          # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
+  #     - task: DotNetCoreCLI@2
+  #       displayName: Build standalone, framework-dependent exe
+  #       inputs:
+  #         command: publish
+  #         publishWebProjects: false
+  #         zipAfterPublish: false
+  #         projects: $(workingDirectory)/**/WingetCreateCLI.csproj
+  #         arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
 
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
-        displayName: Update package manifest in the OWC
+  #     - task: DotNetCoreCLI@2
+  #       displayName: Build standalone, self-contained exe
+  #       inputs:
+  #         command: publish
+  #         publishWebProjects: false
+  #         zipAfterPublish: false
+  #         projects: $(workingDirectory)/**/WingetCreateCLI.csproj
+  #         arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
+
+  #     - task: MSBuild@1
+  #       displayName: Build Solution
+  #       inputs:
+  #         platform: "$(buildPlatform)"
+  #         solution: "$(solution)"
+  #         configuration: "$(buildConfiguration)"
+  #         msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
+  #           /p:AppxBundle=Always
+  #           /p:UapAppxPackageBuildMode=SideloadOnly
+  #           /p:AppxPackageSigningEnabled=false'
+
+  #     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  #       displayName: "ESRP CodeSigning"
+  #       inputs:
+  #         ConnectedServiceName: "PeetPackageEs2"
+  #         FolderPath: $(appxPackageDir)
+  #         Pattern: |
+  #           $(appxBundleFile)
+  #           **/WingetCreateCLI.exe
+  #         UseMinimatch: true
+  #         signConfigType: inlineSignParams
+  #         inlineOperation: |
+  #           [
+  #             {
+  #                 "KeyCode" : "CP-230012",
+  #                 "OperationCode" : "SigntoolSign",
+  #                 "Parameters" : {
+  #                     "OpusName" : "Microsoft",
+  #                     "OpusInfo" : "http://www.microsoft.com",
+  #                     "FileDigest" : "/fd \"SHA256\"",
+  #                     "PageHash" : "/NPH",
+  #                     "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+  #                 },
+  #                 "ToolName" : "sign",
+  #                 "ToolVersion" : "1.0"
+  #             },
+  #             {
+  #                 "KeyCode" : "CP-230012",
+  #                 "OperationCode" : "SigntoolVerify",
+  #                 "Parameters" : {},
+  #                 "ToolName" : "sign",
+  #                 "ToolVersion" : "1.0"
+  #             }
+  #           ]
+
+  #     - powershell: |
+  #         ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
+  #         ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
+  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
+  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
+  #         (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
+  #       displayName: "Create hash files"
+
+  #     - task: CopyFiles@2
+  #       displayName: Copy files to be published to staging directory
+  #       inputs:
+  #         targetFolder: $(Build.ArtifactStagingDirectory)
+  #         flattenFolders: true
+  #         contents: |
+  #           $(exePathFrameworkDependent)
+  #           $(exePathSelfContained)
+  #           $(exePathFrameworkDependent).txt
+  #           $(exePathSelfContained).txt
+  #           $(appxBundlePath)
+  #           $(appxBundlePath).txt
+
+  #     - publish: $(Build.ArtifactStagingDirectory)
+  #       artifact: wingetcreate
+  #       displayName: Publish appx, exe, and hash files
+
+  #     - task: GitHubRelease@1
+  #       displayName: Create GitHub release
+  #       inputs:
+  #         gitHubConnection: github
+  #         repositoryName: $(Build.Repository.Name)
+  #         tagSource: userSpecifiedTag
+  #         tag: v$(version)-preview
+  #         isPreRelease: true
+  #         isDraft: true # After running this step, visit the new draft release, edit, and publish.
+  #         assets: $(Build.ArtifactStagingDirectory)/*
+
+  # - job: Wait
+  #   displayName: Wait for vanity URL to be manually updated
+  #   dependsOn: Build
+  #   pool: server
+  #   timeoutInMinutes: 1440 # job times out in 1 day
+  #   steps:
+  #     - task: ManualValidation@0
+  #       timeoutInMinutes: 1440 # task times out in 1 day
+  #       inputs:
+  #         instructions: "Please update aka.ms vanity URLs for latest release"
+
+  # - job: UpdateManifest
+  #   dependsOn:
+  #     - Build
+  #     - Wait
+  #   pool:
+  #     vmImage: $(vmImageName)
+  #   variables:
+  #     runCodesignValidationInjection: ${{ false }}
+  #     skipComponentGovernanceDetection: ${{ true }}
+  #     manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
+  #     appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+  #     packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
+  #   steps:
+  #     - checkout: none
+
+  #     - powershell: |
+  #         # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+  #         # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
+  #         # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+
+  #         # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
+  #         # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
+  #         # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
+
+  #         # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
+  #         # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
+  #         # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
+
+  #         iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+  #         .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
+  #       displayName: Update package manifest in the OWC

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -56,16 +56,19 @@ jobs:
       - checkout: self
         lfs: "true"     
 
-      - powershell: |
-        iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
-        Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
-
+      - task: PowerShell@2
+        displayName: Download and install VCLibs package
+        inputs:
+          targetType: 'inline'
+          script: | 
+            iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
+            Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package 2'
         inputs:
           Contents: |
-            'C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe'
+            'C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll'
           TargetFolder: '$(Build.ArtifactStagingDirectory)'    
 
   #     - powershell: |
@@ -239,7 +242,7 @@ jobs:
   #     appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
   #     packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
   #   steps:
-  #     - checkout: none
+  # #     - checkout: none
 
   #     - powershell: |
   #         # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -54,17 +54,7 @@ jobs:
 
     steps:
       - checkout: self
-        lfs: "true"
-
-      - task: CopyFiles@2
-        displayName: 'Copy Binaries from Visual Studio Package'
-        inputs:
-          SourceFolder: 'C:\Program Files\'
-          Contents: |
-            'WindowsApps\**\MSVCP140.dll'
-            'WindowsApps\**\VCRUNTIME140.dll'
-            'WindowsApps\**\VCRUNTIME140_1.dll'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'           
+        lfs: "true"          
 
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package 2'
@@ -73,7 +63,8 @@ jobs:
             'C:\Program Files\WindowsApps\Microsoft.VCLibs*\MSVCP140.dll'
             'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140.dll'
             'C:\Program Files\WindowsApps\Microsoft.VCLibs*\VCRUNTIME140_1.dll'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'       
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'    
+
   #     - powershell: |
   #         echo $(version)
   #         echo $(appxBundlePath)

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -34,7 +34,6 @@ jobs:
           echo "##vso[task.setvariable variable=majorMinorBuildVersion;isOutput=true]$version"
         name: GetVersionStep
         displayName: Get version from CLI project
-
   - job: Build
     displayName: Build
     dependsOn: GetVersion
@@ -54,8 +53,40 @@ jobs:
 
     steps:
       - checkout: self
-        lfs: "true"     
+        lfs: "true"
 
+      - powershell: |
+          echo $(version)
+          echo $(appxBundlePath)
+          echo $(appxBundleFile)
+          echo $(exePathSelfContained)
+          echo $(exePathFrameworkDependent)
+          echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
+          echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
+        name: OutputVersionStep
+        displayName: Set output variables for UpdateManifest job
+      - powershell: |
+          [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
+          $manifest.Package.Identity.Version = "$(version)"
+          $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
+          [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
+          @($project.Project.PropertyGroup)[0].Version = "$(version)"
+          $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
+        displayName: "Update cli and package manifest version"
+      - task: DeleteFiles@1
+        displayName: "Delete existing stubbed TelemetryEventSources.cs. Not necessary, but will cause build to fail if fetch fails."
+        inputs:
+          Contents: '$(workingDirectory)\WingetCreateCLI\Telemetry\TelemetryEventSource.cs'
+
+      - task: PkgESGitFetch@10
+        displayName: "Fetch TelemetryEventSource.cs from OS repo and overwrite stubbed version"
+        inputs:
+          repository: "https://microsoft.visualstudio.com/os/_git/os.2020"
+          branch: official/main
+          source: 'minkernel\published\internal\telemetry\TelemetryEventSource.cs'
+          destination: '$(workingDirectory)\WingetCreateCLI\Telemetry\'
+
+      # Copies binary dependencies from VCLibs package to be included in standalone exe     
       - task: PowerShell@2
         displayName: Download and install VCLibs package
         inputs:
@@ -64,219 +95,161 @@ jobs:
             iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
             Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
-      - task: PowerShell@2
-        displayName: Show Directory
-        inputs:
-          targetType: 'inline'
-          script: | 
-            Get-ChildItem -Path "C:\Program Files\WindowsApps\*" -Recurse -Include *.dll -Force
-
       - task: CopyFiles@2
-        displayName: 'Copy Binaries from Visual Studio Package 2'
+        displayName: 'Copy Binary Dependencies from VCLibs to Project folder'
         inputs:
           Contents: |
-            "C:\Program Files\WindowsApps\**\MSVCP140.dll"
-            "C:\Program Files\WindowsApps\**\VCRUNTIME140_1.dll"
-            "C:\Program Files\WindowsApps\**\VCRUNTIME140.dll"
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'    
-        condition: succeededOrFailed()
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\msvcp140.dll"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140.dll"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140_1.dll"
+          TargetFolder: '$(workingDirectory)/WingetCreateCLI/bin/$(buildPlatform)/$(buildConfiguration)/net5.0-windows10.0.17763.0/'    
 
-      - task: CopyFiles@2
-        displayName: 'Copy Binaries from Visual Studio Package 3'
+      # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
+      - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+        displayName: Restore Packages
         inputs:
-          Contents: |
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll"          
-          TargetFolder: '$(Build.ArtifactStagingDirectory)' 
-        condition: succeededOrFailed()  
+          restoreSolution: "$(solution)"
 
-  #     - powershell: |
-  #         echo $(version)
-  #         echo $(appxBundlePath)
-  #         echo $(appxBundleFile)
-  #         echo $(exePathSelfContained)
-  #         echo $(exePathFrameworkDependent)
-  #         echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
-  #         echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
-  #       name: OutputVersionStep
-  #       displayName: Set output variables for UpdateManifest job
+      - task: DotNetCoreCLI@2
+        displayName: Restore
+        inputs:
+          command: restore
+          feedsToUse: config
+          nugetConfigPath: "nuget.config"
+          projects: $(workingDirectory)/**/*.csproj
 
-  #     - powershell: |
-  #         [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
-  #         $manifest.Package.Identity.Version = "$(version)"
-  #         $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
+      - task: DotNetCoreCLI@2
+        displayName: Build standalone, framework-dependent exe
+        inputs:
+          command: publish
+          publishWebProjects: false
+          zipAfterPublish: false
+          projects: $(workingDirectory)/**/WingetCreateCLI.csproj
+          arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
 
-  #         [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
-  #         @($project.Project.PropertyGroup)[0].Version = "$(version)"
-  #         $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
-  #       displayName: "Update cli and package manifest version"
+      - task: DotNetCoreCLI@2
+        displayName: Build standalone, self-contained exe
+        inputs:
+          command: publish
+          publishWebProjects: false
+          zipAfterPublish: false
+          projects: $(workingDirectory)/**/WingetCreateCLI.csproj
+          arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
 
-  #     - task: DeleteFiles@1
-  #       displayName: "Delete existing stubbed TelemetryEventSources.cs. Not necessary, but will cause build to fail if fetch fails."
-  #       inputs:
-  #         Contents: '$(workingDirectory)\WingetCreateCLI\Telemetry\TelemetryEventSource.cs'
+      - task: MSBuild@1
+        displayName: Build Solution
+        inputs:
+          platform: "$(buildPlatform)"
+          solution: "$(solution)"
+          configuration: "$(buildConfiguration)"
+          msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
+            /p:AppxBundle=Always
+            /p:UapAppxPackageBuildMode=SideloadOnly
+            /p:AppxPackageSigningEnabled=false'
 
-  #     - task: PkgESGitFetch@10
-  #       displayName: "Fetch TelemetryEventSource.cs from OS repo and overwrite stubbed version"
-  #       inputs:
-  #         repository: "https://microsoft.visualstudio.com/os/_git/os.2020"
-  #         branch: official/main
-  #         source: 'minkernel\published\internal\telemetry\TelemetryEventSource.cs'
-  #         destination: '$(workingDirectory)\WingetCreateCLI\Telemetry\'
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "ESRP CodeSigning"
+        inputs:
+          ConnectedServiceName: "PeetPackageEs2"
+          FolderPath: $(appxPackageDir)
+          Pattern: |
+            $(appxBundleFile)
+            **/WingetCreateCLI.exe
+          UseMinimatch: true
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+              {
+                  "KeyCode" : "CP-230012",
+                  "OperationCode" : "SigntoolSign",
+                  "Parameters" : {
+                      "OpusName" : "Microsoft",
+                      "OpusInfo" : "http://www.microsoft.com",
+                      "FileDigest" : "/fd \"SHA256\"",
+                      "PageHash" : "/NPH",
+                      "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                  },
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+              },
+              {
+                  "KeyCode" : "CP-230012",
+                  "OperationCode" : "SigntoolVerify",
+                  "Parameters" : {},
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+              }
+            ]
+      - powershell: |
+          ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
+          ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
+          (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
+          (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
+          (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
+        displayName: "Create hash files"
+      - task: CopyFiles@2
+        displayName: Copy files to be published to staging directory
+        inputs:
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+          contents: |
+            $(exePathFrameworkDependent)
+            $(exePathSelfContained)
+            $(exePathFrameworkDependent).txt
+            $(exePathSelfContained).txt
+            $(appxBundlePath)
+            $(appxBundlePath).txt
+      - publish: $(Build.ArtifactStagingDirectory)
+        artifact: wingetcreate
+        displayName: Publish appx, exe, and hash files
 
-  #     # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
-  #     - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-  #       displayName: Restore Packages
-  #       inputs:
-  #         restoreSolution: "$(solution)"
+      - task: GitHubRelease@1
+        displayName: Create GitHub release
+        inputs:
+          gitHubConnection: github
+          repositoryName: $(Build.Repository.Name)
+          tagSource: userSpecifiedTag
+          tag: v$(version)-preview
+          isPreRelease: true
+          isDraft: true # After running this step, visit the new draft release, edit, and publish.
+          assets: $(Build.ArtifactStagingDirectory)/*
 
-  #     - task: DotNetCoreCLI@2
-  #       displayName: Restore
-  #       inputs:
-  #         command: restore
-  #         feedsToUse: config
-  #         nugetConfigPath: "nuget.config"
-  #         projects: $(workingDirectory)/**/*.csproj      
+  - job: Wait
+    displayName: Wait for vanity URL to be manually updated
+    dependsOn: Build
+    pool: server
+    timeoutInMinutes: 1440 # job times out in 1 day
+    steps:
+      - task: ManualValidation@0
+        timeoutInMinutes: 1440 # task times out in 1 day
+        inputs:
+          instructions: "Please update aka.ms vanity URLs for latest release"
 
-  #     - task: DotNetCoreCLI@2
-  #       displayName: Build standalone, framework-dependent exe
-  #       inputs:
-  #         command: publish
-  #         publishWebProjects: false
-  #         zipAfterPublish: false
-  #         projects: $(workingDirectory)/**/WingetCreateCLI.csproj
-  #         arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
+  - job: UpdateManifest
+    dependsOn:
+      - Build
+      - Wait
+    pool:
+      vmImage: $(vmImageName)
+    variables:
+      runCodesignValidationInjection: ${{ false }}
+      skipComponentGovernanceDetection: ${{ true }}
+      manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
+      appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
+    steps:
+      - checkout: none
 
-  #     - task: DotNetCoreCLI@2
-  #       displayName: Build standalone, self-contained exe
-  #       inputs:
-  #         command: publish
-  #         publishWebProjects: false
-  #         zipAfterPublish: false
-  #         projects: $(workingDirectory)/**/WingetCreateCLI.csproj
-  #         arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
-
-  #     - task: MSBuild@1
-  #       displayName: Build Solution
-  #       inputs:
-  #         platform: "$(buildPlatform)"
-  #         solution: "$(solution)"
-  #         configuration: "$(buildConfiguration)"
-  #         msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
-  #           /p:AppxBundle=Always
-  #           /p:UapAppxPackageBuildMode=SideloadOnly
-  #           /p:AppxPackageSigningEnabled=false'
-
-  #     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  #       displayName: "ESRP CodeSigning"
-  #       inputs:
-  #         ConnectedServiceName: "PeetPackageEs2"
-  #         FolderPath: $(appxPackageDir)
-  #         Pattern: |
-  #           $(appxBundleFile)
-  #           **/WingetCreateCLI.exe
-  #         UseMinimatch: true
-  #         signConfigType: inlineSignParams
-  #         inlineOperation: |
-  #           [
-  #             {
-  #                 "KeyCode" : "CP-230012",
-  #                 "OperationCode" : "SigntoolSign",
-  #                 "Parameters" : {
-  #                     "OpusName" : "Microsoft",
-  #                     "OpusInfo" : "http://www.microsoft.com",
-  #                     "FileDigest" : "/fd \"SHA256\"",
-  #                     "PageHash" : "/NPH",
-  #                     "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-  #                 },
-  #                 "ToolName" : "sign",
-  #                 "ToolVersion" : "1.0"
-  #             },
-  #             {
-  #                 "KeyCode" : "CP-230012",
-  #                 "OperationCode" : "SigntoolVerify",
-  #                 "Parameters" : {},
-  #                 "ToolName" : "sign",
-  #                 "ToolVersion" : "1.0"
-  #             }
-  #           ]
-
-  #     - powershell: |
-  #         ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
-  #         ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
-  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
-  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
-  #         (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
-  #       displayName: "Create hash files"
-
-  #     - task: CopyFiles@2
-  #       displayName: Copy files to be published to staging directory
-  #       inputs:
-  #         targetFolder: $(Build.ArtifactStagingDirectory)
-  #         flattenFolders: true
-  #         contents: |
-  #           $(exePathFrameworkDependent)
-  #           $(exePathSelfContained)
-  #           $(exePathFrameworkDependent).txt
-  #           $(exePathSelfContained).txt
-  #           $(appxBundlePath)
-  #           $(appxBundlePath).txt
-
-  #     - publish: $(Build.ArtifactStagingDirectory)
-  #       artifact: wingetcreate
-  #       displayName: Publish appx, exe, and hash files
-
-  #     - task: GitHubRelease@1
-  #       displayName: Create GitHub release
-  #       inputs:
-  #         gitHubConnection: github
-  #         repositoryName: $(Build.Repository.Name)
-  #         tagSource: userSpecifiedTag
-  #         tag: v$(version)-preview
-  #         isPreRelease: true
-  #         isDraft: true # After running this step, visit the new draft release, edit, and publish.
-  #         assets: $(Build.ArtifactStagingDirectory)/*
-
-  # - job: Wait
-  #   displayName: Wait for vanity URL to be manually updated
-  #   dependsOn: Build
-  #   pool: server
-  #   timeoutInMinutes: 1440 # job times out in 1 day
-  #   steps:
-  #     - task: ManualValidation@0
-  #       timeoutInMinutes: 1440 # task times out in 1 day
-  #       inputs:
-  #         instructions: "Please update aka.ms vanity URLs for latest release"
-
-  # - job: UpdateManifest
-  #   dependsOn:
-  #     - Build
-  #     - Wait
-  #   pool:
-  #     vmImage: $(vmImageName)
-  #   variables:
-  #     runCodesignValidationInjection: ${{ false }}
-  #     skipComponentGovernanceDetection: ${{ true }}
-  #     manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
-  #     appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-  #     packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
-  #   steps:
-  # #     - checkout: none
-
-  #     - powershell: |
-  #         # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-  #         # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
-  #         # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
-
-  #         # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
-  #         # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
-  #         # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
-
-  #         # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
-  #         # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
-  #         # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
-
-  #         iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-  #         .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
-  #       displayName: Update package manifest in the OWC
+      - powershell: |
+          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
+          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+          # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
+          # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
+          # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
+          # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
+          # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
+          # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
+        displayName: Update package manifest in the OWC

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -65,6 +65,7 @@ jobs:
           echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
         name: OutputVersionStep
         displayName: Set output variables for UpdateManifest job
+
       - powershell: |
           [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
           $manifest.Package.Identity.Version = "$(version)"
@@ -73,6 +74,7 @@ jobs:
           @($project.Project.PropertyGroup)[0].Version = "$(version)"
           $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
         displayName: "Update cli and package manifest version"
+
       - task: DeleteFiles@1
         displayName: "Delete existing stubbed TelemetryEventSources.cs. Not necessary, but will cause build to fail if fetch fails."
         inputs:
@@ -98,7 +100,7 @@ jobs:
       - task: CopyFiles@2
         displayName: 'Copy Binary Dependencies from VCLibs to Project folder'
         inputs:
-          SourceFolder: "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe"
+          SourceFolder: "C:/Program Files/WindowsApps/Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe"
           Contents: |
             "msvcp140.dll"
             "vcruntime140.dll"

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -98,11 +98,13 @@ jobs:
       - task: CopyFiles@2
         displayName: 'Copy Binary Dependencies from VCLibs to Project folder'
         inputs:
+          SourceFolder: "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe"
           Contents: |
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\msvcp140.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140_1.dll"
-          TargetFolder: '$(workingDirectory)/WingetCreateCLI/bin/$(buildPlatform)/$(buildConfiguration)/net5.0-windows10.0.17763.0/'    
+            "msvcp140.dll"
+            "vcruntime140.dll"
+            "vcruntime140_1.dll"
+          TargetFolder: "$(workingDirectory)/WingetCreateCLI/bin/$(buildPlatform)/$(buildConfiguration)/net5.0-windows10.0.17763.0/"
+          retryCount: 3    
 
       # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
       - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -100,13 +100,11 @@ jobs:
       - task: CopyFiles@2
         displayName: 'Copy Binary Dependencies from VCLibs to Project folder'
         inputs:
-          SourceFolder: "C:/Program Files/WindowsApps/Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe"
           Contents: |
-            "msvcp140.dll"
-            "vcruntime140.dll"
-            "vcruntime140_1.dll"
-          TargetFolder: "$(workingDirectory)/WingetCreateCLI/bin/$(buildPlatform)/$(buildConfiguration)/net5.0-windows10.0.17763.0/"
-          retryCount: 3    
+            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\msvcp140.dll
+            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140.dll
+            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140_1.dll
+          TargetFolder: '$(workingDirectory)\WingetCreateCLI\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.17763.0'
 
       # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
       - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -64,11 +64,18 @@ jobs:
             iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
             Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
+      - task: PowerShell@2
+        displayName: Show Directory
+        inputs:
+          targetType: 'inline'
+          script: | 
+            Get-ChildItem -Path C:\Program Files\* -Recurse -Force
+
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package 2'
         inputs:
           Contents: |
-            'C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll'
+            'C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_*\'
           TargetFolder: '$(Build.ArtifactStagingDirectory)'    
 
   #     - powershell: |

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -56,13 +56,6 @@ jobs:
       - checkout: self
         lfs: "true"     
 
-      - task: PowerShell@2
-        displayName: Install Tests Dependencies
-        inputs:
-          targetType: 'inline'
-          script: |
-            Add-AppxPackage %ProgramFiles(x86)%\Microsoft SDKs\Windows Kits\10\ExtensionSDKs\Microsoft.VCLibs.Desktop\14.0\Appx\Retail\x64\Microsoft.VCLibs.x64.14.00.Desktop.appx
-
       - script: dir
         workingDirectory: 'C:\Program Files\WindowsApps\'
         displayName: List contents of a folder

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -108,9 +108,9 @@ jobs:
         displayName: 'Copy Binaries from Visual Studio Package'
         inputs:
           Contents: |
-            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\MSVCP140.dll
-            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll
-            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll
+            C:\Program Files\WindowsApps\**\MSVCP140.dll
+            C:\Program Files\WindowsApps\**\VCRUNTIME140.dll
+            C:\Program Files\WindowsApps\**\VCRUNTIME140_1.dll
           TargetFolder: '$(Build.ArtifactStagingDirectory)'          
 
       - task: DotNetCoreCLI@2

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -106,6 +106,13 @@ jobs:
             C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140_1.dll
           TargetFolder: '$(workingDirectory)\WingetCreateCLI\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.17763.0'
 
+      - task: ExtractFiles@1
+        inputs:
+          archiveFilePatterns: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
+          destinationFolder: '$(workingDirectory)\WingetCreateCLI\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.17763.0'
+          cleanDestinationFolder: false
+          overwriteExistingFiles: false        
+
       # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
       - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
         displayName: Restore Packages
@@ -138,120 +145,120 @@ jobs:
           projects: $(workingDirectory)/**/WingetCreateCLI.csproj
           arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
 
-      - task: MSBuild@1
-        displayName: Build Solution
-        inputs:
-          platform: "$(buildPlatform)"
-          solution: "$(solution)"
-          configuration: "$(buildConfiguration)"
-          msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
-            /p:AppxBundle=Always
-            /p:UapAppxPackageBuildMode=SideloadOnly
-            /p:AppxPackageSigningEnabled=false'
+  #     - task: MSBuild@1
+  #       displayName: Build Solution
+  #       inputs:
+  #         platform: "$(buildPlatform)"
+  #         solution: "$(solution)"
+  #         configuration: "$(buildConfiguration)"
+  #         msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
+  #           /p:AppxBundle=Always
+  #           /p:UapAppxPackageBuildMode=SideloadOnly
+  #           /p:AppxPackageSigningEnabled=false'
 
-      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-        displayName: "ESRP CodeSigning"
-        inputs:
-          ConnectedServiceName: "PeetPackageEs2"
-          FolderPath: $(appxPackageDir)
-          Pattern: |
-            $(appxBundleFile)
-            **/WingetCreateCLI.exe
-          UseMinimatch: true
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-              {
-                  "KeyCode" : "CP-230012",
-                  "OperationCode" : "SigntoolSign",
-                  "Parameters" : {
-                      "OpusName" : "Microsoft",
-                      "OpusInfo" : "http://www.microsoft.com",
-                      "FileDigest" : "/fd \"SHA256\"",
-                      "PageHash" : "/NPH",
-                      "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                  },
-                  "ToolName" : "sign",
-                  "ToolVersion" : "1.0"
-              },
-              {
-                  "KeyCode" : "CP-230012",
-                  "OperationCode" : "SigntoolVerify",
-                  "Parameters" : {},
-                  "ToolName" : "sign",
-                  "ToolVersion" : "1.0"
-              }
-            ]
-      - powershell: |
-          ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
-          ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
-          (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
-          (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
-          (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
-        displayName: "Create hash files"
-      - task: CopyFiles@2
-        displayName: Copy files to be published to staging directory
-        inputs:
-          targetFolder: $(Build.ArtifactStagingDirectory)
-          flattenFolders: true
-          contents: |
-            $(exePathFrameworkDependent)
-            $(exePathSelfContained)
-            $(exePathFrameworkDependent).txt
-            $(exePathSelfContained).txt
-            $(appxBundlePath)
-            $(appxBundlePath).txt
-      - publish: $(Build.ArtifactStagingDirectory)
-        artifact: wingetcreate
-        displayName: Publish appx, exe, and hash files
+  #     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  #       displayName: "ESRP CodeSigning"
+  #       inputs:
+  #         ConnectedServiceName: "PeetPackageEs2"
+  #         FolderPath: $(appxPackageDir)
+  #         Pattern: |
+  #           $(appxBundleFile)
+  #           **/WingetCreateCLI.exe
+  #         UseMinimatch: true
+  #         signConfigType: inlineSignParams
+  #         inlineOperation: |
+  #           [
+  #             {
+  #                 "KeyCode" : "CP-230012",
+  #                 "OperationCode" : "SigntoolSign",
+  #                 "Parameters" : {
+  #                     "OpusName" : "Microsoft",
+  #                     "OpusInfo" : "http://www.microsoft.com",
+  #                     "FileDigest" : "/fd \"SHA256\"",
+  #                     "PageHash" : "/NPH",
+  #                     "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+  #                 },
+  #                 "ToolName" : "sign",
+  #                 "ToolVersion" : "1.0"
+  #             },
+  #             {
+  #                 "KeyCode" : "CP-230012",
+  #                 "OperationCode" : "SigntoolVerify",
+  #                 "Parameters" : {},
+  #                 "ToolName" : "sign",
+  #                 "ToolVersion" : "1.0"
+  #             }
+  #           ]
+  #     - powershell: |
+  #         ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
+  #         ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
+  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
+  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
+  #         (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
+  #       displayName: "Create hash files"
+  #     - task: CopyFiles@2
+  #       displayName: Copy files to be published to staging directory
+  #       inputs:
+  #         targetFolder: $(Build.ArtifactStagingDirectory)
+  #         flattenFolders: true
+  #         contents: |
+  #           $(exePathFrameworkDependent)
+  #           $(exePathSelfContained)
+  #           $(exePathFrameworkDependent).txt
+  #           $(exePathSelfContained).txt
+  #           $(appxBundlePath)
+  #           $(appxBundlePath).txt
+  #     - publish: $(Build.ArtifactStagingDirectory)
+  #       artifact: wingetcreate
+  #       displayName: Publish appx, exe, and hash files
 
-      - task: GitHubRelease@1
-        displayName: Create GitHub release
-        inputs:
-          gitHubConnection: github
-          repositoryName: $(Build.Repository.Name)
-          tagSource: userSpecifiedTag
-          tag: v$(version)-preview
-          isPreRelease: true
-          isDraft: true # After running this step, visit the new draft release, edit, and publish.
-          assets: $(Build.ArtifactStagingDirectory)/*
+  #     - task: GitHubRelease@1
+  #       displayName: Create GitHub release
+  #       inputs:
+  #         gitHubConnection: github
+  #         repositoryName: $(Build.Repository.Name)
+  #         tagSource: userSpecifiedTag
+  #         tag: v$(version)-preview
+  #         isPreRelease: true
+  #         isDraft: true # After running this step, visit the new draft release, edit, and publish.
+  #         assets: $(Build.ArtifactStagingDirectory)/*
 
-  - job: Wait
-    displayName: Wait for vanity URL to be manually updated
-    dependsOn: Build
-    pool: server
-    timeoutInMinutes: 1440 # job times out in 1 day
-    steps:
-      - task: ManualValidation@0
-        timeoutInMinutes: 1440 # task times out in 1 day
-        inputs:
-          instructions: "Please update aka.ms vanity URLs for latest release"
+  # - job: Wait
+  #   displayName: Wait for vanity URL to be manually updated
+  #   dependsOn: Build
+  #   pool: server
+  #   timeoutInMinutes: 1440 # job times out in 1 day
+  #   steps:
+  #     - task: ManualValidation@0
+  #       timeoutInMinutes: 1440 # task times out in 1 day
+  #       inputs:
+  #         instructions: "Please update aka.ms vanity URLs for latest release"
 
-  - job: UpdateManifest
-    dependsOn:
-      - Build
-      - Wait
-    pool:
-      vmImage: $(vmImageName)
-    variables:
-      runCodesignValidationInjection: ${{ false }}
-      skipComponentGovernanceDetection: ${{ true }}
-      manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
-      appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
-    steps:
-      - checkout: none
+  # - job: UpdateManifest
+  #   dependsOn:
+  #     - Build
+  #     - Wait
+  #   pool:
+  #     vmImage: $(vmImageName)
+  #   variables:
+  #     runCodesignValidationInjection: ${{ false }}
+  #     skipComponentGovernanceDetection: ${{ true }}
+  #     manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
+  #     appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+  #     packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
+  #   steps:
+  #     - checkout: none
 
-      - powershell: |
-          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
-          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
-          # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
-          # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
-          # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
-          # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
-          # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
-          # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
-        displayName: Update package manifest in the OWC
+  #     - powershell: |
+  #         # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+  #         # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
+  #         # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+  #         # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
+  #         # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
+  #         # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
+  #         # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
+  #         # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
+  #         # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
+  #         iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+  #         .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
+  #       displayName: Update package manifest in the OWC

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -97,16 +97,8 @@ jobs:
             iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
             Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
-      - task: CopyFiles@2
-        displayName: 'Copy Binary Dependencies from VCLibs to Project folder'
-        inputs:
-          Contents: |
-            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\msvcp140.dll
-            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140.dll
-            C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\vcruntime140_1.dll
-          TargetFolder: '$(workingDirectory)\WingetCreateCLI\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.17763.0'
-
       - task: ExtractFiles@1
+        displayName: Extract files from VCLibs appx
         inputs:
           archiveFilePatterns: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
           destinationFolder: '$(workingDirectory)\WingetCreateCLI\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.17763.0'
@@ -145,120 +137,120 @@ jobs:
           projects: $(workingDirectory)/**/WingetCreateCLI.csproj
           arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
 
-  #     - task: MSBuild@1
-  #       displayName: Build Solution
-  #       inputs:
-  #         platform: "$(buildPlatform)"
-  #         solution: "$(solution)"
-  #         configuration: "$(buildConfiguration)"
-  #         msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
-  #           /p:AppxBundle=Always
-  #           /p:UapAppxPackageBuildMode=SideloadOnly
-  #           /p:AppxPackageSigningEnabled=false'
+      - task: MSBuild@1
+        displayName: Build Solution
+        inputs:
+          platform: "$(buildPlatform)"
+          solution: "$(solution)"
+          configuration: "$(buildConfiguration)"
+          msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
+            /p:AppxBundle=Always
+            /p:UapAppxPackageBuildMode=SideloadOnly
+            /p:AppxPackageSigningEnabled=false'
 
-  #     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  #       displayName: "ESRP CodeSigning"
-  #       inputs:
-  #         ConnectedServiceName: "PeetPackageEs2"
-  #         FolderPath: $(appxPackageDir)
-  #         Pattern: |
-  #           $(appxBundleFile)
-  #           **/WingetCreateCLI.exe
-  #         UseMinimatch: true
-  #         signConfigType: inlineSignParams
-  #         inlineOperation: |
-  #           [
-  #             {
-  #                 "KeyCode" : "CP-230012",
-  #                 "OperationCode" : "SigntoolSign",
-  #                 "Parameters" : {
-  #                     "OpusName" : "Microsoft",
-  #                     "OpusInfo" : "http://www.microsoft.com",
-  #                     "FileDigest" : "/fd \"SHA256\"",
-  #                     "PageHash" : "/NPH",
-  #                     "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-  #                 },
-  #                 "ToolName" : "sign",
-  #                 "ToolVersion" : "1.0"
-  #             },
-  #             {
-  #                 "KeyCode" : "CP-230012",
-  #                 "OperationCode" : "SigntoolVerify",
-  #                 "Parameters" : {},
-  #                 "ToolName" : "sign",
-  #                 "ToolVersion" : "1.0"
-  #             }
-  #           ]
-  #     - powershell: |
-  #         ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
-  #         ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
-  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
-  #         (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
-  #         (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
-  #       displayName: "Create hash files"
-  #     - task: CopyFiles@2
-  #       displayName: Copy files to be published to staging directory
-  #       inputs:
-  #         targetFolder: $(Build.ArtifactStagingDirectory)
-  #         flattenFolders: true
-  #         contents: |
-  #           $(exePathFrameworkDependent)
-  #           $(exePathSelfContained)
-  #           $(exePathFrameworkDependent).txt
-  #           $(exePathSelfContained).txt
-  #           $(appxBundlePath)
-  #           $(appxBundlePath).txt
-  #     - publish: $(Build.ArtifactStagingDirectory)
-  #       artifact: wingetcreate
-  #       displayName: Publish appx, exe, and hash files
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "ESRP CodeSigning"
+        inputs:
+          ConnectedServiceName: "PeetPackageEs2"
+          FolderPath: $(appxPackageDir)
+          Pattern: |
+            $(appxBundleFile)
+            **/WingetCreateCLI.exe
+          UseMinimatch: true
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+              {
+                  "KeyCode" : "CP-230012",
+                  "OperationCode" : "SigntoolSign",
+                  "Parameters" : {
+                      "OpusName" : "Microsoft",
+                      "OpusInfo" : "http://www.microsoft.com",
+                      "FileDigest" : "/fd \"SHA256\"",
+                      "PageHash" : "/NPH",
+                      "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                  },
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+              },
+              {
+                  "KeyCode" : "CP-230012",
+                  "OperationCode" : "SigntoolVerify",
+                  "Parameters" : {},
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+              }
+            ]
+      - powershell: |
+          ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
+          ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
+          (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
+          (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
+          (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
+        displayName: "Create hash files"
+      - task: CopyFiles@2
+        displayName: Copy files to be published to staging directory
+        inputs:
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+          contents: |
+            $(exePathFrameworkDependent)
+            $(exePathSelfContained)
+            $(exePathFrameworkDependent).txt
+            $(exePathSelfContained).txt
+            $(appxBundlePath)
+            $(appxBundlePath).txt
+      - publish: $(Build.ArtifactStagingDirectory)
+        artifact: wingetcreate
+        displayName: Publish appx, exe, and hash files
 
-  #     - task: GitHubRelease@1
-  #       displayName: Create GitHub release
-  #       inputs:
-  #         gitHubConnection: github
-  #         repositoryName: $(Build.Repository.Name)
-  #         tagSource: userSpecifiedTag
-  #         tag: v$(version)-preview
-  #         isPreRelease: true
-  #         isDraft: true # After running this step, visit the new draft release, edit, and publish.
-  #         assets: $(Build.ArtifactStagingDirectory)/*
+      - task: GitHubRelease@1
+        displayName: Create GitHub release
+        inputs:
+          gitHubConnection: github
+          repositoryName: $(Build.Repository.Name)
+          tagSource: userSpecifiedTag
+          tag: v$(version)-preview
+          isPreRelease: true
+          isDraft: true # After running this step, visit the new draft release, edit, and publish.
+          assets: $(Build.ArtifactStagingDirectory)/*
 
-  # - job: Wait
-  #   displayName: Wait for vanity URL to be manually updated
-  #   dependsOn: Build
-  #   pool: server
-  #   timeoutInMinutes: 1440 # job times out in 1 day
-  #   steps:
-  #     - task: ManualValidation@0
-  #       timeoutInMinutes: 1440 # task times out in 1 day
-  #       inputs:
-  #         instructions: "Please update aka.ms vanity URLs for latest release"
+  - job: Wait
+    displayName: Wait for vanity URL to be manually updated
+    dependsOn: Build
+    pool: server
+    timeoutInMinutes: 1440 # job times out in 1 day
+    steps:
+      - task: ManualValidation@0
+        timeoutInMinutes: 1440 # task times out in 1 day
+        inputs:
+          instructions: "Please update aka.ms vanity URLs for latest release"
 
-  # - job: UpdateManifest
-  #   dependsOn:
-  #     - Build
-  #     - Wait
-  #   pool:
-  #     vmImage: $(vmImageName)
-  #   variables:
-  #     runCodesignValidationInjection: ${{ false }}
-  #     skipComponentGovernanceDetection: ${{ true }}
-  #     manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
-  #     appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-  #     packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
-  #   steps:
-  #     - checkout: none
+  - job: UpdateManifest
+    dependsOn:
+      - Build
+      - Wait
+    pool:
+      vmImage: $(vmImageName)
+    variables:
+      runCodesignValidationInjection: ${{ false }}
+      skipComponentGovernanceDetection: ${{ true }}
+      manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
+      appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
+    steps:
+      - checkout: none
 
-  #     - powershell: |
-  #         # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-  #         # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
-  #         # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
-  #         # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
-  #         # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
-  #         # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
-  #         # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
-  #         # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
-  #         # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
-  #         iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-  #         .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
-  #       displayName: Update package manifest in the OWC
+      - powershell: |
+          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
+          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+          # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
+          # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
+          # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
+          # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
+          # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
+          # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
+        displayName: Update package manifest in the OWC

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -64,26 +64,25 @@ jobs:
             iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
             Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
-      - task: PowerShell@2
-        displayName: Show Directory
-        inputs:
-          targetType: 'inline'
-          script: | 
-            Get-ChildItem -Path "C:\Program Files\*" -Recurse -Force
-
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package 2'
         inputs:
           Contents: |
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll*\"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll"
           TargetFolder: '$(Build.ArtifactStagingDirectory)'    
+        condition: succeededOrFailed()
 
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package 3'
         inputs:
           Contents: |
             "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\MSVCP140.dll"
-          TargetFolder: '$(Build.ArtifactStagingDirectory)'   
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll"          
+          TargetFolder: '$(Build.ArtifactStagingDirectory)' 
+        condition: succeededOrFailed()  
 
   #     - powershell: |
   #         echo $(version)

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -101,7 +101,7 @@ jobs:
         displayName: Extract files from VCLibs appx
         inputs:
           archiveFilePatterns: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
-          destinationFolder: '$(workingDirectory)\WingetCreateCLI\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.17763.0'
+          destinationFolder: '$(workingDirectory)\WingetCreateCLI'
           cleanDestinationFolder: false
           overwriteExistingFiles: false        
 

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -69,14 +69,21 @@ jobs:
         inputs:
           targetType: 'inline'
           script: | 
-            Get-ChildItem -Path C:\Program Files\* -Recurse -Force
+            Get-ChildItem -Path "C:\Program Files\*" -Recurse -Force
 
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package 2'
         inputs:
           Contents: |
-            'C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_*\'
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll*\"
           TargetFolder: '$(Build.ArtifactStagingDirectory)'    
+
+      - task: CopyFiles@2
+        displayName: 'Copy Binaries from Visual Studio Package 3'
+        inputs:
+          Contents: |
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\MSVCP140.dll"
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'   
 
   #     - powershell: |
   #         echo $(version)

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -64,13 +64,20 @@ jobs:
             iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
             Add-AppxPackage Microsoft.VCLibs.x64.14.00.Desktop.appx
 
+      - task: PowerShell@2
+        displayName: Show Directory
+        inputs:
+          targetType: 'inline'
+          script: | 
+            Get-ChildItem -Path "C:\Program Files\WindowsApps\*" -Recurse -Include *.dll -Force
+
       - task: CopyFiles@2
         displayName: 'Copy Binaries from Visual Studio Package 2'
         inputs:
           Contents: |
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll"
+            "C:\Program Files\WindowsApps\**\MSVCP140.dll"
+            "C:\Program Files\WindowsApps\**\VCRUNTIME140_1.dll"
+            "C:\Program Files\WindowsApps\**\VCRUNTIME140.dll"
           TargetFolder: '$(Build.ArtifactStagingDirectory)'    
         condition: succeededOrFailed()
 
@@ -78,9 +85,9 @@ jobs:
         displayName: 'Copy Binaries from Visual Studio Package 3'
         inputs:
           Contents: |
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\MSVCP140.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll"
-            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.30035.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll"          
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\MSVCP140.dll"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140_1.dll"
+            "C:\Program Files\WindowsApps\Microsoft.VCLibs.140.00.UWPDesktop_14.0.29231.0_x64__8wekyb3d8bbwe\VCRUNTIME140.dll"          
           TargetFolder: '$(Build.ArtifactStagingDirectory)' 
         condition: succeededOrFailed()  
 

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -100,5 +100,18 @@
       <SdkToolsPathMaybeWithx64Architecture>$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</SdkToolsPathMaybeWithx64Architecture>
     </PropertyGroup>
   </Target>
+    
+  <!--Include VCLib binary dependencies-->  
+  <ItemGroup Condition="'$(SelfContained)' == true">
+    <None Update="\bin\$(PlatformTarget)\Release\net5.0-windows10.0.17763.0\msvcp140.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="\bin\$(PlatformTarget)\Release\net5.0-windows10.0.17763.0\vcruntime140.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="\bin\$(PlatformTarget)\Release\net5.0-windows10.0.17763.0\vcruntime140_1.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>        
+  </ItemGroup>
 
 </Project>

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -77,6 +77,19 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
     </EmbeddedResource>
   </ItemGroup>
+    
+  <!--Include VCLib binary dependencies-->  
+  <ItemGroup Condition="'$(SelfContained)' == true">
+    <None Update="msvcp140.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="vcruntime140.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="vcruntime140_1.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>   
+  </ItemGroup>    
 
   <ItemGroup>
       <SettingSchema Include="$(ProjectDir)\Schemas\settings.schema.0.1.json" ModelName="Settings" />
@@ -100,18 +113,4 @@
       <SdkToolsPathMaybeWithx64Architecture>$(TargetFrameworkSDKToolsDirectory)$(PlatformTarget)\</SdkToolsPathMaybeWithx64Architecture>
     </PropertyGroup>
   </Target>
-    
-  <!--Include VCLib binary dependencies-->  
-  <ItemGroup Condition="'$(SelfContained)' == true">
-    <None Update="\bin\$(PlatformTarget)\Release\net5.0-windows10.0.17763.0\msvcp140.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="\bin\$(PlatformTarget)\Release\net5.0-windows10.0.17763.0\vcruntime140.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="\bin\$(PlatformTarget)\Release\net5.0-windows10.0.17763.0\vcruntime140_1.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>        
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Resolves #145 

Changes:
- Adds an additional ADO task to extract the binaries from the VCLibs appx package
- Modifies the csproj file to include binaries in build

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/181)