### PR TITLE
Fix build pipeline for transition to VS2022

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -106,12 +106,6 @@ jobs:
           cleanDestinationFolder: false
           overwriteExistingFiles: false                 
 
-      # NuGetCommand task, but since there are two duplicate tasks by this name in the org, must refer to it by GUID
-      - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-        displayName: Restore Packages
-        inputs:
-          restoreSolution: "$(solution)"
-
       - task: DotNetCoreCLI@2
         displayName: Restore
         inputs:

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -78,11 +78,6 @@ jobs:
           $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
         displayName: "Update package manifest version"
 
-      - task: NuGetCommand@2
-        displayName: Restore Packages
-        inputs:
-          restoreSolution: "$(solution)"
-
       - task: DotNetCoreCLI@2
         displayName: Restore
         inputs:

--- a/src/WingetCreatePackage/WingetCreatePackage.wapproj
+++ b/src/WingetCreatePackage/WingetCreatePackage.wapproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
-    <VisualStudioVersion>15.0</VisualStudioVersion>
+<Project ToolsVersion="17.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '17.0'">
+    <VisualStudioVersion>17.0</VisualStudioVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x86">

--- a/src/WingetCreatePackage/WingetCreatePackage.wapproj
+++ b/src/WingetCreatePackage/WingetCreatePackage.wapproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="17.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '17.0'">
-    <VisualStudioVersion>17.0</VisualStudioVersion>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
+    <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x86">
@@ -27,7 +27,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>ac37dfd2-1332-4282-b373-8dcf8bb4e3ba</ProjectGuid>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <EntryPointProjectUniqueName>..\WingetCreateCLI\WingetCreateCLI.csproj</EntryPointProjectUniqueName>

--- a/src/WingetCreateTests/WingetCreateTestMsixInstaller/WingetCreateTestMsixInstaller.wapproj
+++ b/src/WingetCreateTests/WingetCreateTestMsixInstaller/WingetCreateTestMsixInstaller.wapproj
@@ -39,7 +39,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>154eb646-d902-41b5-9ce1-e78acc63aa0a</ProjectGuid>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>


### PR DESCRIPTION
The changes in this PR fix build issues that have appeared because of the transition to VS2022

Changes:
- Removed nuget restore task
- Updated .wapproj to target 10.22000

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/232)