### PR TITLE
Update manifest version for locale manifests

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -402,6 +402,11 @@ namespace Microsoft.WingetCreateCLI.Commands
             manifests.VersionManifest.ManifestVersion = latestManifestVersion;
             manifests.DefaultLocaleManifest.ManifestVersion = latestManifestVersion;
             manifests.InstallerManifest.ManifestVersion = latestManifestVersion;
+
+            foreach (var localeManifest in manifests.LocaleManifests)
+            {
+                localeManifest.ManifestVersion = latestManifestVersion;
+            }
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.MsixTest/Multifile.MsixTest.locale.en-GB.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.MsixTest/Multifile.MsixTest.locale.en-GB.yaml
@@ -1,0 +1,9 @@
+﻿PackageIdentifier: Multifile.MsixTest
+PackageVersion: 1.2.3.4
+PackageLocale: en-GB
+Publisher: Multifile
+PackageName: MsixTest
+License: MIT
+ShortDescription: Testing WingetCreate with a multifile msix manifest
+ManifestType: locale
+ManifestVersion: 1.0.0

--- a/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
+++ b/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
@@ -6,6 +6,7 @@ namespace Microsoft.WingetCreateTests
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
@@ -112,6 +113,17 @@ namespace Microsoft.WingetCreateTests
             string testFilePath = GetTestFile(manifestFileName);
             var initialManifestContent = new List<string> { File.ReadAllText(testFilePath) };
             return initialManifestContent;
+        }
+
+        /// <summary>
+        /// Obtains the initial manifest content string from the provided manifest directory name.
+        /// </summary>
+        /// <param name="manifestDirName">Manifest directory name string.</param>
+        /// <returns>List of manifest content strings.</returns>
+        public static List<string> GetInitialMultifileManifestContent(string manifestDirName)
+        {
+            string testDirPath = GetTestFile(manifestDirName);
+            return Directory.GetFiles(testDirPath).Select(f => File.ReadAllText(f)).ToList();
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -27,6 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-GB.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.installer.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixes #300 

Change:
Fixes a bug where the manifest version was not getting updated to the latest for locale manifests.

Tests:
Added unit test to verify that the change takes place for locale manifests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/303)