### PR TITLE
Add "32-bit" and "64-bit" to url arch parsing

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -463,12 +463,12 @@ namespace Microsoft.WingetCreateCore
                 archMatches.Add(InstallerArchitecture.Arm);
             }
 
-            if (Regex.Match(url, "x64|win64|_64", RegexOptions.IgnoreCase).Success)
+            if (Regex.Match(url, "x64|win64|_64|64-bit", RegexOptions.IgnoreCase).Success)
             {
                 archMatches.Add(InstallerArchitecture.X64);
             }
 
-            if (Regex.Match(url, "x86|win32|ia32|_86", RegexOptions.IgnoreCase).Success)
+            if (Regex.Match(url, "x86|win32|ia32|_86|32-bit", RegexOptions.IgnoreCase).Success)
             {
                 archMatches.Add(InstallerArchitecture.X86);
             }


### PR DESCRIPTION
Fixes #199 

Changes:
- Url arch parsing logic now detects a x86 arch if the installer contains "32-bit"
- Url arch parsing logic now detects a x64 arch if the installer contains "64-bit"

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/200)