### PR TITLE
Update target framework to .NET6

### DIFF
--- a/src/WingetCreateCLI/Properties/PublishProfiles/x64ReleasePublishProfile.pubxml
+++ b/src/WingetCreateCLI/Properties/PublishProfiles/x64ReleasePublishProfile.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>x64</Platform>
-    <PublishDir>bin\x64\Release\net5.0-windows10.0.22000.0\win-x64\publish\</PublishDir>
+    <PublishDir>bin\x64\Release\net6.0-windows10.0.22000.0\win-x64\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/WingetCreateCLI/Properties/PublishProfiles/x86ReleasePublishProfile.pubxml
+++ b/src/WingetCreateCLI/Properties/PublishProfiles/x86ReleasePublishProfile.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>x86</Platform>
-    <PublishDir>bin\x86\Release\net5.0-windows10.0.22000.0\win-x86\publish\</PublishDir>
+    <PublishDir>bin\x86\Release\net6.0-windows10.0.22000.0\win-x86\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
     <Version>1.1</Version>

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -312,7 +312,10 @@ namespace Microsoft.WingetCreateCore
         /// </summary>
         private class MultilineScalarFlowStyleEmitter : ChainedEventEmitter
         {
-            public MultilineScalarFlowStyleEmitter(IEventEmitter nextEmitter) : base(nextEmitter) { }
+            public MultilineScalarFlowStyleEmitter(IEventEmitter nextEmitter)
+                : base(nextEmitter)
+            {
+            }
 
             public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)
             {
@@ -324,10 +327,11 @@ namespace Microsoft.WingetCreateCore
                         bool isMultiLine = new[] { '\r', '\n', '\x85', '\x2028', '\x2029' }.Any(outString.Contains);
                         if (isMultiLine)
                         {
-                            eventInfo = new ScalarEventInfo(eventInfo.Source) {Style = ScalarStyle.Literal};
+                            eventInfo = new ScalarEventInfo(eventInfo.Source) { Style = ScalarStyle.Literal };
                         }
                     }
                 }
+
                 this.nextEmitter.Emit(eventInfo, emitter);
             }
         }

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -4,7 +4,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <RootNamespace>Microsoft.WingetCreateCore</RootNamespace>
-    <TargetFramework>net5.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <Platforms>x86;x64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/WingetCreateTests/WingetCreateTestExeInstaller/WingetCreateTestExeInstaller.csproj
+++ b/src/WingetCreateTests/WingetCreateTestExeInstaller/WingetCreateTestExeInstaller.csproj
@@ -5,7 +5,7 @@
     <Publisher>Microsoft Corporation</Publisher>
     <Copyright>Microsoft Copyright</Copyright>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Description>Test exe installer for WingetCreateCLI</Description>
     <Company>Microsoft Corporation</Company>
     <Authors>Microsoft Corporation</Authors>

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Platforms>x64;x86</Platforms>


### PR DESCRIPTION
Changes:

Updates the target framework to .NET 6 since .NET 5 is no longer supported.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/304)