### PR TITLE
Remove fields with empty strings from manifest output

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -357,6 +357,26 @@ namespace Microsoft.WingetCreateCLI.Commands
         }
 
         /// <summary>
+        /// Removes fields with empty string values from all manifests.
+        /// </summary>
+        /// <param name="manifests">Wrapper object containing the manifest object models.</param>
+        protected static void RemoveEmptyStringFieldsInManifests(Manifests manifests)
+        {
+            RemoveEmptyStringFields(manifests.InstallerManifest);
+            RemoveEmptyStringFields(manifests.DefaultLocaleManifest);
+
+            foreach (var localeManifest in manifests.LocaleManifests)
+            {
+                RemoveEmptyStringFields(localeManifest);
+            }
+
+            foreach (var installer in manifests.InstallerManifest.Installers)
+            {
+                RemoveEmptyStringFields(installer);
+            }
+        }
+
+        /// <summary>
         /// Launches the GitHub OAuth flow and obtains a GitHub token.
         /// </summary>
         /// <returns>A boolean value indicating whether the OAuth login flow was successful.</returns>
@@ -493,6 +513,24 @@ namespace Microsoft.WingetCreateCLI.Commands
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Removes fields with empty string values from a given object.
+        /// </summary>
+        /// <param name="obj">Object to remove empty string fields from.</param>
+        private static void RemoveEmptyStringFields(object obj)
+        {
+            var stringProperties = obj.GetType().GetProperties()
+                .Where(p => p.PropertyType == typeof(string));
+
+            foreach (var prop in stringProperties)
+            {
+                if ((string)prop.GetValue(obj) == string.Empty)
+                {
+                    prop.SetValue(obj, null);
+                }
+            }
         }
     }
 }

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -161,6 +161,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     }
 
                     PromptPropertiesAndDisplayManifests(manifests);
+                    RemoveEmptyStringFieldsInManifests(manifests);
                     isManifestValid = ValidateManifestsInTempDir(manifests);
                 }
                 while (Prompt.Confirm(Resources.ConfirmManifestCreation_Message));

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -175,6 +175,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 return false;
             }
 
+            RemoveEmptyStringFieldsInManifests(updatedManifests);
             DisplayManifestPreview(updatedManifests);
 
             if (string.IsNullOrEmpty(this.OutputDir))

--- a/src/WingetCreateCore/Models/InstallerManifestModels.cs
+++ b/src/WingetCreateCore/Models/InstallerManifestModels.cs
@@ -157,7 +157,8 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     public partial class Installer 
     {
         [Newtonsoft.Json.JsonProperty("InstallerLocale", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.StringLength(20, MinimumLength = 1)]
+        [System.ComponentModel.DataAnnotations.StringLength(20)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([a-zA-Z]{2,3}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$")]
         public string InstallerLocale { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Platform", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -237,6 +238,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
         [Newtonsoft.Json.JsonProperty("ProductCode", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.StringLength(255, MinimumLength = 1)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$")]
         public string ProductCode { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Capabilities", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -280,7 +282,8 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         public string Channel { get; set; }
     
         [Newtonsoft.Json.JsonProperty("InstallerLocale", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.StringLength(20, MinimumLength = 1)]
+        [System.ComponentModel.DataAnnotations.StringLength(20)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([a-zA-Z]{2,3}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$")]
         public string InstallerLocale { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Platform", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -336,6 +339,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
         [Newtonsoft.Json.JsonProperty("ProductCode", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.StringLength(255, MinimumLength = 1)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$")]
         public string ProductCode { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Capabilities", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.EmptyFields.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.EmptyFields.yaml
@@ -1,0 +1,19 @@
+﻿PackageIdentifier: TestPublisher.EmptyFields
+PackageVersion: 0.1.2
+PackageName: Empty fields test
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used to test if empty fields are removed from the manifest.
+InstallerLocale: en-US
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+    ProductCode: ''
+    PackageFamilyName: ''
+PrivacyUrl: ''
+Author: ''
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -33,6 +33,9 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-US.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.EmptyFields.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.MultipleArchitectureOverride.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Changes:
- Checks string fields to see if they have empty string values and convert them into null so that they do not get published in the generated manifest. 

Tests:
- Added UpdateWithEmptyFields test to verify that the empty string fields of a manifest are removed prior to being published.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/208)