### PR TITLE
Update version in release build and remove preview labels

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -40,7 +40,8 @@ jobs:
     dependsOn: GetVersion
     variables:
       majorMinorBuildVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorBuildVersion']]
-      version: "$(majorMinorBuildVersion)"
+      revision: $[counter(format('{0}.{1}', '3', variables['majorMinorBuildVersion']), 1)]
+      version: "$(majorMinorBuildVersion).$(revision)"
       appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
       appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
       exeDirSelfContained: '$(appxPackageDir)\selfcontained'
@@ -233,7 +234,7 @@ jobs:
       skipComponentGovernanceDetection: ${{ true }}
       manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
       appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)-preview/$(appxBundleFile)"
+      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
     steps:
       - checkout: none
 

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -42,7 +42,7 @@ jobs:
       majorMinorVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorVersion']]
       buildVersion: $[counter(variables['majorMinorVersion'], 1)]
       version: "$(majorMinorVersion).$(buildVersion).0"
-      appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe.msixbundle"
+      appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
       appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
       exeDirSelfContained: '$(appxPackageDir)\selfcontained'
       exeDirFrameworkDependent: '$(appxPackageDir)\dependent'

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -31,7 +31,7 @@ jobs:
       - powershell: |
           [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
           $version = @($project.Project.PropertyGroup)[0].Version
-          echo "##vso[task.setvariable variable=majorMinorBuildVersion;isOutput=true]$version"
+          echo "##vso[task.setvariable variable=majorMinorVersion;isOutput=true]$version"
         name: GetVersionStep
         displayName: Get version from CLI project
 
@@ -39,10 +39,10 @@ jobs:
     displayName: Build
     dependsOn: GetVersion
     variables:
-      majorMinorBuildVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorBuildVersion']]
-      revision: $[counter(format('{0}.{1}', '3', variables['majorMinorBuildVersion']), 1)]
-      version: "$(majorMinorBuildVersion).$(revision)"
-      appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
+      majorMinorVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorVersion']]
+      buildVersion: $[counter(-1, 1)]
+      version: "$(majorMinorVersion).$(buildVersion).0"
+      appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe.msixbundle"
       appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
       exeDirSelfContained: '$(appxPackageDir)\selfcontained'
       exeDirFrameworkDependent: '$(appxPackageDir)\dependent'

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -40,7 +40,7 @@ jobs:
     dependsOn: GetVersion
     variables:
       majorMinorVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorVersion']]
-      buildVersion: $[counter(-1, 1)]
+      buildVersion: $[counter(variables['majorMinorVersion'], 1)]
       version: "$(majorMinorVersion).$(buildVersion).0"
       appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe.msixbundle"
       appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
       - powershell: |
           [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
           $version = $project.Project.PropertyGroup.Version
-          echo "##vso[task.setvariable variable=majorMinorBuildVersion;isOutput=true]$version"
+          echo "##vso[task.setvariable variable=majorMinorVersion;isOutput=true]$version"
         name: GetVersionStep
         displayName: Get version from CLI project
 
@@ -50,16 +50,15 @@ jobs:
     displayName: Build
     dependsOn: GetVersion
     variables:
-      majorMinorBuildVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorBuildVersion']]
-
+      majorMinorVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorVersion']]
       # Only update counter for non-PR builds, otherwise just use 0 for the revision
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        revision: 0
+        buildVersion: 0
       ${{ if not(eq(variables['Build.Reason'], 'PullRequest')) }}:
-        revision: $[counter(variables['majorMinorBuildVersion'], 1)]
-
-      version: "$(majorMinorBuildVersion).$(revision)"
-      appxBundlePath: '$(appxPackageDir)\Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle'
+        buildVersion: $[counter(variables['majorMinorVersion'], 1)]
+        
+      version: "$(majorMinorVersion).$(buildVersion).0"
+      appxBundlePath: '$(appxPackageDir)\Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe.msixbundle'
     pool:
       vmImage: $(vmImageName)
 

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
         buildVersion: 0
       ${{ if not(eq(variables['Build.Reason'], 'PullRequest')) }}:
         buildVersion: $[counter(variables['majorMinorVersion'], 1)]
-        
+
       version: "$(majorMinorVersion).$(buildVersion).0"
       appxBundlePath: '$(appxPackageDir)\Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe.msixbundle'
     pool:
@@ -135,6 +135,6 @@ jobs:
         displayName: Run Tests
         inputs:
           testSelector: "testAssemblies"
-          testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.17763.0\WingetCreateTests.dll'
+          testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.22000.0\WingetCreateTests.dll'
           runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
           overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
         buildVersion: $[counter(variables['majorMinorVersion'], 1)]
 
       version: "$(majorMinorVersion).$(buildVersion).0"
-      appxBundlePath: '$(appxPackageDir)\Microsoft.WindowsPackageManagerManifestCreator_8wekyb3d8bbwe.msixbundle'
+      appxBundlePath: '$(appxPackageDir)\Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle'
     pool:
       vmImage: $(vmImageName)
 

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows10.0.22000.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
-    <Version>1.0</Version>
+    <Version>1.0.0</Version>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows10.0.22000.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
-    <Version>1.0.0</Version>
+    <Version>1.0</Version>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This PR removes the "preview" labels as we prepare to release our 1.0 version of winget-create. Also fixes the versioning so that the build version is incremented and not the revision value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/240)