### PR TITLE
Update VmImage name to fix pipeline

### DIFF
--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -22,7 +22,7 @@ variables:
   appxPackageDir: '$(Build.ArtifactStagingDirectory)\AppxPackages'
 
   # Agent VM image name
-  vmImageName: "windows-latest"
+  vmImageName: "ubuntu-latest"
 
   # Working Directory
   workingDirectory: "src"


### PR DESCRIPTION
According to this (thread)[https://developercommunity.visualstudio.com/t/pipelines-without-a-pool-specified-are-failing-wit/1557841], Ubuntu16 is no longer available. Changed vmImage name to use latest.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/193)