### PR TITLE
Preserve existing ProductCode when updating

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -360,10 +360,12 @@ namespace Microsoft.WingetCreateCore
             existingInstaller.InstallerUrl = newInstaller.InstallerUrl;
             existingInstaller.InstallerSha256 = newInstaller.InstallerSha256;
             existingInstaller.SignatureSha256 = newInstaller.SignatureSha256;
-            existingInstaller.ProductCode = newInstaller.ProductCode;
-            existingInstaller.MinimumOSVersion = newInstaller.MinimumOSVersion;
-            existingInstaller.PackageFamilyName = newInstaller.PackageFamilyName;
-            existingInstaller.Platform = newInstaller.Platform;
+
+            // If the newInstaller field value is null, we default to using the existingInstaller field value.
+            existingInstaller.ProductCode = newInstaller.ProductCode ?? existingInstaller.ProductCode;
+            existingInstaller.MinimumOSVersion = newInstaller.MinimumOSVersion ?? existingInstaller.MinimumOSVersion;
+            existingInstaller.PackageFamilyName = newInstaller.PackageFamilyName ?? existingInstaller.PackageFamilyName;
+            existingInstaller.Platform = newInstaller.Platform ?? existingInstaller.Platform;
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.SingleExe.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.SingleExe.yaml
@@ -1,0 +1,19 @@
+﻿PackageIdentifier: TestPublisher.SingleExe
+PackageVersion: 0.1.2
+PackageName: Single exe test
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used to test the update command with a single exe installer.
+InstallerLocale: en-US
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+    ProductCode: FakeProductCode
+    PackageFamilyName: FakePackageFamilyName
+    Platform:
+    - Windows.Desktop
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.0.0

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -392,6 +392,41 @@ namespace Microsoft.WingetCreateUnitTests
             }
         }
 
+        /// <summary>
+        /// Tests that the provided installer url with leading and trailing spaces is trimmed prior to being updated.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateWithUntrimmedInstallerUrl()
+        {
+            string untrimmedInstallerUrl = $"  https://fakedomain.com/{TestConstants.TestExeInstaller}   ";
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) =
+                GetUpdateCommandAndManifestData("TestPublisher.SingleExe", "1.2.3.4", this.tempPath, new[] { untrimmedInstallerUrl });
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+            Assert.AreNotEqual(untrimmedInstallerUrl, updatedManifests.InstallerManifest.Installers.First().InstallerUrl, "InstallerUrl was not trimmed prior to update.");
+        }
+
+        /// <summary>
+        /// Tests if a new installer has null values, the update does not overwrite existing values for ProductCode, PackageFamilyName, and Platform from the existing manifest.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdatePreservesExistingValues()
+        {
+            string installerUrl = $"https://fakedomain.com/{TestConstants.TestExeInstaller}";
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) =
+                GetUpdateCommandAndManifestData("TestPublisher.SingleExe", "1.2.3.4", this.tempPath, new[] { $"{installerUrl}" });
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+            var updatedInstaller = updatedManifests.InstallerManifest.Installers.First();
+            Assert.AreEqual("FakeProductCode", updatedInstaller.ProductCode, "Existing value for ProductCode was overwritten.");
+            Assert.AreEqual("FakePackageFamilyName", updatedInstaller.PackageFamilyName, "Existing value for PackageFamilyName was overwritten.");
+            Assert.IsNotNull(updatedInstaller.Platform, "Existing value for Platform was overwritten.;");
+        }
+
         private static (UpdateCommand UpdateCommand, List<string> InitialManifestContent) GetUpdateCommandAndManifestData(string id, string version, string outputDir, IEnumerable<string> installerUrls)
         {
             var updateCommand = new UpdateCommand

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -33,6 +33,9 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-US.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.SingleExe.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.EmptyFields.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixes #212 

Issue:
When updating an existingInstaller with a newInstaller, if the newInstaller does not have the productCode defined, it would overwrite the existing ProductCode. 

Fix:
In order to address this issue, I added a check to first see if the new ProductCode is non-null before assigning the value. That way the existing ProductCode can be preserved if no new value is present.

I have also applied the same logic to other relevant fields such as MinimumOSVersion, PackageFamilyName, and Platform.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/215)