### PR TITLE
Fix null/empty filename string when downloading package file

### DIFF
--- a/src/WingetCreateCore/Common/Extensions.cs
+++ b/src/WingetCreateCore/Common/Extensions.cs
@@ -96,6 +96,16 @@ namespace Microsoft.WingetCreateCore.Common
         }
 
         /// <summary>
+        /// Returns null if the target string is empty.
+        /// </summary>
+        /// <param name="s">Target string value.</param>
+        /// <returns>Null if the string is empty; otherwise the original string value.</returns>
+        public static string NullIfEmpty(this string s)
+        {
+            return string.IsNullOrEmpty(s) ? null : s;
+        }
+
+        /// <summary>
         /// Determines if the properties of an object are all equal to null excluding properties with dictionary type if needed.
         /// </summary>
         /// <param name="o">Object to be evaluated.</param>

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -136,14 +136,15 @@ namespace Microsoft.WingetCreateCore
 
             string urlFile = Path.GetFileName(url.Split('?').Last());
             string contentDispositionFile = response.Content.Headers.ContentDisposition?.FileName?.Trim('"');
+            string requestUrl = response.RequestMessage.RequestUri.ToString();
 
             if (!Directory.Exists(InstallerDownloadPath))
             {
                 Directory.CreateDirectory(InstallerDownloadPath);
             }
 
-            string targetFile = GetNumericFilename(Path.Combine(InstallerDownloadPath, contentDispositionFile ?? urlFile));
-
+            string targetFileName = contentDispositionFile.NullIfEmpty() ?? urlFile.NullIfEmpty() ?? Path.GetFileName(requestUrl);
+            string targetFile = GetNumericFilename(Path.Combine(InstallerDownloadPath, targetFileName));
             using var targetFileStream = File.OpenWrite(targetFile);
             var contentStream = await response.Content.ReadAsStreamAsync();
 

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -136,14 +136,15 @@ namespace Microsoft.WingetCreateCore
 
             string urlFile = Path.GetFileName(url.Split('?').Last());
             string contentDispositionFile = response.Content.Headers.ContentDisposition?.FileName?.Trim('"');
-            string requestUrl = response.RequestMessage.RequestUri.ToString();
+            string requestUrlFileName = Path.GetFileName(response.RequestMessage?.RequestUri?.ToString());
 
             if (!Directory.Exists(InstallerDownloadPath))
             {
                 Directory.CreateDirectory(InstallerDownloadPath);
             }
 
-            string targetFileName = contentDispositionFile.NullIfEmpty() ?? urlFile.NullIfEmpty() ?? Path.GetFileName(requestUrl);
+            // If no relevant filename can be obtained for the installer download, use a temporary filename as last option.
+            string targetFileName = contentDispositionFile.NullIfEmpty() ?? urlFile.NullIfEmpty() ?? requestUrlFileName.NullIfEmpty() ?? Path.GetTempFileName();
             string targetFile = GetNumericFilename(Path.Combine(InstallerDownloadPath, targetFileName));
             using var targetFileStream = File.OpenWrite(targetFile);
             var contentStream = await response.Content.ReadAsStreamAsync();


### PR DESCRIPTION
Fixes #292 

The changes in this PR fix an issue where the target filename used to create the package file is null. This can cause an UnauthorizedAccessException since an empty filename means that the File.OpenWrite is trying to write to a directory instead of a file. To resolve this, I use the filename from the requestUrl as the last option for the filename in case both the contentDispositionFile and urlFile names are both empty. 

Verified manually with the related issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/293)