### PR TITLE
Add custom YamlDotNet emitter that makes all fields with newlines use literal style.

### DIFF
--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/CharacterValidationTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/CharacterValidationTests.cs
@@ -3,10 +3,13 @@
 
 namespace Microsoft.WingetCreateUnitTests
 {
+    using System;
     using System.IO;
+    using System.Linq;
     using Microsoft.WingetCreateCore;
     using Microsoft.WingetCreateCore.Models.Singleton;
     using NUnit.Framework;
+    using WinGetUtil.Models.V1;
 
     /// <summary>
     /// Unit tests for verifying unicode text and directionality.
@@ -26,6 +29,8 @@ namespace Microsoft.WingetCreateUnitTests
             "नमस्ते धन्यवाद",
             "도망각하갂",
         };
+        
+        
 
         /// <summary>
         /// Verifies text support for unicode characters.
@@ -48,5 +53,45 @@ namespace Microsoft.WingetCreateUnitTests
                 File.Delete(testManifestFilePath);
             }
         }
+
+        /// <summary>
+        /// Verifies that we aren't adding more newlines than expected.
+        /// </summary>
+        [Test]
+        public void VerfiyNewLineSupport()
+        {
+            string[] stringsWithNewLines =
+            {
+                "This\n has\n some newlines.",
+                "So\r\n does this.",
+                "And this does\x85.",
+                "As does this\x2028.",
+                "Me too!\x2029:)",
+            };
+
+            string[] delimiters = {"\r\n", "\r", "\n", "\x85", "\x2028", "\x2029"};
+            string testManifestFilePath = Path.Combine(Path.GetTempPath(), "TestManifest.yaml");
+
+            foreach (var i in stringsWithNewLines)
+            {
+                SingletonManifest written = new SingletonManifest {Description = i};
+                File.WriteAllText(testManifestFilePath, written.ToYaml());
+                SingletonManifest read = Serialization.DeserializeFromPath<SingletonManifest>(testManifestFilePath);
+
+                // we know when written that \r\n and \x85 characters are replaced with \n.
+                var writtenFixed = string.Join(
+                    '\n',
+                    written.Description.Split(new string[] {"\n", "\r\n", "\x85"}, StringSplitOptions.None));
+                
+                Assert.AreEqual
+                (
+                    writtenFixed,
+                    read.Description,
+                    $"String {read.Description} had the wrong number of newlines :(."
+                );
+                File.Delete(testManifestFilePath);
+            }
+        }
+        
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/CharacterValidationTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/CharacterValidationTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.WingetCreateUnitTests
                 SingletonManifest read = Serialization.DeserializeFromPath<SingletonManifest>(testManifestFilePath);
 
                 // we know when written that \r\n and \x85 characters are replaced with \n.
-                var writtenFixed = string.Join('\n', written.Description.Split(new string[] {"\n", "\r\n", "\x85"}, StringSplitOptions.None));
+                var writtenFixed = string.Join('\n', written.Description.Split(new string[] { "\n", "\r\n", "\x85" }, StringSplitOptions.None));
                 
                 Assert.AreEqual(writtenFixed, read.Description, $"String {read.Description} had the wrong number of newlines :(.");
                 File.Delete(testManifestFilePath);

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/CharacterValidationTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/CharacterValidationTests.cs
@@ -9,8 +9,7 @@ namespace Microsoft.WingetCreateUnitTests
     using Microsoft.WingetCreateCore;
     using Microsoft.WingetCreateCore.Models.Singleton;
     using NUnit.Framework;
-    using WinGetUtil.Models.V1;
-
+ 
     /// <summary>
     /// Unit tests for verifying unicode text and directionality.
     /// </summary>
@@ -29,8 +28,6 @@ namespace Microsoft.WingetCreateUnitTests
             "नमस्ते धन्यवाद",
             "도망각하갂",
         };
-        
-        
 
         /// <summary>
         /// Verifies text support for unicode characters.
@@ -69,26 +66,18 @@ namespace Microsoft.WingetCreateUnitTests
                 "Me too!\x2029:)",
             };
 
-            string[] delimiters = {"\r\n", "\r", "\n", "\x85", "\x2028", "\x2029"};
             string testManifestFilePath = Path.Combine(Path.GetTempPath(), "TestManifest.yaml");
 
             foreach (var i in stringsWithNewLines)
             {
-                SingletonManifest written = new SingletonManifest {Description = i};
+                SingletonManifest written = new SingletonManifest { Description = i };
                 File.WriteAllText(testManifestFilePath, written.ToYaml());
                 SingletonManifest read = Serialization.DeserializeFromPath<SingletonManifest>(testManifestFilePath);
 
                 // we know when written that \r\n and \x85 characters are replaced with \n.
-                var writtenFixed = string.Join(
-                    '\n',
-                    written.Description.Split(new string[] {"\n", "\r\n", "\x85"}, StringSplitOptions.None));
+                var writtenFixed = string.Join('\n', written.Description.Split(new string[] {"\n", "\r\n", "\x85"}, StringSplitOptions.None));
                 
-                Assert.AreEqual
-                (
-                    writtenFixed,
-                    read.Description,
-                    $"String {read.Description} had the wrong number of newlines :(."
-                );
+                Assert.AreEqual(writtenFixed, read.Description, $"String {read.Description} had the wrong number of newlines :(.");
                 File.Delete(testManifestFilePath);
             }
         }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?

-----

Resolves #280.

This PR adds a custom emitter for YamlDotNet where when it is serializing to YAML, it will make sure all fields with a newline character are set to use `ScalarStyle.Literal`, which doesn't add newlines to our newlines. Usually, you would just add this to the YamlMember for the property, but since we have a ton of properties that can have newlines, adding partials for all of them seemed to be way harder to support than this. It turns out someone on Stack Overflow [had the exact same problem](https://stackoverflow.com/questions/58431796/change-the-scalar-style-used-for-all-multi-line-strings-when-serialising-a-dynam), so I ~~stole~~ borrowed their solution :)

(It also appears that Rider has decided to reformat this file a lot. I can put it back if needed, but since it's just interpreting the existing .editorconfig, maybe you want to keep it?)

Tested: manually, although I'm happy to write tests if needed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/281)