### PR TITLE
Sync fork prior to creating reference and handle NotFoundException

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -503,9 +503,11 @@ namespace Microsoft.WingetCreateCLI.Commands
                     Logger.ErrorLocalized(nameof(Resources.Error_Prefix), e.Message);
                     return false;
                 }
-                else if (e is NonFastForwardException nonFastForwardException)
+                else if (e is Octokit.NotFoundException)
                 {
-                    Logger.ErrorLocalized(nameof(Resources.FastForwardUpdateFailed_Message), nonFastForwardException.CommitsAheadBy);
+                    // This exception can occur if the client is unable to create a reference due to being behind by too many commits.
+                    // The user will need to manually update their master branch of their winget-pkgs fork.
+                    Logger.ErrorLocalized(nameof(Resources.SyncForkWithUpstream_Message));
                     return false;
                 }
                 else

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -745,15 +745,6 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to update fork because the default branch is ahead by {0} commit(s). .
-        /// </summary>
-        public static string FastForwardUpdateFailed_Message {
-            get {
-                return ResourceManager.GetString("FastForwardUpdateFailed_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to [{0}] value is.
         /// </summary>
         public static string FieldValueIs_Message {
@@ -2028,6 +2019,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string Switches_KeywordDescription {
             get {
                 return ResourceManager.GetString("Switches_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to create a reference to the forked repository. This can be caused when the forked repository is behind by too many commits. Sync your fork and try again..
+        /// </summary>
+        public static string SyncForkWithUpstream_Message {
+            get {
+                return ResourceManager.GetString("SyncForkWithUpstream_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -890,10 +890,6 @@
   <data name="UpgradeCode_KeywordDescription" xml:space="preserve">
     <value>UpgradeCode used for correlation of packages across sources</value>
   </data>
-  <data name="FastForwardUpdateFailed_Message" xml:space="preserve">
-    <value>Failed to update fork because the default branch is ahead by {0} commit(s). </value>
-    <comment>{0} - represents the number of commits the default branch is ahead by</comment>
-  </data>
   <data name="DisplayInstallWarnings_KeywordDescription" xml:space="preserve">
     <value>Indicates whether winget should display a warning message if the install or upgrade is known to interfere with running applications</value>
   </data>
@@ -918,5 +914,8 @@
   <data name="UnsupportedArguments_KeywordDescription" xml:space="preserve">
     <value>List of winget arguments the installer does not support</value>
     <comment>"winget" is the proper name of the tool</comment>
+  </data>
+  <data name="SyncForkWithUpstream_Message" xml:space="preserve">
+    <value>Unable to create a reference to the forked repository. This can be caused when the forked repository is behind by too many commits. Sync your fork and try again.</value>
   </data>
 </root>

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -324,7 +324,7 @@ namespace Microsoft.WingetCreateCore.Common
                     // If the fork is behind by too many commits, syncing will also fail with a NotFoundException.
                     // Updating the fork can fail if it is a non-fast forward update, but this should not be blocking as pull request submission can still proceed.
                     // If creating a reference fails, that means syncing the fork also failed, therefore the user will need to manually sync their repo regardless.
-                    if (!forkSyncAttempted)
+                    if (!forkSyncAttempted && submitToFork)
                     {
                         forkSyncAttempted = true;
                         await this.UpdateForkedRepoWithUpstreamCommits(repo);

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -307,22 +307,30 @@ namespace Microsoft.WingetCreateCore.Common
             var upstreamMasterSha = upstreamMaster.Object.Sha;
 
             Reference newBranch = null;
+            bool forkSyncAttempted = false;
 
             try
             {
-                var retryPolicy = Policy.Handle<ApiException>().WaitAndRetryAsync(3, i => TimeSpan.FromSeconds(i));
+                var retryPolicy = Policy
+                    .Handle<ApiException>()
+                    .Or<NonFastForwardException>()
+                    .WaitAndRetryAsync(3, i => TimeSpan.FromSeconds(i));
+
                 await retryPolicy.ExecuteAsync(async () =>
                 {
-                    try
+                    // Related issue: https://github.com/microsoft/winget-create/issues/282
+                    // There is a known issue where a reference is unable to be created if the fork is behind by too many commits.
+                    // Always attempt to sync fork during first execution in order to mitigate the possibility of this scenario occurring.
+                    // If the fork is behind by too many commits, syncing will also fail with a NotFoundException.
+                    // Updating the fork can fail if it is a non-fast forward update, but this should not be blocking as pull request submission can still proceed.
+                    // If creating a reference fails, that means syncing the fork also failed, therefore the user will need to manually sync their repo regardless.
+                    if (!forkSyncAttempted)
                     {
-                        await this.github.Git.Reference.Create(repo.Id, new NewReference($"refs/{newBranchNameHeads}", upstreamMasterSha));
-                    }
-                    catch (Octokit.NotFoundException)
-                    {
-                        // Creating a reference can sometimes fail with a NotFoundException if the fork is not up to date with the upstream repository.
+                        forkSyncAttempted = true;
                         await this.UpdateForkedRepoWithUpstreamCommits(repo);
-                        throw;
                     }
+
+                    await this.github.Git.Reference.Create(repo.Id, new NewReference($"refs/{newBranchNameHeads}", upstreamMasterSha));
                 });
 
                 // Update from upstream branch master


### PR DESCRIPTION
Fixes #287 

A NotFoundException occurs when the forked repo is behind by too many commits. This fails even when attempting to sync the forked repo with the upstream which nullifies my previous fix #235 

To address this issue, I have added the following changes:
1. Always attempt to sync fork but make it nonblocking if it fails as creating a reference could still possibly succeed. (Example: unable to sync fork because it is a fast-forward update) 
2. Add a friendly error message if a NotFoundException is encountered instructing the user to manually sync their fork. 

Current tests should verify that submission succeeds as this is a minor edge case that is difficult to replicate due to the requirement of the fork needing to be behind by X amount of commits.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/289)