### PR TITLE
Use AppExecutionAlias in release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Click on the individual commands to learn more.
 You can use WingetCreate to update your existing app manifest as part of your CI/CD pipeline. For reference, see the final task in this repo's [release Azure pipeline](https://github.com/microsoft/winget-create/blob/main/pipelines/azure-pipelines.release.yml).
 
 ### Using the standalone exe:
-The latest version of the standalone exe  can be found at https://aka.ms/wingetcreate/latest, and the latest preview version can be found at https://aka.ms/wingetcreate/preview, both of these require .NET to be installed on the build machine.
+The latest version of the standalone exe can be found at https://aka.ms/wingetcreate/latest, and the latest preview version can be found at https://aka.ms/wingetcreate/preview, both of these require .NET to be installed on the build machine.
 
 > Make sure your build machine has the [Microsoft Visual C++ Redistributable for Visual Studio](https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0) already installed. Without this, the standalone WingetCreate exe will fail to execute and likely show a "DllNotFoundException" error.
 
@@ -52,7 +52,7 @@ Then simply add a new powershell task to download the exe, and run it to update 
       displayName: Update package manifest in the OWC
 
 ### Using the msixbundle:
-Windows Server 2022 now supports App Execution Aliases, which means the alias `wingetcreate` can be used to run the tool after installing the msixbundle. Similar to the standalone exe steps, download the msixbundle, add the package, and run `wingetcreate` to update your manifest. 
+Windows Server 2022 now supports App Execution Aliases, which means the alias `wingetcreate` can be used to run the tool after installing the msixbundle. The latest version of the msixbundle can be found at https://aka.ms/wingetcreate/latest/msixbundle. Similar to the standalone exe steps, download the msixbundle, add the package, and run `wingetcreate` to update your manifest. 
 
 > Winget-Create has a dependency on the [C++ Runtime Desktop framework package](https://docs.microsoft.com/en-us/troubleshoot/developer/visualstudio/cpp/libraries/c-runtime-packages-desktop-bridge). Be sure to also download and install this package prior to installing wingetcreate as shown in the steps below.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Click on the individual commands to learn more.
 You can use WingetCreate to update your existing app manifest as part of your CI/CD pipeline. For reference, see the final task in this repo's [release Azure pipeline](https://github.com/microsoft/winget-create/blob/main/pipelines/azure-pipelines.release.yml).
 
 ### Using the standalone exe:
-The latest version of the standalone exe can be found at https://aka.ms/wingetcreate/latest, and the latest preview version can be found at https://aka.ms/wingetcreate/preview, both of these require .NET to be installed on the build machine.
+The latest version of the standalone exe can be found at https://aka.ms/wingetcreate/latest, and the latest preview version can be found at https://aka.ms/wingetcreate/preview, both of these require [.NET 5.0](https://dotnet.microsoft.com/en-us/download/dotnet/5.0) to be installed on the build machine.
 
 > Make sure your build machine has the [Microsoft Visual C++ Redistributable for Visual Studio](https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0) already installed. Without this, the standalone WingetCreate exe will fail to execute and likely show a "DllNotFoundException" error.
 

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -44,9 +44,7 @@ jobs:
       version: "$(majorMinorVersion).$(buildVersion).0"
       appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
       appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
-      exeDirSelfContained: '$(appxPackageDir)\selfcontained'
       exeDirFrameworkDependent: '$(appxPackageDir)\dependent'
-      exePathSelfContained: '$(exeDirSelfContained)\WingetCreateCLI\wingetcreate-self-contained.exe'
       exePathFrameworkDependent: '$(exeDirFrameworkDependent)\WingetCreateCLI\wingetcreate.exe'
     pool:
       vmImage: $(vmImageName)
@@ -59,7 +57,6 @@ jobs:
           echo $(version)
           echo $(appxBundlePath)
           echo $(appxBundleFile)
-          echo $(exePathSelfContained)
           echo $(exePathFrameworkDependent)
           echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
           echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
@@ -122,15 +119,6 @@ jobs:
           projects: $(workingDirectory)/**/WingetCreateCLI.csproj
           arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
 
-      - task: DotNetCoreCLI@2
-        displayName: Build standalone, self-contained exe
-        inputs:
-          command: publish
-          publishWebProjects: false
-          zipAfterPublish: false
-          projects: $(workingDirectory)/**/WingetCreateCLI.csproj
-          arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
-
       - task: MSBuild@1
         displayName: Build Solution
         inputs:
@@ -178,9 +166,7 @@ jobs:
 
       - powershell: |
           ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
-          ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
           (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
-          (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
           (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
         displayName: "Create hash files"
 
@@ -191,9 +177,7 @@ jobs:
           flattenFolders: true
           contents: |
             $(exePathFrameworkDependent)
-            $(exePathSelfContained)
             $(exePathFrameworkDependent).txt
-            $(exePathSelfContained).txt
             $(appxBundlePath)
             $(appxBundlePath).txt
 
@@ -234,23 +218,22 @@ jobs:
       skipComponentGovernanceDetection: ${{ true }}
       manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
       appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+      vcLibsBundleFile: "Microsoft.VCLibs.x64.14.00.Desktop.appx"
       packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
     steps:
       - checkout: none
 
       - powershell: |
-          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
-          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+          # These are the steps you would run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+          # More information about using wingetcreate in your CI/CD pipeline can be found here:
+          # https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
 
-          # https://aka.ms/wingetcreate/latest points to latest version of wingetcreate.exe
-          # https://aka.ms/wingetcreate/preview points to latest preview version of wingetcreate.exe
-          # requires .NET to be installed on the build machine to operate correctly, but is a smaller download
+          # Download and install C++ Runtime framework package.
+          iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile $(vcLibsBundleFile)
+          Add-AppxPackage $(vcLibsBundleFile)
 
-          # https://aka.ms/wingetcreate/latest/self-contained points to latest self-contained version of wingetcreate.exe
-          # https://aka.ms/wingetcreate/preview/self-contained points to latest self-contained preview version of wingetcreate.exe
-          # does not require .NET to be installed on the build machine to operate correctly, but is a larger download
-
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
+          # Download, install, and execute update.
+          iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
+          Add-AppxPackage $(appxBundleFile)
+          wingetcreate update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
         displayName: Update package manifest in the OWC

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -100,42 +100,47 @@ jobs:
         artifact: msixbundle
         displayName: Publish msix bundle
 
-      - task: ComponentGovernanceComponentDetection@0
-        displayName: Component Governance
-        inputs:
-          scanType: "Register"
-          verbosity: "Verbose"
-          alertWarningLevel: "High"
+      # - task: ComponentGovernanceComponentDetection@0
+      #   displayName: Component Governance
+      #   inputs:
+      #     scanType: "Register"
+      #     verbosity: "Verbose"
+      #     alertWarningLevel: "High"
 
-      - task: notice@0
-        displayName: "NOTICE File Generator"
-        condition: not(eq(variables['Build.Reason'], 'PullRequest'))
-        inputs:
-          outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
-          outputformat: "text"
+      # - task: notice@0
+      #   displayName: "NOTICE File Generator"
+      #   condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+      #   inputs:
+      #     outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
+      #     outputformat: "text"
 
-      - bash: |
-          echo "Diffing existing NOTICE.txt with generated version"
-          diff -w NOTICE.txt temp/NOTICE.txt
-          if [[ $? -ne 0 ]];
-          then
-            echo "Notice file modified"
-            echo "*******************************************************************************************************"
-            echo "Download the updated NOTICE.txt from the build artifacts and update the file in your PR, then re-submit"
-            echo "*******************************************************************************************************"
-            exit 1
-          else
-            echo "Notice file not modified."
-          fi
-        displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
-        condition: not(eq(variables['Build.Reason'], 'PullRequest'))
-        continueOnError: "true"
+      # - bash: |
+      #     echo "Diffing existing NOTICE.txt with generated version"
+      #     diff -w NOTICE.txt temp/NOTICE.txt
+      #     if [[ $? -ne 0 ]];
+      #     then
+      #       echo "Notice file modified"
+      #       echo "*******************************************************************************************************"
+      #       echo "Download the updated NOTICE.txt from the build artifacts and update the file in your PR, then re-submit"
+      #       echo "*******************************************************************************************************"
+      #       exit 1
+      #     else
+      #       echo "Notice file not modified."
+      #     fi
+      #   displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
+      #   condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+      #   continueOnError: "true"
 
       - powershell: |
           # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
           # Add WingetCreate AppxPackage and run the alias 'wingetcreate'
           # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
           # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+
+          # Winget-Create depends on the C++ Runtime framework, so download and install the framework
+          iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile vclibs.appx
+          Add-AppxPackage vclibs.appx
+
           iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile wingetcreate.msixbundle
           Add-AppxPackage wingetcreate.msixbundle
           wingetcreate update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion)

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -131,6 +131,16 @@ jobs:
         condition: not(eq(variables['Build.Reason'], 'PullRequest'))
         continueOnError: "true"
 
+      - powershell: |
+          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+          # Add WingetCreate AppxPackage and run the alias 'wingetcreate'
+          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
+          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+          iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile wingetcreate.msixbundle
+          Add-AppxPackage wingetcreate.msixbundle
+          wingetcreate update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion)
+        displayName: Update package manifest in the OWC   
+
       # - task: VSTest@2
       #   displayName: Run Tests
       #   inputs:
@@ -138,28 +148,3 @@ jobs:
       #     testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.22000.0\WingetCreateTests.dll'
       #     runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
       #     overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'
-
-  - job: UpdateManifest
-    dependsOn:
-      - Build
-      - Wait
-    pool:
-      vmImage: $(vmImageName)
-    variables:
-      runCodesignValidationInjection: ${{ false }}
-      skipComponentGovernanceDetection: ${{ true }}
-      manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
-      appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
-    steps:
-      - checkout: none
-
-      - powershell: |
-          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-          # Add WingetCreate AppxPackage and run the alias 'wingetcreate'
-          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
-          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
-          iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
-          Add-AppxPackage $(appxBundleFile)
-          wingetcreate update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion)
-        displayName: Update package manifest in the OWC 

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -143,7 +143,7 @@ jobs:
 
           iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile wingetcreate.msixbundle
           Add-AppxPackage wingetcreate.msixbundle
-          wingetcreate update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion)
+          wingetcreate update Microsoft.WingetCreate -u 'https://github.com/microsoft/winget-create/releases/download/v1.0.3.0/Microsoft.WindowsPackageManagerManifestCreator_1.0.3.0_8wekyb3d8bbwe.msixbundle' -v 1.0.6.0
         displayName: Update package manifest in the OWC   
 
       # - task: VSTest@2

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -139,20 +139,20 @@ jobs:
       #     runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
       #     overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'
 
-    - job: UpdateManifest
-      dependsOn:
-        - Build
-        - Wait
-      pool:
-        vmImage: $(vmImageName)
-      variables:
-        runCodesignValidationInjection: ${{ false }}
-        skipComponentGovernanceDetection: ${{ true }}
-        manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
-        appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-        packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
-      steps:
-        - checkout: none
+  - job: UpdateManifest
+    dependsOn:
+      - Build
+      - Wait
+    pool:
+      vmImage: $(vmImageName)
+    variables:
+      runCodesignValidationInjection: ${{ false }}
+      skipComponentGovernanceDetection: ${{ true }}
+      manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
+      appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
+    steps:
+      - checkout: none
 
       - powershell: |
           # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -100,56 +100,41 @@ jobs:
         artifact: msixbundle
         displayName: Publish msix bundle
 
-      # - task: ComponentGovernanceComponentDetection@0
-      #   displayName: Component Governance
-      #   inputs:
-      #     scanType: "Register"
-      #     verbosity: "Verbose"
-      #     alertWarningLevel: "High"
+      - task: ComponentGovernanceComponentDetection@0
+        displayName: Component Governance
+        inputs:
+          scanType: "Register"
+          verbosity: "Verbose"
+          alertWarningLevel: "High"
 
-      # - task: notice@0
-      #   displayName: "NOTICE File Generator"
-      #   condition: not(eq(variables['Build.Reason'], 'PullRequest'))
-      #   inputs:
-      #     outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
-      #     outputformat: "text"
+      - task: notice@0
+        displayName: "NOTICE File Generator"
+        condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+        inputs:
+          outputfile: "$(System.DefaultWorkingDirectory)/temp/NOTICE.txt"
+          outputformat: "text"
 
-      # - bash: |
-      #     echo "Diffing existing NOTICE.txt with generated version"
-      #     diff -w NOTICE.txt temp/NOTICE.txt
-      #     if [[ $? -ne 0 ]];
-      #     then
-      #       echo "Notice file modified"
-      #       echo "*******************************************************************************************************"
-      #       echo "Download the updated NOTICE.txt from the build artifacts and update the file in your PR, then re-submit"
-      #       echo "*******************************************************************************************************"
-      #       exit 1
-      #     else
-      #       echo "Notice file not modified."
-      #     fi
-      #   displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
-      #   condition: not(eq(variables['Build.Reason'], 'PullRequest'))
-      #   continueOnError: "true"
+      - bash: |
+          echo "Diffing existing NOTICE.txt with generated version"
+          diff -w NOTICE.txt temp/NOTICE.txt
+          if [[ $? -ne 0 ]];
+          then
+            echo "Notice file modified"
+            echo "*******************************************************************************************************"
+            echo "Download the updated NOTICE.txt from the build artifacts and update the file in your PR, then re-submit"
+            echo "*******************************************************************************************************"
+            exit 1
+          else
+            echo "Notice file not modified."
+          fi
+        displayName: "Trigger build warning if NOTICE.txt file needs to be modified."
+        condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+        continueOnError: "true"
 
-      - powershell: |
-          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-          # Add WingetCreate AppxPackage and run the alias 'wingetcreate'
-          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
-          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
-
-          # Winget-Create depends on the C++ Runtime framework, so download and install the framework
-          iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile vclibs.appx
-          Add-AppxPackage vclibs.appx
-
-          iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile wingetcreate.msixbundle
-          Add-AppxPackage wingetcreate.msixbundle
-          wingetcreate update Microsoft.WingetCreate -u 'https://github.com/microsoft/winget-create/releases/download/v1.0.3.0/Microsoft.WindowsPackageManagerManifestCreator_1.0.3.0_8wekyb3d8bbwe.msixbundle' -v 1.0.6.0
-        displayName: Update package manifest in the OWC   
-
-      # - task: VSTest@2
-      #   displayName: Run Tests
-      #   inputs:
-      #     testSelector: "testAssemblies"
-      #     testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.22000.0\WingetCreateTests.dll'
-      #     runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
-      #     overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'
+      - task: VSTest@2
+        displayName: Run Tests
+        inputs:
+          testSelector: "testAssemblies"
+          testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.22000.0\WingetCreateTests.dll'
+          runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
+          overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -131,10 +131,35 @@ jobs:
         condition: not(eq(variables['Build.Reason'], 'PullRequest'))
         continueOnError: "true"
 
-      - task: VSTest@2
-        displayName: Run Tests
-        inputs:
-          testSelector: "testAssemblies"
-          testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.22000.0\WingetCreateTests.dll'
-          runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
-          overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'
+      # - task: VSTest@2
+      #   displayName: Run Tests
+      #   inputs:
+      #     testSelector: "testAssemblies"
+      #     testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.22000.0\WingetCreateTests.dll'
+      #     runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
+      #     overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'
+
+    - job: UpdateManifest
+      dependsOn:
+        - Build
+        - Wait
+      pool:
+        vmImage: $(vmImageName)
+      variables:
+        runCodesignValidationInjection: ${{ false }}
+        skipComponentGovernanceDetection: ${{ true }}
+        manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
+        appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+        packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
+      steps:
+        - checkout: none
+
+      - powershell: |
+          # These are the steps you'd run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+          # Add WingetCreate AppxPackage and run the alias 'wingetcreate'
+          # The update command only supports a single installer URL, if you have multiple URLs you'll have to manually modify
+          # your manifests as described here https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+          iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
+          Add-AppxPackage $(appxBundleFile)
+          wingetcreate update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion)
+        displayName: Update package manifest in the OWC 


### PR DESCRIPTION
WS2022 now supports appExecutionAliases. The changes in this PR updates the pipeline to use the 'wingetcreate' alias and removes the self-contained exes. It also updates the README documentation with instructions on how to use the msixbundle in the pipeline.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/265)