### PR TITLE
Create self-contained exe in release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ Click on the individual commands to learn more.
 
 You can use WingetCreate to update your existing app manifest as part of your CI/CD pipeline. For reference, see the final task in this repo's [release Azure pipeline](https://github.com/microsoft/winget-create/blob/main/pipelines/azure-pipelines.release.yml).
 
+If .NET isn't already installed, you can use https://aka.ms/wingetcreate/latest/self-contained, which has .NET built-in, but is a larger download.
+
 ### Using the standalone exe:
-The latest version of the standalone exe can be found at https://aka.ms/wingetcreate/latest, and the latest preview version can be found at https://aka.ms/wingetcreate/preview, both of these require [.NET 5.0](https://dotnet.microsoft.com/en-us/download/dotnet/5.0) to be installed on the build machine.
+The latest version of the standalone exe can be found at https://aka.ms/wingetcreate/latest, and the latest preview version can be found at https://aka.ms/wingetcreate/preview, both of these require [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) to be installed on the build machine.
 
 > Make sure your build machine has the [Microsoft Visual C++ Redistributable for Visual Studio](https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0) already installed. Without this, the standalone WingetCreate exe will fail to execute and likely show a "DllNotFoundException" error.
 
@@ -144,5 +146,3 @@ In short to opt-out, go to `Start`, then select `Settings` > `Privacy` > `Diagno
 You can also opt-out of telemetry by configuring the `settings.json` file and setting the `telemetry.disabled` field to true. More information can be found in our [Settings Command documentation](/doc/settings.md)
 
 See the [privacy statement](/PRIVACY.md) for more details.
-
-## Known Issues

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -44,7 +44,9 @@ jobs:
       version: "$(majorMinorVersion).$(buildVersion).0"
       appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
       appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
+      exeDirSelfContained: '$(appxPackageDir)\selfcontained'
       exeDirFrameworkDependent: '$(appxPackageDir)\dependent'
+      exePathSelfContained: '$(exeDirSelfContained)\WingetCreateCLI\wingetcreate-self-contained.exe'
       exePathFrameworkDependent: '$(exeDirFrameworkDependent)\WingetCreateCLI\wingetcreate.exe'
     pool:
       vmImage: $(vmImageName)
@@ -57,6 +59,7 @@ jobs:
           echo $(version)
           echo $(appxBundlePath)
           echo $(appxBundleFile)
+          echo $(exePathSelfContained)
           echo $(exePathFrameworkDependent)
           echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
           echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
@@ -119,6 +122,15 @@ jobs:
           projects: $(workingDirectory)/**/WingetCreateCLI.csproj
           arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
 
+      - task: DotNetCoreCLI@2
+        displayName: Build standalone, self-contained exe
+        inputs:
+          command: publish
+          publishWebProjects: false
+          zipAfterPublish: false
+          projects: $(workingDirectory)/**/WingetCreateCLI.csproj
+          arguments: "--configuration Release --runtime=win-x64 --output $(exeDirSelfContained) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=true"
+
       - task: MSBuild@1
         displayName: Build Solution
         inputs:
@@ -166,7 +178,9 @@ jobs:
 
       - powershell: |
           ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
+          ren "$(exeDirSelfContained)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate-self-contained.exe
           (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
+          (Get-FileHash -Algorithm SHA256 -Path $(exePathSelfContained)).Hash > "$(exePathSelfContained).txt"
           (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
         displayName: "Create hash files"
 
@@ -177,7 +191,9 @@ jobs:
           flattenFolders: true
           contents: |
             $(exePathFrameworkDependent)
+            $(exePathSelfContained)
             $(exePathFrameworkDependent).txt
+            $(exePathSelfContained).txt
             $(appxBundlePath)
             $(appxBundlePath).txt
 


### PR DESCRIPTION
Reverts some of the changes from #265 by creating the self-contained exe in the release pipeline. This is to support builds that have not yet updated to WS2022.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/305)