### PR TITLE
Handle taskcanceled exception with error message

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -305,6 +305,12 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return null;
                 }
 
+                if (e is TaskCanceledException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.DownloadConnectionTimeout_Error));
+                    return null;
+                }
+
                 throw;
             }
         }

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -292,26 +292,25 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                     return null;
                 }
-
-                if (e is DownloadSizeExceededException downloadSizeExceededException)
+                else if (e is DownloadSizeExceededException downloadSizeExceededException)
                 {
                     Logger.ErrorLocalized(nameof(Resources.DownloadFileExceedsMaxSize_Error), $"{downloadSizeExceededException.MaxDownloadSizeInBytes / 1024 / 1024}");
                     return null;
                 }
-
-                if (e is InvalidOperationException)
+                else if (e is InvalidOperationException)
                 {
                     Logger.ErrorLocalized(nameof(Resources.InvalidUrl_Error));
                     return null;
                 }
-
-                if (e is TaskCanceledException)
+                else if (e is TaskCanceledException)
                 {
                     Logger.ErrorLocalized(nameof(Resources.DownloadConnectionTimeout_Error));
                     return null;
                 }
-
-                throw;
+                else
+                {
+                    throw;
+                }
             }
         }
 

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -412,6 +412,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to complete the download request as the connection has timed out. Please verify your installer URL and try again..
+        /// </summary>
+        public static string DownloadConnectionTimeout_Error {
+            get {
+                return ResourceManager.GetString("DownloadConnectionTimeout_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to download installer..
         /// </summary>
         public static string DownloadFile_Error {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -783,4 +783,7 @@
   <data name="SelectManifestToEdit_Message" xml:space="preserve">
     <value>Which manifest do you want to edit?</value>
   </data>
+  <data name="DownloadConnectionTimeout_Error" xml:space="preserve">
+    <value>Unable to complete the download request as the connection has timed out. Please verify your installer URL and try again.</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Fixes #197 

Changes
- Handles the exception that's thrown when the download request fails due to timeout.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/201)