### PR TITLE
Added WiX installer detection to MSI Parser.

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -651,7 +651,9 @@ namespace Microsoft.WingetCreateCore
             {
                 using (var database = new QDatabase(path, Deployment.WindowsInstaller.DatabaseOpenMode.ReadOnly))
                 {
-                    baseInstaller.InstallerType = InstallerType.Msi;
+                    baseInstaller.InstallerType = database.SummaryInfo.CreatingApp.Contains("Windows Installer XML")
+                        ? InstallerType.Wix
+                        : InstallerType.Msi;
 
                     var properties = database.Properties.ToList();
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

This PR adds WiX installer detection to the MSI Parser by looking to see if the "CreatingApp" property in the MSI says "Windows Installer XML". Inspired by the [changes to YamlCreate.ps1](https://github.com/Trenly/winget-pkgs/pull/140).

Also, it appears VSCode had some issues with the formatting of the file. Sorry for the large diff (although, strangely, the diff doesn't appear the same way in VSCode. Line endings, characters, everything looks unchanged...)

Tested: manually. If it needs a unit test, as always, I'm happy to add one.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/219)