### PR TITLE
Add support for 1.2 Schema

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -273,7 +273,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 if (type.IsEnumerable())
                 {
                     Type elementType = type.GetGenericArguments().SingleOrDefault();
-                    if (elementType.IsNonStringClassType() && !Prompt.Confirm(Resources.EditAgreements_Message))
+                    if (elementType.IsNonStringClassType() && !Prompt.Confirm(string.Format(Resources.EditObjectTypeField_Message, property.Name)))
                     {
                         continue;
                     }

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -366,6 +366,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Markets, WingetCreateCore.Models.Installer.Markets>();
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Markets2, WingetCreateCore.Models.Installer.Markets2>(); // Markets2 is not used, but is required to satisfy mapping configuration.
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Agreement, WingetCreateCore.Models.DefaultLocale.Agreement>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.Documentation, WingetCreateCore.Models.DefaultLocale.Documentation>();
             });
             var mapper = config.CreateMapper();
 

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -519,7 +519,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                     string installerUrl = installerUrlOverride[0];
                     string overrideArchString = installerUrlOverride[1];
-                    InstallerArchitecture? overrideArch = overrideArchString.ToEnumOrDefault<InstallerArchitecture>();
+                    Architecture? overrideArch = overrideArchString.ToEnumOrDefault<Architecture>();
                     if (overrideArch.HasValue)
                     {
                         installerMetadata.InstallerUrl = installerUrl;

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -448,6 +448,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Indicates whether winget should display a warning message if the install or upgrade is known to interfere with running applications.
+        /// </summary>
+        public static string DisplayInstallWarnings_KeywordDescription {
+            get {
+                return ResourceManager.GetString("DisplayInstallWarnings_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The DisplayName registry value.
         /// </summary>
         public static string DisplayName_KeywordDescription {
@@ -489,6 +498,33 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string DisplayVersion_KeywordDescription {
             get {
                 return ResourceManager.GetString("DisplayVersion_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List of documentation.
+        /// </summary>
+        public static string Documentations_KeywordDescription {
+            get {
+                return ResourceManager.GetString("Documentations_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The label of the documentation for providing software guides such as manuals and troubleshooting URLs.
+        /// </summary>
+        public static string DocumentLabel_KeywordDescription {
+            get {
+                return ResourceManager.GetString("DocumentLabel_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The documentation URL.
+        /// </summary>
+        public static string DocumentUrl_KeywordDescription {
+            get {
+                return ResourceManager.GetString("DocumentUrl_KeywordDescription", resourceCulture);
             }
         }
         
@@ -547,20 +583,20 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Would you like to edit the Agreements field?.
-        /// </summary>
-        public static string EditAgreements_Message {
-            get {
-                return ResourceManager.GetString("EditAgreements_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Would you like to edit your manifests?.
         /// </summary>
         public static string EditManifests_Message {
             get {
                 return ResourceManager.GetString("EditManifests_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Would you like to edit the {0} field?.
+        /// </summary>
+        public static string EditObjectTypeField_Message {
+            get {
+                return ResourceManager.GetString("EditObjectTypeField_Message", resourceCulture);
             }
         }
         
@@ -840,6 +876,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string InitiatingGitHubLogin_Message {
             get {
                 return ResourceManager.GetString("InitiatingGitHubLogin_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The notes displayed to the user upon completion of a package installation.
+        /// </summary>
+        public static string InstallationNotes_KeywordDescription {
+            get {
+                return ResourceManager.GetString("InstallationNotes_KeywordDescription", resourceCulture);
             }
         }
         
@@ -1645,6 +1690,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The purchase url for acquiring entitlement for the package.
+        /// </summary>
+        public static string PurchaseUrl_KeywordDescription {
+            get {
+                return ResourceManager.GetString("PurchaseUrl_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to GitHub api rate limit exceeded. To extend your rate limit, provide your GitHub token with the &apos;-t&apos; flag or store one using the &apos;token --store&apos; command..
         /// </summary>
         public static string RateLimitExceeded_Message {
@@ -1776,6 +1830,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string ReturnResponse_KeywordDescription {
             get {
                 return ResourceManager.GetString("ReturnResponse_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The return response url to provide additional guidance for expected return codes.
+        /// </summary>
+        public static string ReturnResponseUrl_KeywordDescription {
+            get {
+                return ResourceManager.GetString("ReturnResponseUrl_KeywordDescription", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -2131,6 +2131,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to List of winget arguments the installer does not support.
+        /// </summary>
+        public static string UnsupportedArguments_KeywordDescription {
+            get {
+                return ResourceManager.GetString("UnsupportedArguments_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to List of OS architectures the installer does not support.
         /// </summary>
         public static string UnsupportedOSArchitectures_KeywordDescription {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -862,9 +862,9 @@
   <data name="DisplayVersion_KeywordDescription" xml:space="preserve">
     <value>The DisplayVersion registry value</value>
   </data>
-  <data name="EditAgreements_Message" xml:space="preserve">
-    <value>Would you like to edit the Agreements field?</value>
-    <comment>`Agreements` refers to a specific field name that the user can edit.</comment>
+  <data name="EditObjectTypeField_Message" xml:space="preserve">
+    <value>Would you like to edit the {0} field?</value>
+    <comment>{0} - will be replaced with the name of the object type field</comment>
   </data>
   <data name="ExpectedReturnCodes_KeywordDescription" xml:space="preserve">
     <value>Installer exit codes for common errors</value>
@@ -893,5 +893,26 @@
   <data name="FastForwardUpdateFailed_Message" xml:space="preserve">
     <value>Failed to update fork because the default branch is ahead by {0} commit(s). </value>
     <comment>{0} - represents the number of commits the default branch is ahead by</comment>
+  </data>
+  <data name="DisplayInstallWarnings_KeywordDescription" xml:space="preserve">
+    <value>Indicates whether winget should display a warning message if the install or upgrade is known to interfere with running applications</value>
+  </data>
+  <data name="Documentations_KeywordDescription" xml:space="preserve">
+    <value>List of documentation</value>
+  </data>
+  <data name="DocumentLabel_KeywordDescription" xml:space="preserve">
+    <value>The label of the documentation for providing software guides such as manuals and troubleshooting URLs</value>
+  </data>
+  <data name="DocumentUrl_KeywordDescription" xml:space="preserve">
+    <value>The documentation URL</value>
+  </data>
+  <data name="InstallationNotes_KeywordDescription" xml:space="preserve">
+    <value>The notes displayed to the user upon completion of a package installation</value>
+  </data>
+  <data name="PurchaseUrl_KeywordDescription" xml:space="preserve">
+    <value>The purchase url for acquiring entitlement for the package</value>
+  </data>
+  <data name="ReturnResponseUrl_KeywordDescription" xml:space="preserve">
+    <value>The return response url to provide additional guidance for expected return codes</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -915,4 +915,8 @@
   <data name="ReturnResponseUrl_KeywordDescription" xml:space="preserve">
     <value>The return response url to provide additional guidance for expected return codes</value>
   </data>
+  <data name="UnsupportedArguments_KeywordDescription" xml:space="preserve">
+    <value>List of winget arguments the installer does not support</value>
+    <comment>"winget" is the proper name of the tool</comment>
+  </data>
 </root>

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -11,7 +11,6 @@ namespace Microsoft.WingetCreateCore
     using System.IO;
     using System.Linq;
     using System.Net.Http;
-    using System.Runtime.InteropServices;
     using System.Security.Cryptography;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
@@ -298,7 +297,7 @@ namespace Microsoft.WingetCreateCore
             else
             {
                 // For a single installer, detect the architecture. If no architecture is detected, default to architecture from existing manifest.
-                newInstaller.Architecture = GetArchFromUrl(url) ?? GetMachineType(path)?.ToString().ToEnumOrDefault<InstallerArchitecture>() ?? installer.Architecture;
+                newInstaller.Architecture = GetArchFromUrl(url) ?? GetMachineType(path)?.ToString().ToEnumOrDefault<Architecture>() ?? installer.Architecture;
             }
 
             newInstaller.InstallerUrl = url;
@@ -465,7 +464,7 @@ namespace Microsoft.WingetCreateCore
             var baseInstaller = new Installer();
             baseInstaller.InstallerUrl = url;
             baseInstaller.InstallerSha256 = GetFileHash(path);
-            baseInstaller.Architecture = GetMachineType(path)?.ToString().ToEnumOrDefault<InstallerArchitecture>() ?? InstallerArchitecture.Neutral;
+            baseInstaller.Architecture = GetMachineType(path)?.ToString().ToEnumOrDefault<Architecture>() ?? Architecture.Neutral;
 
             bool parseMsixResult = false;
 
@@ -500,28 +499,28 @@ namespace Microsoft.WingetCreateCore
         /// </summary>
         /// <param name="url">Installer url string.</param>
         /// <returns>Installer architecture enum.</returns>
-        private static InstallerArchitecture? GetArchFromUrl(string url)
+        private static Architecture? GetArchFromUrl(string url)
         {
-            List<InstallerArchitecture> archMatches = new List<InstallerArchitecture>();
+            List<Architecture> archMatches = new List<Architecture>();
 
             // Arm must only be checked if arm64 check fails, otherwise it'll match for arm64 too
             if (Regex.Match(url, "arm64|aarch64", RegexOptions.IgnoreCase).Success)
             {
-                archMatches.Add(InstallerArchitecture.Arm64);
+                archMatches.Add(Architecture.Arm64);
             }
             else if (Regex.Match(url, @"\barm\b", RegexOptions.IgnoreCase).Success)
             {
-                archMatches.Add(InstallerArchitecture.Arm);
+                archMatches.Add(Architecture.Arm);
             }
 
             if (Regex.Match(url, "x64|win64|_64|64-bit", RegexOptions.IgnoreCase).Success)
             {
-                archMatches.Add(InstallerArchitecture.X64);
+                archMatches.Add(Architecture.X64);
             }
 
             if (Regex.Match(url, "x86|win32|ia32|_86|32-bit", RegexOptions.IgnoreCase).Success)
             {
-                archMatches.Add(InstallerArchitecture.X86);
+                archMatches.Add(Architecture.X86);
             }
 
             return archMatches.Count == 1 ? archMatches.Single() : null;
@@ -713,7 +712,7 @@ namespace Microsoft.WingetCreateCore
                         archString.EqualsIC("Arm64") ? "Arm64" :
                         archString.EqualsIC("Arm") ? "Arm" : archString;
 
-                    baseInstaller.Architecture = archString.ToEnumOrDefault<InstallerArchitecture>() ?? InstallerArchitecture.Neutral;
+                    baseInstaller.Architecture = archString.ToEnumOrDefault<Architecture>() ?? Architecture.Neutral;
 
                     if (baseInstaller.InstallerLocale == null)
                     {
@@ -793,7 +792,7 @@ namespace Microsoft.WingetCreateCore
 
         private static void SetInstallerPropertiesFromAppxMetadata(AppxMetadata appxMetadata, Installer installer, InstallerManifest installerManifest)
         {
-            installer.Architecture = appxMetadata.Architecture.ToEnumOrDefault<InstallerArchitecture>() ?? InstallerArchitecture.Neutral;
+            installer.Architecture = appxMetadata.Architecture.ToEnumOrDefault<Architecture>() ?? Architecture.Neutral;
 
             installer.MinimumOSVersion = SetInstallerStringPropertyIfNeeded(installerManifest?.MinimumOSVersion, appxMetadata.MinOSVersion?.ToString());
             installer.PackageFamilyName = SetInstallerStringPropertyIfNeeded(installerManifest?.PackageFamilyName, appxMetadata.PackageFamilyName);
@@ -839,7 +838,7 @@ namespace Microsoft.WingetCreateCore
                         appxMetadatas.Add(new AppxMetadata(appxFile.GetStream()));
                     }
                 }
-                catch (COMException)
+                catch (System.Runtime.InteropServices.COMException)
                 {
                     // Check if package is an Msix
                     var appxMetadata = new AppxMetadata(path);
@@ -862,7 +861,7 @@ namespace Microsoft.WingetCreateCore
 
                 return appxMetadatas.First();
             }
-            catch (COMException)
+            catch (System.Runtime.InteropServices.COMException)
             {
                 // Binary wasn't an MSIX
                 return null;

--- a/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
@@ -35,9 +35,37 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
             get { return _additionalProperties; }
             set { _additionalProperties = value; }
         }
+    
+    
     }
     
-    /// <summary>A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.1.0</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class Documentation 
+    {
+        /// <summary>The label of the documentation for providing software guides such as manuals and troubleshooting URLs.</summary>
+        [Newtonsoft.Json.JsonProperty("DocumentLabel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(100, MinimumLength = 1)]
+        public string DocumentLabel { get; set; }
+    
+        /// <summary>The documentation URL.</summary>
+        [Newtonsoft.Json.JsonProperty("DocumentUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string DocumentUrl { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
+    
+    }
+    
+    /// <summary>A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.2.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class DefaultLocaleManifest 
     {
@@ -162,6 +190,21 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
         public string ReleaseNotesUrl { get; set; }
     
+        /// <summary>The purchase url for acquiring entitlement for the package.</summary>
+        [Newtonsoft.Json.JsonProperty("PurchaseUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string PurchaseUrl { get; set; }
+    
+        /// <summary>The notes displayed to the user upon completion of a package installation.</summary>
+        [Newtonsoft.Json.JsonProperty("InstallationNotes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(256, MinimumLength = 1)]
+        public string InstallationNotes { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("Documentations", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(256)]
+        public System.Collections.Generic.List<Documentation> Documentations { get; set; }
+    
         /// <summary>The manifest type</summary>
         [Newtonsoft.Json.JsonProperty("ManifestType", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
@@ -171,7 +214,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.1.0";
+        public string ManifestVersion { get; set; } = "1.2.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -181,5 +224,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
             get { return _additionalProperties; }
             set { _additionalProperties = value; }
         }
+    
+    
     }
 }

--- a/src/WingetCreateCore/Models/InstallerManifestModels.cs
+++ b/src/WingetCreateCore/Models/InstallerManifestModels.cs
@@ -42,6 +42,30 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [System.Runtime.Serialization.EnumMember(Value = @"pwa")]
         Pwa = 9,
     
+        [System.Runtime.Serialization.EnumMember(Value = @"portable")]
+        Portable = 10,
+    
+    }
+    
+    /// <summary>The installer target architecture</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum Architecture
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"x86")]
+        X86 = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"x64")]
+        X64 = 1,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"arm")]
+        Arm = 2,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"arm64")]
+        Arm64 = 3,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"neutral")]
+        Neutral = 4,
+    
     }
     
     /// <summary>Scope indicates if the installer is per user or per machine</summary>
@@ -243,11 +267,10 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){0,3}$")]
         public string MinimumOSVersion { get; set; }
     
-        /// <summary>The installer target architecture</summary>
         [Newtonsoft.Json.JsonProperty("Architecture", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public InstallerArchitecture Architecture { get; set; }
+        public Architecture Architecture { get; set; }
     
         [Newtonsoft.Json.JsonProperty("InstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -303,7 +326,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(256)]
+        [System.ComponentModel.DataAnnotations.MaxLength(512)]
         public System.Collections.Generic.List<string> FileExtensions { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Dependencies", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -342,6 +365,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("RequireExplicitUpgrade", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? RequireExplicitUpgrade { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("DisplayInstallWarnings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? DisplayInstallWarnings { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
     
@@ -365,7 +391,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
     }
     
-    /// <summary>A representation of a single-file manifest representing an app installers in the OWC. v1.1.0</summary>
+    /// <summary>A representation of a single-file manifest representing an app installers in the OWC. v1.2.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class InstallerManifest 
     {
@@ -434,7 +460,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(256)]
+        [System.ComponentModel.DataAnnotations.MaxLength(512)]
         public System.Collections.Generic.List<string> FileExtensions { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Dependencies", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -484,6 +510,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ElevationRequirement? ElevationRequirement { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("DisplayInstallWarnings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? DisplayInstallWarnings { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("Installers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]
         [System.ComponentModel.DataAnnotations.MinLength(1)]
@@ -499,7 +528,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.1.0";
+        public string ManifestVersion { get; set; } = "1.2.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -551,26 +580,6 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
-    public enum InstallerArchitecture
-    {
-        [System.Runtime.Serialization.EnumMember(Value = @"x86")]
-        X86 = 0,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"x64")]
-        X64 = 1,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"arm")]
-        Arm = 2,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"arm64")]
-        Arm64 = 3,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"neutral")]
-        Neutral = 4,
-    
-    }
-    
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public enum InstallModes
     {
         [System.Runtime.Serialization.EnumMember(Value = @"interactive")]
@@ -594,6 +603,12 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("ReturnResponse", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ExpectedReturnCodeReturnResponse ReturnResponse { get; set; }
+    
+        /// <summary>The return response url to provide additional guidance for expected return codes</summary>
+        [Newtonsoft.Json.JsonProperty("ReturnResponseUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string ReturnResponseUrl { get; set; }
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -671,6 +686,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
         [System.Runtime.Serialization.EnumMember(Value = @"blockedByPolicy")]
         BlockedByPolicy = 14,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"custom")]
+        Custom = 15,
     
     }
     

--- a/src/WingetCreateCore/Models/InstallerManifestModels.cs
+++ b/src/WingetCreateCore/Models/InstallerManifestModels.cs
@@ -371,6 +371,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("UnsupportedArguments", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public System.Collections.Generic.List<UnsupportedArgument> UnsupportedArguments { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("AppsAndFeaturesEntries", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.MaxLength(128)]
         public System.Collections.Generic.List<AppsAndFeaturesEntry> AppsAndFeaturesEntries { get; set; }
@@ -501,6 +504,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("UnsupportedArguments", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public System.Collections.Generic.List<UnsupportedArgument> UnsupportedArguments { get; set; }
     
         [Newtonsoft.Json.JsonProperty("AppsAndFeaturesEntries", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.MaxLength(128)]
@@ -636,6 +642,17 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
         [System.Runtime.Serialization.EnumMember(Value = @"arm64")]
         Arm64 = 3,
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum UnsupportedArgument
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"log")]
+        Log = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"location")]
+        Location = 1,
     
     }
     

--- a/src/WingetCreateCore/Models/InstallerMetadata.cs
+++ b/src/WingetCreateCore/Models/InstallerMetadata.cs
@@ -29,16 +29,16 @@ namespace Microsoft.WingetCreateCore.Models
         /// <summary>
         /// Gets or sets the architecture detected from the URL string.
         /// </summary>
-        public InstallerArchitecture? UrlArchitecture { get; set; }
+        public Architecture? UrlArchitecture { get; set; }
 
         /// <summary>
         /// Gets or sets the architecture detected from the binary.
         /// </summary>
-        public InstallerArchitecture? BinaryArchitecture { get; set; }
+        public Architecture? BinaryArchitecture { get; set; }
 
         /// <summary>
         /// Gets or sets the architecture specified as an override.
         /// </summary>
-        public InstallerArchitecture? OverrideArchitecture { get; set; }
+        public Architecture? OverrideArchitecture { get; set; }
     }
 }

--- a/src/WingetCreateCore/Models/LocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/LocaleManifestModels.cs
@@ -39,7 +39,33 @@ namespace Microsoft.WingetCreateCore.Models.Locale
     
     }
     
-    /// <summary>A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.1.0</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class Documentation 
+    {
+        /// <summary>The label of the documentation for providing software guides such as manuals and troubleshooting URLs.</summary>
+        [Newtonsoft.Json.JsonProperty("DocumentLabel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(100, MinimumLength = 1)]
+        public string DocumentLabel { get; set; }
+    
+        /// <summary>The documentation URL.</summary>
+        [Newtonsoft.Json.JsonProperty("DocumentUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string DocumentUrl { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
+    
+    }
+    
+    /// <summary>A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.2.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class LocaleManifest 
     {
@@ -155,6 +181,21 @@ namespace Microsoft.WingetCreateCore.Models.Locale
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
         public string ReleaseNotesUrl { get; set; }
     
+        /// <summary>The purchase url for acquiring entitlement for the package.</summary>
+        [Newtonsoft.Json.JsonProperty("PurchaseUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string PurchaseUrl { get; set; }
+    
+        /// <summary>The notes displayed to the user upon completion of a package installation.</summary>
+        [Newtonsoft.Json.JsonProperty("InstallationNotes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(256, MinimumLength = 1)]
+        public string InstallationNotes { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("Documentations", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(256)]
+        public System.Collections.Generic.List<Documentation> Documentations { get; set; }
+    
         /// <summary>The manifest type</summary>
         [Newtonsoft.Json.JsonProperty("ManifestType", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
@@ -164,7 +205,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.1.0";
+        public string ManifestVersion { get; set; } = "1.2.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     

--- a/src/WingetCreateCore/Models/SingletonManifestModels.cs
+++ b/src/WingetCreateCore/Models/SingletonManifestModels.cs
@@ -425,6 +425,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("UnsupportedArguments", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public System.Collections.Generic.List<UnsupportedArgument> UnsupportedArguments { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("AppsAndFeaturesEntries", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.MaxLength(128)]
         public System.Collections.Generic.List<AppsAndFeaturesEntry> AppsAndFeaturesEntries { get; set; }
@@ -676,6 +679,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("UnsupportedArguments", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public System.Collections.Generic.List<UnsupportedArgument> UnsupportedArguments { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("AppsAndFeaturesEntries", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.MaxLength(128)]
         public System.Collections.Generic.List<AppsAndFeaturesEntry> AppsAndFeaturesEntries { get; set; }
@@ -807,6 +813,17 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
         [System.Runtime.Serialization.EnumMember(Value = @"arm64")]
         Arm64 = 3,
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum UnsupportedArgument
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"log")]
+        Log = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"location")]
+        Location = 1,
     
     }
     

--- a/src/WingetCreateCore/Models/SingletonManifestModels.cs
+++ b/src/WingetCreateCore/Models/SingletonManifestModels.cs
@@ -39,6 +39,32 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
     }
     
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class Documentation 
+    {
+        /// <summary>The label of the documentation for providing software guides such as manuals and troubleshooting URLs.</summary>
+        [Newtonsoft.Json.JsonProperty("DocumentLabel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(100, MinimumLength = 1)]
+        public string DocumentLabel { get; set; }
+    
+        /// <summary>The documentation URL.</summary>
+        [Newtonsoft.Json.JsonProperty("DocumentUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string DocumentUrl { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
+    
+    }
+    
     /// <summary>Enumeration of supported installer types. InstallerType is required in either root level or individual Installer level</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public enum InstallerType
@@ -72,6 +98,30 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
         [System.Runtime.Serialization.EnumMember(Value = @"pwa")]
         Pwa = 9,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"portable")]
+        Portable = 10,
+    
+    }
+    
+    /// <summary>The installer target architecture</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum Architecture
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"x86")]
+        X86 = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"x64")]
+        X64 = 1,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"arm")]
+        Arm = 2,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"arm64")]
+        Arm64 = 3,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"neutral")]
+        Neutral = 4,
     
     }
     
@@ -274,11 +324,10 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){0,3}$")]
         public string MinimumOSVersion { get; set; }
     
-        /// <summary>The installer target architecture</summary>
         [Newtonsoft.Json.JsonProperty("Architecture", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public InstallerArchitecture Architecture { get; set; }
+        public Architecture Architecture { get; set; }
     
         [Newtonsoft.Json.JsonProperty("InstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -334,7 +383,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(256)]
+        [System.ComponentModel.DataAnnotations.MaxLength(512)]
         public System.Collections.Generic.List<string> FileExtensions { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Dependencies", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -396,7 +445,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
     }
     
-    /// <summary>A representation of a single-file manifest representing an app in the OWC. v1.1.0</summary>
+    /// <summary>A representation of a single-file manifest representing an app in the OWC. v1.2.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class SingletonManifest 
     {
@@ -517,6 +566,21 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
         public string ReleaseNotesUrl { get; set; }
     
+        /// <summary>The purchase url for acquiring entitlement for the package.</summary>
+        [Newtonsoft.Json.JsonProperty("PurchaseUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string PurchaseUrl { get; set; }
+    
+        /// <summary>The notes displayed to the user upon completion of a package installation.</summary>
+        [Newtonsoft.Json.JsonProperty("InstallationNotes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(256, MinimumLength = 1)]
+        public string InstallationNotes { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("Documentations", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(256)]
+        public System.Collections.Generic.List<Documentation> Documentations { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("Channel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.StringLength(16, MinimumLength = 1)]
         public string Channel { get; set; }
@@ -570,7 +634,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(256)]
+        [System.ComponentModel.DataAnnotations.MaxLength(512)]
         public System.Collections.Generic.List<string> FileExtensions { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Dependencies", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -635,7 +699,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.1.0";
+        public string ManifestVersion { get; set; } = "1.2.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -687,26 +751,6 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
-    public enum InstallerArchitecture
-    {
-        [System.Runtime.Serialization.EnumMember(Value = @"x86")]
-        X86 = 0,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"x64")]
-        X64 = 1,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"arm")]
-        Arm = 2,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"arm64")]
-        Arm64 = 3,
-    
-        [System.Runtime.Serialization.EnumMember(Value = @"neutral")]
-        Neutral = 4,
-    
-    }
-    
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public enum InstallModes
     {
         [System.Runtime.Serialization.EnumMember(Value = @"interactive")]
@@ -730,6 +774,12 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ReturnResponse", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ExpectedReturnCodeReturnResponse ReturnResponse { get; set; }
+    
+        /// <summary>The return response url to provide additional guidance for expected return codes</summary>
+        [Newtonsoft.Json.JsonProperty("ReturnResponseUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
+        public string ReturnResponseUrl { get; set; }
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -807,6 +857,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
         [System.Runtime.Serialization.EnumMember(Value = @"blockedByPolicy")]
         BlockedByPolicy = 14,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"custom")]
+        Custom = 15,
     
     }
     

--- a/src/WingetCreateCore/Models/VersionManifestModels.cs
+++ b/src/WingetCreateCore/Models/VersionManifestModels.cs
@@ -8,7 +8,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
 {
     #pragma warning disable // Disable all warnings
 
-    /// <summary>A representation of a multi-file manifest representing an app version in the OWC. v1.1.0</summary>
+    /// <summary>A representation of a multi-file manifest representing an app version in the OWC. v1.2.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class VersionManifest 
     {
@@ -42,7 +42,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.1.0";
+        public string ManifestVersion { get; set; } = "1.2.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
     <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.0" />
     <!--https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#generatepathproperty-->
-    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.1.6" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.3.2" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="NSwag.MSBuild" Version="13.11.1">
@@ -52,8 +52,8 @@
     <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.defaultLocale.1.2.0.json" ModelName="DefaultLocale" />
     <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.installer.1.2.0.json" ModelName="Installer" />
     <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.locale.1.2.0.json" ModelName="Locale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json" ModelName="Singleton" />
     <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.version.1.2.0.json" ModelName="Version" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json" ModelName="Singleton" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Inputs="@(SchemaFiles)" Outputs="@(SchemaFiles -> '$(ProjectDir)Models\%(ModelName)ManifestModels.cs')">

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -49,11 +49,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.1.0\manifest.defaultLocale.1.1.0.json" ModelName="DefaultLocale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.1.0\manifest.installer.1.1.0.json" ModelName="Installer" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.1.0\manifest.locale.1.1.0.json" ModelName="Locale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.1.0\manifest.singleton.1.1.0.json" ModelName="Singleton" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.1.0\manifest.version.1.1.0.json" ModelName="Version" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.defaultLocale.1.2.0.json" ModelName="DefaultLocale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.installer.1.2.0.json" ModelName="Installer" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.locale.1.2.0.json" ModelName="Locale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json" ModelName="Singleton" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.version.1.2.0.json" ModelName="Version" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Inputs="@(SchemaFiles)" Outputs="@(SchemaFiles -> '$(ProjectDir)Models\%(ModelName)ManifestModels.cs')">

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullSingleton1_2.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullSingleton1_2.yaml
@@ -1,0 +1,90 @@
+﻿PackageIdentifier: TestPublisher.FullSingleton1_1
+PackageVersion: 0.1.2.3
+PackageLocale: en-US
+DefaultLocale: en-US
+Publisher: TestPublisher
+PublisherUrl: https://fakeTestUrl.com
+PublisherSupportUrl: https://fakeTestUrl.com
+PrivacyUrl: https://fakeTestUrl.com
+Author: fakeAuthor
+PackageName: Full Singleton 1.1 Test
+PackageUrl: https://fakeTestUrl.com
+License: MIT
+LicenseUrl: https://fakeTestUrl.com
+Copyright: fakeCopyright
+CopyrightUrl: https://fakeTestUrl.com
+ShortDescription: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.
+Description: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deseri
+Moniker: testMoniker
+Tags:
+- testSingleton
+Agreements:
+- AgreementLabel: fakeAgreementLabel
+  AgreementUrl: https://fakeTestUrl.com
+  Agreement: fakeAgreementContent
+ReleaseNotes: fakeReleaseNotes
+ReleaseNotesUrl: https://fakeTestUrl.com
+PurchaseUrl: https://fakeTestUrl.com
+InstallationNotes: fakeInstallationNotes
+Documentations:
+- DocumentLabel: fakeDocumentLabel
+- DocumentUrl: fakeDocumentUrl
+Installers:
+- MinimumOSVersion: 10.0.0.0
+  Architecture: x64
+  InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+  InstallerType: exe
+  InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+  ProductCode: FakeProductCode
+  PackageFamilyName: FakePackageFamilyName
+  InstallModes:
+  - silent
+  InstallerSwitches:
+    Silent: /s
+    Upgrade: /u
+  InstallerSuccessCodes:
+  - 1
+  ExpectedReturnCodes:
+  - InstallerReturnCode: 123
+    ReturnResponse: alreadyInstalled
+    ReturnResponseUrl: https://fakeTestUrl.com
+  UpgradeBehavior: install
+  Commands:
+  - fakeCommand
+  Protocols:
+  - fakeProtocol
+  FileExtensions:
+  - .exe
+  Dependencies:
+    WindowsFeatures:
+    - fakeValue
+    WindowsLibraries:
+    - fakeValue
+    PackageDependencies:
+    - MinimumVersion: 10.0.0.0
+    ExternalDependencies:
+    - fakeValue
+  Markets:
+    AllowedMarkets:
+    - fakeAllowedMarket
+    ExcludedMarkets:
+    - fakeExcludedMarket
+  InstallerAbortsTerminal: true
+  InstallLocationRequired: true
+  RequireExplicitUpgrade: true
+  UnsupportedOSArchitectures:
+  - arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: testName
+    Publisher: testPublisher
+    DisplayVersion: testVersion
+    UpgradeCode: fakeProductCode
+  ElevationRequirement: elevationRequired
+  ReleaseDate: 1-1-2022
+  DisplayInstallWarnings: true
+  UnsupportedArguments:
+  - log
+  - location
+ManifestType: singleton
+ManifestVersion: 1.2.0
+

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -223,10 +223,10 @@ namespace Microsoft.WingetCreateUnitTests
             var archs = new[] { "arm64", "arm", "win64", "win32" };
             var expectedArchs = new[]
             {
-                InstallerArchitecture.Arm64,
-                InstallerArchitecture.Arm,
-                InstallerArchitecture.X64,
-                InstallerArchitecture.X86,
+                Architecture.Arm64,
+                Architecture.Arm,
+                Architecture.X64,
+                Architecture.X86,
             };
 
             TestUtils.InitializeMockDownloads(archs.Select(a => $"{a}/{TestConstants.TestMsiInstaller}").ToArray());
@@ -259,7 +259,7 @@ namespace Microsoft.WingetCreateUnitTests
             Assert.IsNotNull(updatedManifests, "Command should have succeeded");
             foreach (var updatedInstaller in updatedManifests.InstallerManifest.Installers)
             {
-                Assert.AreNotEqual(InstallerArchitecture.Arm64, updatedInstaller.Architecture, "Architecture should not be detected from string.");
+                Assert.AreNotEqual(Architecture.Arm64, updatedInstaller.Architecture, "Architecture should not be detected from string.");
                 Assert.AreNotEqual(initialInstaller.InstallerSha256, updatedInstaller.InstallerSha256, "InstallerSha256 should be updated");
             }
         }
@@ -323,7 +323,7 @@ namespace Microsoft.WingetCreateUnitTests
             TestUtils.InitializeMockDownload();
             TestUtils.SetMockHttpResponseContent(TestConstants.TestExeInstaller);
             string testInstallerUrl = $"https://fakedomain.com/{TestConstants.TestExeInstaller}";
-            InstallerArchitecture expectedArch = InstallerArchitecture.Arm;
+            Architecture expectedArch = Architecture.Arm;
 
             // Test without architecture override should fail.
             (UpdateCommand badCommand, var manifests) =
@@ -371,8 +371,8 @@ namespace Microsoft.WingetCreateUnitTests
         {
             var expectedArchs = new[]
             {
-                InstallerArchitecture.Arm,
-                InstallerArchitecture.X64,
+                Architecture.Arm,
+                Architecture.X64,
             };
 
             string x64ExeInstallerUrl = $"https://fakedomain.com/{TestConstants.TestExeInstaller}";

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -505,6 +505,19 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Ensures that all fields from the Singleton v1.2. manifest can be deserialized and updated correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateFullSingletonVersion1_2()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullSingleton1_2", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+        }
+
+        /// <summary>
         /// Ensures that version specific fields are reset after an update.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -33,6 +33,9 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-US.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.FullSingleton1_2.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.ResetVersionSpecificFields.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Resolves #269 

Changes:
- Adds support for generating and updating manifests using the 1.2 schema

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/270)