### PR TITLE
Trim InstallerUrls before update

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -224,7 +224,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             }
 
             // Generate list of InstallerUpdate objects and parse out any specified architecture overrides.
-            List<InstallerMetadata> installerMetadataList = this.ParseInstallerUrlsForArchOverride(this.InstallerUrls.ToList());
+            List<InstallerMetadata> installerMetadataList = this.ParseInstallerUrlsForArchOverride(this.InstallerUrls.Select(i => i.Trim()).ToList());
 
             // If the installer update list is null there was an issue when parsing for architecture override.
             if (installerMetadataList == null)


### PR DESCRIPTION
Fixes #213 

Issue:
Accidentally including an extra leading space with a url can cause schema validation errors when creating the manifest. 

Changes:
To prevent this issue, I now trim any extra whitespaces for all urls that are provided when updating a manifest. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/216)