### PR TITLE
Add UpdateCommand support for 1.1 Schema

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -360,6 +360,12 @@ namespace Microsoft.WingetCreateCLI.Commands
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Dependencies, WingetCreateCore.Models.Installer.Dependencies>();
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Installer, WingetCreateCore.Models.Installer.Installer>();
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.InstallerSwitches, WingetCreateCore.Models.Installer.InstallerSwitches>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.AppsAndFeaturesEntry, WingetCreateCore.Models.Installer.AppsAndFeaturesEntry>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.ExpectedReturnCode, WingetCreateCore.Models.Installer.ExpectedReturnCode>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.PackageDependencies, WingetCreateCore.Models.Installer.PackageDependencies>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.Markets, WingetCreateCore.Models.Installer.Markets>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.Markets2, WingetCreateCore.Models.Installer.Markets2>(); // Markets2 is not used, but is required to satisfy mapping configuration.
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.Agreement, WingetCreateCore.Models.DefaultLocale.Agreement>();
             });
             var mapper = config.CreateMapper();
 

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -24,7 +24,6 @@ namespace Microsoft.WingetCreateCLI.Commands
     using Microsoft.WingetCreateCore.Models.Locale;
     using Microsoft.WingetCreateCore.Models.Version;
     using Sharprompt;
-    using Windows.Media.SpeechRecognition;
 
     /// <summary>
     /// Command for updating the elements of an existing or local manifest.

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -391,7 +391,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         }
 
         /// <summary>
-        /// Ensures that the manifestVersion is updated to the latest schema version.
+        /// Ensures that the manifestVersion is consistent across all manifest object models.
         /// </summary>
         /// <param name="manifests">Manifests object model.</param>
         private static void EnsureManifestVersionConsistency(Manifests manifests)

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -313,7 +313,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 manifests = ConvertSingletonToMultifileManifest(manifests.SingletonManifest);
             }
 
-            UpdateManifestVersionToLatest(manifests);
+            EnsureManifestVersionConsistency(manifests);
 
             VersionManifest versionManifest = manifests.VersionManifest;
             InstallerManifest installerManifest = manifests.InstallerManifest;
@@ -394,7 +394,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Ensures that the manifestVersion is updated to the latest schema version.
         /// </summary>
         /// <param name="manifests">Manifests object model.</param>
-        private static void UpdateManifestVersionToLatest(Manifests manifests)
+        private static void EnsureManifestVersionConsistency(Manifests manifests)
         {
             string latestManifestVersion = new VersionManifest().ManifestVersion;
             manifests.VersionManifest.ManifestVersion = latestManifestVersion;

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
-    <Version>0.4.4</Version>
+    <Version>0.5.0</Version>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -221,7 +221,14 @@ namespace Microsoft.WingetCreateCore
             public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
             {
                 var propertyDescriptors = this.innerTypeDescriptor.GetProperties(type, container);
-                var aliasDefinedProps = type.GetProperties().ToList().Where(p => p.GetCustomAttribute<YamlMemberAttribute>() != null).ToList();
+                var aliasDefinedProps = type.GetProperties().ToList()
+                    .Where(p =>
+                    {
+                        var yamlMemberAttribute = p.GetCustomAttribute<YamlMemberAttribute>();
+                        return yamlMemberAttribute != null && !string.IsNullOrEmpty(yamlMemberAttribute.Alias);
+                    })
+                    .ToList();
+
                 if (aliasDefinedProps.Any())
                 {
                     var overriddenProps = propertyDescriptors

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -5,11 +5,9 @@ namespace Microsoft.WingetCreateCore
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using System.Reflection;
-    using System.Reflection.Metadata;
     using System.Runtime.Serialization;
     using System.Text;
     using Microsoft.WingetCreateCore.Models;
@@ -58,9 +56,8 @@ namespace Microsoft.WingetCreateCore
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(PascalCaseNamingConvention.Instance)
                 .WithTypeConverter(new YamlStringEnumConverter())
-                .IgnoreUnmatchedProperties()
-                .WithTypeInspector(inspector => new AliasTypeInspector(inspector));
-                //.WithAttributeOverride<InstallerManifest>(c => c.ReleaseDate, new YamlIgnoreAttribute());
+                .WithTypeInspector(inspector => new AliasTypeInspector(inspector))
+                .IgnoreUnmatchedProperties();
             return deserializer.Build();
         }
 

--- a/src/WingetCreateCore/Models/Partials/InstallerPartials.cs
+++ b/src/WingetCreateCore/Models/Partials/InstallerPartials.cs
@@ -5,7 +5,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
 {
     using System;
     using System.Collections.Generic;
+    using System.Text.Json.Serialization;
     using Microsoft.WingetCreateCore.Models.CustomValidation;
+    using Newtonsoft.Json;
     using YamlDotNet.Serialization;
 
     /// <summary>
@@ -21,6 +23,20 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         {
             return new PackageDependencies { MinimumVersion = this.MinimumVersion, PackageIdentifier = this.PackageIdentifier };
         }
+    }
+
+    /// <summary>
+    /// Partial InstallerManifest class for defining a string type ReleaseDateTimeField.
+    /// Workaround for issue with model generating ReleaseDate with DateTimeOffset type.
+    /// </summary>
+    public partial class InstallerManifest
+    {
+        /// <summary>
+        /// Gets or sets the Release Date time.
+        /// </summary>
+        [YamlMember(Alias = "ReleaseDate")]
+        [DateTimeValidation]
+        public string ReleaseDateTime { get; set; }
     }
 
     /// <summary>

--- a/src/WingetCreateCore/Models/Partials/SingletonPartials.cs
+++ b/src/WingetCreateCore/Models/Partials/SingletonPartials.cs
@@ -20,6 +20,20 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     }
 
     /// <summary>
+    /// Partial SingletonManifest class for defining a string type ReleaseDateTime field.
+    /// Workaround for issue with model generating ReleaseDate with DateTimeOffset type.
+    /// </summary>
+    public partial class SingletonManifest
+    {
+        /// <summary>
+        /// Gets or sets the Release Date time.
+        /// </summary>
+        [YamlMember(Alias = "ReleaseDate")]
+        [DateTimeValidation]
+        public string ReleaseDateTime { get; set; }
+    }
+
+    /// <summary>
     /// Partial Installer class for defining a string type ReleaseDateTime field.
     /// Workaround for issue with model generating ReleaseDate with DateTimeOffset type.
     /// </summary>

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.DeserializeAliasFields.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.DeserializeAliasFields.yaml
@@ -1,0 +1,21 @@
+﻿PackageIdentifier: TestPublisher.DeserializeAliasFields
+PackageVersion: 0.1.2
+PackageName: Deserialize Alias Fields Test
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used to test the the deserialization of custom fields that have a YamlMember alias attribute.
+InstallerLocale: en-US
+ReleaseDate: 1-1-2022
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+    ReleaseDate: 1-1-2022
+Agreements: 
+  - Agreement: Agreement text
+    AgreementLabel: Agreement label
+    AgreementUrl: https://fakeagreementurl.com
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.1.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullSingleton1_1.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullSingleton1_1.yaml
@@ -1,0 +1,80 @@
+﻿PackageIdentifier: TestPublisher.FullSingleton1_1
+PackageVersion: 0.1.2.3
+PackageLocale: en-US
+DefaultLocale: en-US
+Publisher: TestPublisher
+PublisherUrl: https://fakeTestUrl.com
+PublisherSupportUrl: https://fakeTestUrl.com
+PrivacyUrl: https://fakeTestUrl.com
+Author: fakeAuthor
+PackageName: Full Singleton 1.1 Test
+PackageUrl: https://fakeTestUrl.com
+License: MIT
+LicenseUrl: https://fakeTestUrl.com
+Copyright: fakeCopyright
+CopyrightUrl: https://fakeTestUrl.com
+ShortDescription: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.
+Description: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deseri
+Moniker: testMoniker
+Tags:
+- testSingleton
+Agreements:
+- AgreementLabel: fakeAgreementLabel
+  AgreementUrl: https://fakeTestUrl.com
+  Agreement: fakeAgreementContent
+ReleaseNotes: fakeReleaseNotes
+ReleaseNotesUrl: https://fakeTestUrl.com
+Installers:
+- MinimumOSVersion: 10.0.0.0
+  Architecture: x64
+  InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+  InstallerType: exe
+  InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+  ProductCode: FakeProductCode
+  PackageFamilyName: FakePackageFamilyName
+  InstallModes:
+  - silent
+  InstallerSwitches:
+    Silent: /s
+    Upgrade: /u
+  InstallerSuccessCodes:
+  - 1
+  ExpectedReturnCodes:
+  - InstallerReturnCode: 123
+    ReturnResponse: alreadyInstalled
+  UpgradeBehavior: install
+  Commands:
+  - fakeCommand
+  Protocols:
+  - fakeProtocol
+  FileExtensions:
+  - .exe
+  Dependencies:
+    WindowsFeatures:
+    - fakeValue
+    WindowsLibraries:
+    - fakeValue
+    PackageDependencies:
+    - MinimumVersion: 10.0.0.0
+    ExternalDependencies:
+    - fakeValue
+  Markets:
+    AllowedMarkets:
+    - fakeAllowedMarket
+    ExcludedMarkets:
+    - fakeExcludedMarket
+  InstallerAbortsTerminal: true
+  InstallLocationRequired: true
+  RequireExplicitUpgrade: true
+  UnsupportedOSArchitectures:
+  - arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: testName
+    Publisher: testPublisher
+    DisplayVersion: testVersion
+    UpgradeCode: fakeProductCode
+  ElevationRequirement: elevationRequired
+  ReleaseDate: 1-1-2022
+ManifestType: singleton
+ManifestVersion: 1.1.0
+

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -446,6 +446,24 @@ namespace Microsoft.WingetCreateUnitTests
             }
         }
 
+        /// <summary>
+        /// Tests that the manifest version gets updated to the latest manifest schema version.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdatesToLatestManifestVersion()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.SingleExe", null, this.tempPath, null);
+            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
+            string initialManifestVersion = initialManifests.SingletonManifest.ManifestVersion;
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+            Assert.AreNotEqual(initialManifestVersion, updatedManifests.InstallerManifest.ManifestVersion, "ManifestVersion should be updated to latest.");
+            Assert.AreNotEqual(initialManifestVersion, updatedManifests.VersionManifest.ManifestVersion, "ManifestVersion should be updated to latest.");
+            Assert.AreNotEqual(initialManifestVersion, updatedManifests.DefaultLocaleManifest.ManifestVersion, "ManifestVersion should be updated to latest.");
+        }
+
         private static (UpdateCommand UpdateCommand, List<string> InitialManifestContent) GetUpdateCommandAndManifestData(string id, string version, string outputDir, IEnumerable<string> installerUrls)
         {
             var updateCommand = new UpdateCommand

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -464,6 +464,46 @@ namespace Microsoft.WingetCreateUnitTests
             Assert.AreNotEqual(initialManifestVersion, updatedManifests.DefaultLocaleManifest.ManifestVersion, "ManifestVersion should be updated to latest.");
         }
 
+        /// <summary>
+        /// Verifies that deserialization prioritizes alias-defined fields and can correctly assign and update those fields.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateDeserializesAliasDefinedFields()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.DeserializeAliasFields", null, this.tempPath, null);
+            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
+            var initialSingleton = initialManifests.SingletonManifest;
+
+            // Verify that fields with an alias-defined counterpart are not deserialized.
+            Assert.IsNull(initialSingleton.ReleaseDate, "ReleaseDate should not be defined as it is a DateTimeOffset type.");
+            Assert.IsNull(initialSingleton.Installers.First().ReleaseDate, "The installer ReleaseDate should not be defined as it is a DateTimeOffset type.");
+            Assert.IsNull(initialSingleton.Agreements.First().Agreement1, "Agreement1 should not be defined since the property name is generated incorrectly.");
+
+            // Verify that the alias-defined fields are correctly updated.
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            var updatedInstallerManifest = updatedManifests.InstallerManifest;
+            var updatedDefaultLocaleManifest = updatedManifests.DefaultLocaleManifest;
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+            Assert.AreEqual(initialSingleton.ReleaseDateTime, updatedInstallerManifest.ReleaseDateTime, "The value for ReleaseDate should be the same.");
+            Assert.AreEqual(initialSingleton.Installers.First().ReleaseDateTime, updatedInstallerManifest.Installers.First().ReleaseDateTime, "The value for ReleaseDateTime should be the same.");
+            Assert.AreEqual(initialSingleton.Agreements.First().AgreementContent, updatedDefaultLocaleManifest.Agreements.First().AgreementContent, "The value for ReleaseDateTime should be the same.");
+        }
+
+        /// <summary>
+        /// Ensures that all fields from the Singleton v1.1. manifest can be deserialized and updated correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateFullSingletonVersion1_1()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullSingleton1_1", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+        }
+
         private static (UpdateCommand UpdateCommand, List<string> InitialManifestContent) GetUpdateCommandAndManifestData(string id, string version, string outputDir, IEnumerable<string> installerUrls)
         {
             var updateCommand = new UpdateCommand

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -33,6 +33,12 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-US.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.FullSingleton1_1.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.DeserializeAliasFields.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.SingleExe.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Resolves #139 

Changes:
- Increment version from 0.4.4 to 0.5 in preparation for new release
- Adds a custom AliasTypeInspector that prioritizes properties with the YamlMemberAttribute to handle custom properties overrides such ReleaseDate and Agreement.
- Updates the Automapper to include mapping for for newly added object models (i.e. AppsAndFeaturesEntry, ExpectedReturnCode, PackageDependencies, Markets, etc.)
- Ensures UpdateCommand updates ManifestVersion field to the latest schema version.

Verification:
Added 3 unit tests to cover the above changes
- UpdatesToLatestManifestVersion()  
- UpdateDeserializesAliasDefinedFields()
- UpdateFullSingletonVersion1_1()

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/224)