### PR TITLE
Remove notice file generation pipeline task

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -557,14 +557,15 @@ SOFTWARE.
 
 ---------------------------------------------------------
 
-Microsoft.WindowsPackageManager.Utils 0.2.8 - MIT
+Microsoft.WindowsPackageManager.Utils 1.1.6 - MIT
 
 
 (c) 2008 VeriSign, Inc.
 (c) Microsoft Corporation.
 CopyrightUrl ShortDescription
 Copyright (c) Microsoft Corporation
-CopyrightUrl ShortDescription WindowsFeatures
+CopyrightUrl ShortDescription Agreements
+CopyrightUrl Copyright Agreements ShortDescription
 CopyrightInfo AbstractInfo FormattingImplementationInfo
 
 MIT License

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -113,28 +113,6 @@ jobs:
           verbosity: "Verbose"
           alertWarningLevel: "High"
 
-      - task: notice@0
-        displayName: "NOTICE File Generator"
-        inputs:
-          outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
-          outputformat: "text"
-
-      - bash: |
-          echo "Diffing existing NOTICE.txt with generated version"
-          diff -w NOTICE.txt temp/NOTICE.txt
-          if [[ $? -ne 0 ]];
-          then
-            echo "Notice file modified"
-            echo "*******************************************************************************************************"
-            echo "Download the updated NOTICE.txt from the build artifacts and update the file in your PR, then re-submit"
-            echo "*******************************************************************************************************"
-            exit 1
-          else
-            echo "Notice file not modified."
-          fi
-        displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
-        continueOnError: "true"
-
       - task: VSTest@2
         displayName: Run Tests
         inputs:

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -135,6 +135,7 @@ jobs:
           fi
         displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
         condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+        continueOnError: "true"
 
       - task: VSTest@2
         displayName: Run Tests

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
 
       - task: notice@0
         displayName: "NOTICE File Generator"
-        continueOnError: "true"
+        continueOnError: not(eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
           outputformat: "text"
@@ -134,7 +134,7 @@ jobs:
             echo "Notice file not modified."
           fi
         displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
-        continueOnError: "true"
+        continueOnError: not(eq(variables['Build.Reason'], 'PullRequest'))
 
       - task: VSTest@2
         displayName: Run Tests

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
 
       - task: notice@0
         displayName: "NOTICE File Generator"
-        continueOnError: $[not(eq(variables['Build.Reason'], 'PullRequest'))]
+        condition: not(eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
           outputformat: "text"
@@ -134,7 +134,7 @@ jobs:
             echo "Notice file not modified."
           fi
         displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
-        continueOnError: $[not(eq(variables['Build.Reason'], 'PullRequest'))]
+        condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
       - task: VSTest@2
         displayName: Run Tests

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
 
       - task: notice@0
         displayName: "NOTICE File Generator"
-        continueOnError: not(eq(variables['Build.Reason'], 'PullRequest'))
+        continueOnError: $[not(eq(variables['Build.Reason'], 'PullRequest'))]
         inputs:
           outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
           outputformat: "text"
@@ -134,7 +134,7 @@ jobs:
             echo "Notice file not modified."
           fi
         displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
-        continueOnError: not(eq(variables['Build.Reason'], 'PullRequest'))
+        continueOnError: $[not(eq(variables['Build.Reason'], 'PullRequest'))]
 
       - task: VSTest@2
         displayName: Run Tests

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -113,6 +113,29 @@ jobs:
           verbosity: "Verbose"
           alertWarningLevel: "High"
 
+      - task: notice@0
+        displayName: "NOTICE File Generator"
+        continueOnError: "true"
+        inputs:
+          outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
+          outputformat: "text"
+
+      - bash: |
+          echo "Diffing existing NOTICE.txt with generated version"
+          diff -w NOTICE.txt temp/NOTICE.txt
+          if [[ $? -ne 0 ]];
+          then
+            echo "Notice file modified"
+            echo "*******************************************************************************************************"
+            echo "Download the updated NOTICE.txt from the build artifacts and update the file in your PR, then re-submit"
+            echo "*******************************************************************************************************"
+            exit 1
+          else
+            echo "Notice file not modified."
+          fi
+        displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
+        continueOnError: "true"
+
       - task: VSTest@2
         displayName: Run Tests
         inputs:


### PR DESCRIPTION
Changes:
- Updates NOTICE.txt to latest
- Removes the NOTICE file generation pipeline task as there is a known issue with the Component Governance task when performing validation on forked PRs which will cause this step to fail. As seen in PR #222 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/223)