### PR TITLE
Implementation for zip manifest support

### DIFF
--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -33,6 +33,9 @@ variables:
   # Build platform
   buildPlatform: "x64"
 
+  # Target framework
+  targetFramework: "net6.0-windows10.0.22000.0"
+
 jobs:
   - job: GetVersion
     variables:
@@ -140,6 +143,6 @@ jobs:
         displayName: Run Tests
         inputs:
           testSelector: "testAssemblies"
-          testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\net5.0-windows10.0.22000.0\WingetCreateTests.dll'
+          testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\$(targetFramework)\WingetCreateTests.dll'
           runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
           overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -211,10 +211,10 @@ namespace Microsoft.WingetCreateCLI.Commands
         }
 
         /// <summary>
-        /// Displays the appropriate warning messages for installers with detected architecture mismatches.
+        /// Displays the appropriate installer architecture warning messages.
         /// </summary>
         /// <param name="installerMetadataList">List of <see cref="InstallerMetadata"/>.</param>
-        protected static void DisplayMismatchedArchitectures(List<InstallerMetadata> installerMetadataList)
+        protected static void DisplayArchitectureWarnings(List<InstallerMetadata> installerMetadataList)
         {
             var mismatchedArchInstallers = installerMetadataList.Where(
                 i => i.UrlArchitecture.HasValue &&
@@ -231,6 +231,19 @@ namespace Microsoft.WingetCreateCLI.Commands
                     Logger.Warn($"{mismatch.InstallerUrl}");
                     Console.WriteLine();
                 }
+            }
+
+            var multipleNestedArchInstallers = installerMetadataList.Where(i => i.MultipleNestedInstallerArchitectures);
+
+            if (multipleNestedArchInstallers.Any())
+            {
+                Logger.WarnLocalized(nameof(Resources.MultipleNestedArchitectures_Message));
+                foreach (var multipleNestedArchInstaller in multipleNestedArchInstallers)
+                {
+                    Logger.Warn($"{multipleNestedArchInstaller.InstallerUrl}");
+                }
+
+                Console.WriteLine();
             }
         }
 

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -26,7 +26,6 @@ namespace Microsoft.WingetCreateCLI.Commands
     using Microsoft.WingetCreateCore.Models.Version;
     using Newtonsoft.Json;
     using Sharprompt;
-    using YamlDotNet.Core.Tokens;
 
     /// <summary>
     /// Command to launch a wizard that prompt users for information to generate a new manifest.
@@ -37,7 +36,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// The url path to the manifest documentation site.
         /// </summary>
-        private const string ManifestDocumentationUrl = "https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.4.0";
+        private const string ManifestDocumentationUrl = "https://aka.ms/winget-manifest-schema";
 
         /// <summary>
         /// Installer types for which we can trust that the detected architecture is correct, so don't need to prompt the user to confirm.
@@ -141,15 +140,15 @@ namespace Microsoft.WingetCreateCLI.Commands
                             .Where(filePath => SupportedInstallerTypeExtensions.Contains(Path.GetExtension(filePath)))
                             .ToList();
 
-                        int fileCount = extractedFiles.Count();
+                        int extractedFilesCount = extractedFiles.Count();
                         List<string> selectedInstallers;
 
-                        if (fileCount == 0)
+                        if (extractedFilesCount == 0)
                         {
                             Logger.ErrorLocalized(nameof(Resources.NoInstallersFoundInArchive_ErrorMessage));
                             return false;
                         }
-                        else if (fileCount == 1)
+                        else if (extractedFilesCount == 1)
                         {
                             selectedInstallers = extractedFiles;
                         }
@@ -363,7 +362,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     PromptInstallerSwitchesForExe(installer);
                 }
 
-                PromptForPortableAlias(installer);
+                PromptForPortableAliasIfApplicable(installer);
 
                 foreach (var requiredProperty in requiredInstallerProperties)
                 {
@@ -399,7 +398,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             }
         }
 
-        private static void PromptForPortableAlias(Installer installer)
+        private static void PromptForPortableAliasIfApplicable(Installer installer)
         {
             if (installer.InstallerType == InstallerType.Portable)
             {

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -60,7 +60,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 yield return new Example(Resources.Example_NewCommand_DownloadInstaller, new NewCommand { InstallerUrls = new string[] { "<InstallerUrl1>", "<InstallerUrl2>, .." } });
                 yield return new Example(Resources.Example_NewCommand_SaveLocallyOrSubmit, new NewCommand
                 {
-                    InstallerUrls = new string[] { "<InstallerUrl1>", "<InstallerUrl2>, .." },
+                    InstallerUrls = new string[] { "<InstallerUrl1>", "<InstallerUrl2>, ..." },
                     OutputDir = "<OutputDirectory>",
                     GitHubToken = "<GitHubPersonalAccessToken>",
                 });
@@ -191,7 +191,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 try
                 {
                     PackageParser.ParsePackages(installerUpdateList, manifests);
-                    DisplayMismatchedArchitectures(installerUpdateList);
+                    DisplayArchitectureWarnings(installerUpdateList);
                 }
                 catch (IOException iOException) when (iOException.HResult == -2147024671)
                 {

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -367,6 +367,9 @@ namespace Microsoft.WingetCreateCLI.Commands
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Markets2, WingetCreateCore.Models.Installer.Markets2>(); // Markets2 is not used, but is required to satisfy mapping configuration.
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Agreement, WingetCreateCore.Models.DefaultLocale.Agreement>();
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Documentation, WingetCreateCore.Models.DefaultLocale.Documentation>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.NestedInstallerFile, WingetCreateCore.Models.Installer.NestedInstallerFile>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.Files, WingetCreateCore.Models.Installer.Files>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.InstallationMetadata, WingetCreateCore.Models.Installer.InstallationMetadata>();
             });
             var mapper = config.CreateMapper();
 

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -376,6 +376,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Represents the default installed package location. Used for deeper installation detection.
+        /// </summary>
+        public static string DefaultInstallLocation_KeywordDescription {
+            get {
+                return ResourceManager.GetString("DefaultInstallLocation_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package meta-data default locale |e.g. en-US|.
         /// </summary>
         public static string DefaultLocale_KeywordDescription {
@@ -772,6 +781,33 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to List of installed files.
+        /// </summary>
+        public static string Files_KeywordDescription {
+            get {
+                return ResourceManager.GetString("Files_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The optional Sha256 of the installed file.
+        /// </summary>
+        public static string FileSha256_KeywordDescription {
+            get {
+                return ResourceManager.GetString("FileSha256_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The optional installed file type.
+        /// </summary>
+        public static string FileType_KeywordDescription {
+            get {
+                return ResourceManager.GetString("FileType_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Filter menu items by typing a search query below..
         /// </summary>
         public static string FilterMenuItems_Message {
@@ -876,6 +912,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string InitiatingGitHubLogin_Message {
             get {
                 return ResourceManager.GetString("InitiatingGitHubLogin_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Details about the installation. Used for deeper installation detection.
+        /// </summary>
+        public static string InstallationMetadata_KeywordDescription {
+            get {
+                return ResourceManager.GetString("InstallationMetadata_KeywordDescription", resourceCulture);
             }
         }
         
@@ -1141,6 +1186,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The optional parameter for invocable files.
+        /// </summary>
+        public static string InvocationParameter_KeywordDescription {
+            get {
+                return ResourceManager.GetString("InvocationParameter_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Overrides default language.
         /// </summary>
         public static string Language_KeywordDescription {
@@ -1380,6 +1434,24 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string NestedInstallerFileNotFound_Error {
             get {
                 return ResourceManager.GetString("NestedInstallerFileNotFound_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List of nested installer files contained inside an archive.
+        /// </summary>
+        public static string NestedInstallerFiles_KeywordDescription {
+            get {
+                return ResourceManager.GetString("NestedInstallerFiles_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The nested installer type contained inside an archive.
+        /// </summary>
+        public static string NestedInstallerType_KeywordDescription {
+            get {
+                return ResourceManager.GetString("NestedInstallerType_KeywordDescription", resourceCulture);
             }
         }
         
@@ -1636,6 +1708,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The command alias to be used for calling the nested portable package.
+        /// </summary>
+        public static string PortableCommandAlias_KeywordDescription {
+            get {
+                return ResourceManager.GetString("PortableCommandAlias_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to What is the command alias of the portable package |e.g. nuget|.
         /// </summary>
         public static string PortableCommandAlias_Message {
@@ -1749,6 +1830,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string RegexFieldValidation_Error {
             get {
                 return ResourceManager.GetString("RegexFieldValidation_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The relative file path to the nested installer file.
+        /// </summary>
+        public static string RelativeFilePath_KeywordDescription {
+            get {
+                return ResourceManager.GetString("RelativeFilePath_KeywordDescription", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1906,7 +1906,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select the installer(s) from the zip package:.
+        ///   Looks up a localized string similar to Select the installer(s) from the zip archive:.
         /// </summary>
         public static string SelectInstallersFromZip_Message {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1375,6 +1375,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Nested installer not found in zip archive: {0}.
+        /// </summary>
+        public static string NestedInstallerFileNotFound_Error {
+            get {
+                return ResourceManager.GetString("NestedInstallerFileNotFound_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Press ENTER to submit the value for each question including accepting the (default) value..
         /// </summary>
         public static string NewCommand_Description {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -2437,7 +2437,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The downloaded zip path exceeds the system-defined maximum length..
+        ///   Looks up a localized string similar to The downloaded zip contains path exceeding the system-defined maximum length..
         /// </summary>
         public static string ZipPathExceedsMaxLength_ErrorMessage {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -475,7 +475,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The DisplayName registry value.
+        ///   Looks up a localized string similar to The DisplayName of the package or file.
         /// </summary>
         public static string DisplayName_KeywordDescription {
             get {
@@ -1416,6 +1416,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string MultipleMatchedInstaller_Error {
             get {
                 return ResourceManager.GetString("MultipleMatchedInstaller_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple nested installer architectures were detected for following archive packages:.
+        /// </summary>
+        public static string MultipleNestedArchitectures_Message {
+            get {
+                return ResourceManager.GetString("MultipleNestedArchitectures_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1132,6 +1132,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package file is not a valid zip archive..
+        /// </summary>
+        public static string InvalidZipFile_ErrorMessage {
+            get {
+                return ResourceManager.GetString("InvalidZipFile_ErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Overrides default language.
         /// </summary>
         public static string Language_KeywordDescription {
@@ -1416,6 +1425,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string NoChangeDetectedInUpdatedManifest_Message {
             get {
                 return ResourceManager.GetString("NoChangeDetectedInUpdatedManifest_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No supported installer(s) found in zip archive..
+        /// </summary>
+        public static string NoInstallersFoundInArchive_ErrorMessage {
+            get {
+                return ResourceManager.GetString("NoInstallersFoundInArchive_ErrorMessage", resourceCulture);
             }
         }
         
@@ -1875,6 +1893,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string SelectAction_Message {
             get {
                 return ResourceManager.GetString("SelectAction_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the installer(s) from the zip package:.
+        /// </summary>
+        public static string SelectInstallersFromZip_Message {
+            get {
+                return ResourceManager.GetString("SelectInstallersFromZip_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -2426,5 +2426,14 @@ namespace Microsoft.WingetCreateCLI.Properties {
                 return ResourceManager.GetString("WritingCacheTokenFailed_Message", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The downloaded zip path exceeds the system-defined maximum length..
+        /// </summary>
+        public static string ZipPathExceedsMaxLength_ErrorMessage {
+            get {
+                return ResourceManager.GetString("ZipPathExceedsMaxLength_ErrorMessage", resourceCulture);
+            }
+        }
     }
 }

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -925,15 +925,45 @@
   <data name="SyncForkWithUpstream_Message" xml:space="preserve">
     <value>Unable to create a reference to the forked repository. This can be caused when the forked repository is behind by too many commits. Sync your fork and try again.</value>
   </data>
+  <data name="DefaultInstallLocation_KeywordDescription" xml:space="preserve">
+    <value>Represents the default installed package location. Used for deeper installation detection</value>
+  </data>
+  <data name="FileSha256_KeywordDescription" xml:space="preserve">
+    <value>The optional Sha256 of the installed file</value>
+  </data>
+  <data name="Files_KeywordDescription" xml:space="preserve">
+    <value>List of installed files</value>
+  </data>
+  <data name="FileType_KeywordDescription" xml:space="preserve">
+    <value>The optional installed file type</value>
+  </data>
+  <data name="InstallationMetadata_KeywordDescription" xml:space="preserve">
+    <value>Details about the installation. Used for deeper installation detection</value>
+  </data>
   <data name="InvalidZipFile_ErrorMessage" xml:space="preserve">
     <value>The package file is not a valid zip archive.</value>
+  </data>
+  <data name="InvocationParameter_KeywordDescription" xml:space="preserve">
+    <value>The optional parameter for invocable files</value>
   </data>
   <data name="NestedInstallerFileNotFound_Error" xml:space="preserve">
     <value>Nested installer not found in zip archive: {0}</value>
     <comment>{0} - represents the relative file path of the nested installer file.</comment>
   </data>
+  <data name="NestedInstallerFiles_KeywordDescription" xml:space="preserve">
+    <value>List of nested installer files contained inside an archive</value>
+  </data>
+  <data name="NestedInstallerType_KeywordDescription" xml:space="preserve">
+    <value>The nested installer type contained inside an archive</value>
+  </data>
   <data name="NoInstallersFoundInArchive_ErrorMessage" xml:space="preserve">
     <value>No supported installer(s) found in zip archive.</value>
+  </data>
+  <data name="PortableCommandAlias_KeywordDescription" xml:space="preserve">
+    <value>The command alias to be used for calling the nested portable package</value>
+  </data>
+  <data name="RelativeFilePath_KeywordDescription" xml:space="preserve">
+    <value>The relative file path to the nested installer file</value>
   </data>
   <data name="SelectInstallersFromZip_Message" xml:space="preserve">
     <value>Select the installer(s) from the zip archive:</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -928,6 +928,10 @@
   <data name="InvalidZipFile_ErrorMessage" xml:space="preserve">
     <value>The package file is not a valid zip archive.</value>
   </data>
+  <data name="NestedInstallerFileNotFound_Error" xml:space="preserve">
+    <value>Nested installer not found in zip archive: {0}</value>
+    <comment>{0} - represents the relative file path of the nested installer file.</comment>
+  </data>
   <data name="NoInstallersFoundInArchive_ErrorMessage" xml:space="preserve">
     <value>No supported installer(s) found in zip archive.</value>
   </data>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -821,7 +821,7 @@
     <value>Various key values under installer's ARP entry</value>
   </data>
   <data name="DisplayName_KeywordDescription" xml:space="preserve">
-    <value>The DisplayName registry value</value>
+    <value>The DisplayName of the package or file</value>
   </data>
   <data name="ElevationRequirement_KeywordDescription" xml:space="preserve">
     <value>The installer's elevation requirement</value>
@@ -967,6 +967,10 @@
   </data>
   <data name="SelectInstallersFromZip_Message" xml:space="preserve">
     <value>Select the installer(s) from the zip archive:</value>
+  </data>
+  <data name="MultipleNestedArchitectures_Message" xml:space="preserve">
+    <value>Multiple nested installer architectures were detected for following archive packages:</value>
+    <comment>{0} - repesents the installer url of the package that triggered the warning</comment>
   </data>
   <data name="ZipPathExceedsMaxLength_ErrorMessage" xml:space="preserve">
     <value>The downloaded zip path exceeds the system-defined maximum length.</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -936,6 +936,6 @@
     <value>No supported installer(s) found in zip archive.</value>
   </data>
   <data name="SelectInstallersFromZip_Message" xml:space="preserve">
-    <value>Select the installer(s) from the zip package:</value>
+    <value>Select the installer(s) from the zip archive:</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -972,6 +972,6 @@
     <value>Multiple nested installer architectures were detected for following archive packages:</value>
   </data>
   <data name="ZipPathExceedsMaxLength_ErrorMessage" xml:space="preserve">
-    <value>The downloaded zip path exceeds the system-defined maximum length.</value>
+    <value>The downloaded zip contains path exceeding the system-defined maximum length.</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -968,4 +968,7 @@
   <data name="SelectInstallersFromZip_Message" xml:space="preserve">
     <value>Select the installer(s) from the zip archive:</value>
   </data>
+  <data name="ZipPathExceedsMaxLength_ErrorMessage" xml:space="preserve">
+    <value>The downloaded zip path exceeds the system-defined maximum length.</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -970,7 +970,6 @@
   </data>
   <data name="MultipleNestedArchitectures_Message" xml:space="preserve">
     <value>Multiple nested installer architectures were detected for following archive packages:</value>
-    <comment>{0} - repesents the installer url of the package that triggered the warning</comment>
   </data>
   <data name="ZipPathExceedsMaxLength_ErrorMessage" xml:space="preserve">
     <value>The downloaded zip path exceeds the system-defined maximum length.</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -925,4 +925,13 @@
   <data name="SyncForkWithUpstream_Message" xml:space="preserve">
     <value>Unable to create a reference to the forked repository. This can be caused when the forked repository is behind by too many commits. Sync your fork and try again.</value>
   </data>
+  <data name="InvalidZipFile_ErrorMessage" xml:space="preserve">
+    <value>The package file is not a valid zip archive.</value>
+  </data>
+  <data name="NoInstallersFoundInArchive_ErrorMessage" xml:space="preserve">
+    <value>No supported installer(s) found in zip archive.</value>
+  </data>
+  <data name="SelectInstallersFromZip_Message" xml:space="preserve">
+    <value>Select the installer(s) from the zip package:</value>
+  </data>
 </root>

--- a/src/WingetCreateCore/Common/Extensions.cs
+++ b/src/WingetCreateCore/Common/Extensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.WingetCreateCore.Common
         /// </summary>
         /// <param name="installerType">The installer type to be evaluated.</param>
         /// <returns>Boolean value indicating whether the installer type is ZIP.</returns>
-        public static bool IsArchiveType(this InstallerType installerType)
+        public static bool IsArchiveType(this InstallerType? installerType)
         {
             return installerType == InstallerType.Zip;
         }

--- a/src/WingetCreateCore/Common/Extensions.cs
+++ b/src/WingetCreateCore/Common/Extensions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.WingetCreateCore.Common
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization;
+    using Microsoft.WingetCreateCore.Models.Installer;
 
     /// <summary>
     /// Functionality for manipulating data related to the Manifest object model.
@@ -88,7 +89,17 @@ namespace Microsoft.WingetCreateCore.Common
         /// <returns>Boolean value indicating whether the path points to a zip file.</returns>
         public static bool IsZipFile(this string path)
         {
-            return Path.GetExtension(path) == ".zip";
+            return Path.GetExtension(path).EqualsIC(".zip");
+        }
+
+        /// <summary>
+        /// Checks if the installerType is a ZIP installer type.
+        /// </summary>
+        /// <param name="installerType">The installer type to be evaluated.</param>
+        /// <returns>Boolean value indicating whether the installer type is ZIP.</returns>
+        public static bool IsArchiveType(this InstallerType installerType)
+        {
+            return installerType == InstallerType.Zip;
         }
 
         /// <summary>

--- a/src/WingetCreateCore/Common/Extensions.cs
+++ b/src/WingetCreateCore/Common/Extensions.cs
@@ -82,6 +82,16 @@ namespace Microsoft.WingetCreateCore.Common
         }
 
         /// <summary>
+        /// Determines if the file is a zip based on the file extension.
+        /// </summary>
+        /// <param name="path">File path to be evaluated.</param>
+        /// <returns>Boolean value indicating whether the path points to a zip file.</returns>
+        public static bool IsZipFile(this string path)
+        {
+            return Path.GetExtension(path) == ".zip";
+        }
+
+        /// <summary>
         /// Returns the enum member attribute value if one exists.
         /// </summary>
         /// <param name="enumVal">Target enum value.</param>

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -489,12 +489,11 @@ namespace Microsoft.WingetCreateCore
             }
 
             Architecture? nestedArchitecture = null;
+            bool parseMsixResult = false;
 
             // There will only be multiple installer paths if there are multiple nested portable installers in an zip archive.
             foreach (string path in installerPaths)
             {
-                bool parseMsixResult = false;
-
                 bool parseResult = ParseExeInstallerType(path, baseInstaller, newInstallers) ||
                     (parseMsixResult = ParseMsix(path, baseInstaller, manifests, newInstallers)) ||
                     ParseMsi(path, baseInstaller, manifests, newInstallers);
@@ -511,24 +510,24 @@ namespace Microsoft.WingetCreateCore
                 }
 
                 nestedArchitecture = baseInstaller.Architecture;
+            }
 
-                // Only capture architecture if installer is non-msix as the architecture for msix installers is deterministic
-                if (!parseMsixResult)
+            // Only capture architecture if installer is non-msix as the architecture for msix installers is deterministic
+            if (!parseMsixResult)
+            {
+                var urlArchitecture = installerMetadata.UrlArchitecture = GetArchFromUrl(baseInstaller.InstallerUrl);
+                installerMetadata.UrlArchitecture = GetArchFromUrl(baseInstaller.InstallerUrl);
+                installerMetadata.BinaryArchitecture = baseInstaller.Architecture;
+
+                var overrideArch = installerMetadata.OverrideArchitecture;
+
+                if (overrideArch.HasValue)
                 {
-                    var urlArchitecture = installerMetadata.UrlArchitecture = GetArchFromUrl(baseInstaller.InstallerUrl);
-                    installerMetadata.UrlArchitecture = GetArchFromUrl(baseInstaller.InstallerUrl);
-                    installerMetadata.BinaryArchitecture = baseInstaller.Architecture;
-
-                    var overrideArch = installerMetadata.OverrideArchitecture;
-
-                    if (overrideArch.HasValue)
-                    {
-                        baseInstaller.Architecture = overrideArch.Value;
-                    }
-                    else if (urlArchitecture.HasValue)
-                    {
-                        baseInstaller.Architecture = urlArchitecture.Value;
-                    }
+                    baseInstaller.Architecture = overrideArch.Value;
+                }
+                else if (urlArchitecture.HasValue)
+                {
+                    baseInstaller.Architecture = urlArchitecture.Value;
                 }
             }
 

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -911,7 +911,7 @@ namespace Microsoft.WingetCreateCore
 
         private static void SetInstallerType(Installer baseInstaller, InstallerType installerType)
         {
-            if (baseInstaller.InstallerType == InstallerType.Zip)
+            if (installerType.IsArchiveType())
             {
                 baseInstaller.NestedInstallerType = (NestedInstallerType)Enum.Parse(typeof(NestedInstallerType), installerType.ToString());
             }

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -470,8 +470,8 @@ namespace Microsoft.WingetCreateCore
             if (installerMetadata.IsZipFile)
             {
                 baseInstaller.InstallerType = InstallerType.Zip;
-                List<string> relativeFilePaths = installerMetadata.RelativeFilePaths;
 
+                List<string> relativeFilePaths = installerMetadata.RelativeFilePaths;
                 // Update target package file path to point to the first nested installer.
                 // Even for multiple nested portables, we only parse the first package.
                 path = Path.Combine(installerMetadata.ExtractedDirectory, relativeFilePaths.First());

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -470,10 +470,11 @@ namespace Microsoft.WingetCreateCore
             if (installerMetadata.IsZipFile)
             {
                 baseInstaller.InstallerType = InstallerType.Zip;
-
                 List<string> relativeFilePaths = installerMetadata.RelativeFilePaths;
+
                 // Update target package file path to point to the first nested installer.
-                // Even for multiple nested portables, we only parse the first package.
+                // Even for multiple nested portables, we only need to parse the first package
+                // since we already verified that the relative file paths exist in the zip archive.
                 path = Path.Combine(installerMetadata.ExtractedDirectory, relativeFilePaths.First());
 
                 List<NestedInstallerFile> nestedInstallerFiles = new List<NestedInstallerFile>();
@@ -732,7 +733,6 @@ namespace Microsoft.WingetCreateCore
                     InstallerType installerType = IsWix(database)
                             ? InstallerType.Wix
                             : InstallerType.Msi;
-
                     SetInstallerType(baseInstaller, installerType);
 
                     var properties = database.Properties.ToList();
@@ -889,7 +889,6 @@ namespace Microsoft.WingetCreateCore
                 }
 
                 baseInstaller.SignatureSha256 = signatureSha256;
-
                 SetInstallerType(baseInstaller, InstallerType.Msix);
 
                 // Add installer nodes for MSIX installers

--- a/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
@@ -65,7 +65,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
     
     }
     
-    /// <summary>A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.2.0</summary>
+    /// <summary>A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.4.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class DefaultLocaleManifest 
     {
@@ -73,7 +73,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
         [Newtonsoft.Json.JsonProperty("PackageIdentifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,3}$")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,7}$")]
         public string PackageIdentifier { get; set; }
     
         /// <summary>The package version</summary>
@@ -214,7 +214,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.2.0";
+        public string ManifestVersion { get; set; } = "1.4.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     

--- a/src/WingetCreateCore/Models/InstallerManifestModels.cs
+++ b/src/WingetCreateCore/Models/InstallerManifestModels.cs
@@ -47,6 +47,39 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
     }
     
+    /// <summary>Enumeration of supported nested installer types contained inside an archive file</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum NestedInstallerType
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"msix")]
+        Msix = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"msi")]
+        Msi = 1,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"appx")]
+        Appx = 2,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"exe")]
+        Exe = 3,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"inno")]
+        Inno = 4,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"nullsoft")]
+        Nullsoft = 5,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"wix")]
+        Wix = 6,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"burn")]
+        Burn = 7,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"portable")]
+        Portable = 8,
+    
+    }
+    
     /// <summary>The installer target architecture</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public enum Architecture
@@ -251,6 +284,32 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
     }
     
+    /// <summary>Details about the installation. Used for deeper installation detection.</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class InstallationMetadata 
+    {
+        /// <summary>Represents the default installed package location. Used for deeper installation detection.</summary>
+        [Newtonsoft.Json.JsonProperty("DefaultInstallLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048, MinimumLength = 1)]
+        public string DefaultInstallLocation { get; set; }
+    
+        /// <summary>List of installed files.</summary>
+        [Newtonsoft.Json.JsonProperty("Files", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(2048)]
+        public System.Collections.Generic.List<Files> Files { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
+    
+    }
+    
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class Installer 
     {
@@ -275,6 +334,14 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("InstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public InstallerType? InstallerType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("NestedInstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public NestedInstallerType? NestedInstallerType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("NestedInstallerFiles", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(1024)]
+        public System.Collections.Generic.List<NestedInstallerFile> NestedInstallerFiles { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Scope", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -382,6 +449,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ElevationRequirement? ElevationRequirement { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("InstallationMetadata", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public InstallationMetadata InstallationMetadata { get; set; }
+    
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
         [Newtonsoft.Json.JsonExtensionData]
@@ -394,14 +464,14 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
     }
     
-    /// <summary>A representation of a single-file manifest representing an app installers in the OWC. v1.2.0</summary>
+    /// <summary>A representation of a single-file manifest representing an app installers in the OWC. v1.4.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class InstallerManifest 
     {
         [Newtonsoft.Json.JsonProperty("PackageIdentifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,3}$")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,7}$")]
         public string PackageIdentifier { get; set; }
     
         [Newtonsoft.Json.JsonProperty("PackageVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -430,6 +500,14 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("InstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public InstallerType? InstallerType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("NestedInstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public NestedInstallerType? NestedInstallerType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("NestedInstallerFiles", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(1024)]
+        public System.Collections.Generic.List<NestedInstallerFile> NestedInstallerFiles { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Scope", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -502,6 +580,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("RequireExplicitUpgrade", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? RequireExplicitUpgrade { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("DisplayInstallWarnings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? DisplayInstallWarnings { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
     
@@ -516,8 +597,8 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ElevationRequirement? ElevationRequirement { get; set; }
     
-        [Newtonsoft.Json.JsonProperty("DisplayInstallWarnings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool? DisplayInstallWarnings { get; set; }
+        [Newtonsoft.Json.JsonProperty("InstallationMetadata", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public InstallationMetadata InstallationMetadata { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Installers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]
@@ -534,7 +615,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.2.0";
+        public string ManifestVersion { get; set; } = "1.4.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -554,13 +635,55 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("PackageIdentifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,3}$")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,7}$")]
         public string PackageIdentifier { get; set; }
     
         [Newtonsoft.Json.JsonProperty("MinimumVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\\/:\*\?""<>\|\x01-\x1f]+$")]
         public string MinimumVersion { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
+    
+    }
+    
+    /// <summary>Represents an installed file.</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class Files 
+    {
+        /// <summary>The relative path to the installed file.</summary>
+        [Newtonsoft.Json.JsonProperty("RelativeFilePath", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(2048, MinimumLength = 1)]
+        public string RelativeFilePath { get; set; }
+    
+        /// <summary>Optional Sha256 of the installed file.</summary>
+        [Newtonsoft.Json.JsonProperty("FileSha256", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[A-Fa-f0-9]{64}$")]
+        public string FileSha256 { get; set; }
+    
+        /// <summary>The optional installed file type. If not specified, the file is treated as other.</summary>
+        [Newtonsoft.Json.JsonProperty("FileType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FilesFileType? FileType { get; set; }
+    
+        /// <summary>Optional parameter for invocable files.</summary>
+        [Newtonsoft.Json.JsonProperty("InvocationParameter", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048, MinimumLength = 1)]
+        public string InvocationParameter { get; set; }
+    
+        /// <summary>Optional display name for invocable files.</summary>
+        [Newtonsoft.Json.JsonProperty("DisplayName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(256, MinimumLength = 1)]
+        public string DisplayName { get; set; }
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -582,6 +705,33 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     
         [System.Runtime.Serialization.EnumMember(Value = @"Windows.Universal")]
         Windows_Universal = 1,
+    
+    }
+    
+    /// <summary>A nested installer file contained inside an archive</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class NestedInstallerFile 
+    {
+        /// <summary>The relative path to the nested installer file</summary>
+        [Newtonsoft.Json.JsonProperty("RelativeFilePath", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(512, MinimumLength = 1)]
+        public string RelativeFilePath { get; set; }
+    
+        /// <summary>The command alias to be used for calling the package. Only applies to the nested portable package</summary>
+        [Newtonsoft.Json.JsonProperty("PortableCommandAlias", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(40, MinimumLength = 1)]
+        public string PortableCommandAlias { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
     
     }
     
@@ -657,55 +807,72 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum FilesFileType
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"launch")]
+        Launch = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"uninstall")]
+        Uninstall = 1,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"other")]
+        Other = 2,
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public enum ExpectedReturnCodeReturnResponse
     {
         [System.Runtime.Serialization.EnumMember(Value = @"packageInUse")]
         PackageInUse = 0,
     
+        [System.Runtime.Serialization.EnumMember(Value = @"packageInUseByApplication")]
+        PackageInUseByApplication = 1,
+    
         [System.Runtime.Serialization.EnumMember(Value = @"installInProgress")]
-        InstallInProgress = 1,
+        InstallInProgress = 2,
     
         [System.Runtime.Serialization.EnumMember(Value = @"fileInUse")]
-        FileInUse = 2,
+        FileInUse = 3,
     
         [System.Runtime.Serialization.EnumMember(Value = @"missingDependency")]
-        MissingDependency = 3,
+        MissingDependency = 4,
     
         [System.Runtime.Serialization.EnumMember(Value = @"diskFull")]
-        DiskFull = 4,
+        DiskFull = 5,
     
         [System.Runtime.Serialization.EnumMember(Value = @"insufficientMemory")]
-        InsufficientMemory = 5,
+        InsufficientMemory = 6,
     
         [System.Runtime.Serialization.EnumMember(Value = @"noNetwork")]
-        NoNetwork = 6,
+        NoNetwork = 7,
     
         [System.Runtime.Serialization.EnumMember(Value = @"contactSupport")]
-        ContactSupport = 7,
+        ContactSupport = 8,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredToFinish")]
-        RebootRequiredToFinish = 8,
+        RebootRequiredToFinish = 9,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredForInstall")]
-        RebootRequiredForInstall = 9,
+        RebootRequiredForInstall = 10,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootInitiated")]
-        RebootInitiated = 10,
+        RebootInitiated = 11,
     
         [System.Runtime.Serialization.EnumMember(Value = @"cancelledByUser")]
-        CancelledByUser = 11,
+        CancelledByUser = 12,
     
         [System.Runtime.Serialization.EnumMember(Value = @"alreadyInstalled")]
-        AlreadyInstalled = 12,
+        AlreadyInstalled = 13,
     
         [System.Runtime.Serialization.EnumMember(Value = @"downgrade")]
-        Downgrade = 13,
+        Downgrade = 14,
     
         [System.Runtime.Serialization.EnumMember(Value = @"blockedByPolicy")]
-        BlockedByPolicy = 14,
+        BlockedByPolicy = 15,
     
         [System.Runtime.Serialization.EnumMember(Value = @"custom")]
-        Custom = 15,
+        Custom = 16,
     
     }
     

--- a/src/WingetCreateCore/Models/InstallerMetadata.cs
+++ b/src/WingetCreateCore/Models/InstallerMetadata.cs
@@ -52,6 +52,11 @@ namespace Microsoft.WingetCreateCore.Models
         public List<string> RelativeFilePaths { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the nested installers in a zip have multiple architectures.
+        /// </summary>
+        public bool MultipleNestedInstallerArchitectures { get; set; }
+
+        /// <summary>
         /// Gets or sets the directory path of the extracted files from the target zip package file.
         /// </summary>
         public string ExtractedDirectory { get; set; }

--- a/src/WingetCreateCore/Models/InstallerMetadata.cs
+++ b/src/WingetCreateCore/Models/InstallerMetadata.cs
@@ -50,5 +50,10 @@ namespace Microsoft.WingetCreateCore.Models
         /// Gets or sets the nested installer files contained inside a zip.
         /// </summary>
         public List<string> RelativeFilePaths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory path of the extracted files from the target zip package file.
+        /// </summary>
+        public string ExtractedDirectory { get; set; }
     }
 }

--- a/src/WingetCreateCore/Models/InstallerMetadata.cs
+++ b/src/WingetCreateCore/Models/InstallerMetadata.cs
@@ -40,5 +40,15 @@ namespace Microsoft.WingetCreateCore.Models
         /// Gets or sets the architecture specified as an override.
         /// </summary>
         public Architecture? OverrideArchitecture { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the installer came from a zip.
+        /// </summary>
+        public bool IsZipFile { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets the nested installer files contained inside a zip.
+        /// </summary>
+        public List<string> RelativeFilePaths { get; set; }
     }
 }

--- a/src/WingetCreateCore/Models/LocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/LocaleManifestModels.cs
@@ -65,7 +65,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
     
     }
     
-    /// <summary>A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.2.0</summary>
+    /// <summary>A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.4.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class LocaleManifest 
     {
@@ -73,7 +73,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
         [Newtonsoft.Json.JsonProperty("PackageIdentifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,3}$")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,7}$")]
         public string PackageIdentifier { get; set; }
     
         /// <summary>The package version</summary>
@@ -205,7 +205,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.2.0";
+        public string ManifestVersion { get; set; } = "1.4.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     

--- a/src/WingetCreateCore/Models/Partials/InstallerPartials.cs
+++ b/src/WingetCreateCore/Models/Partials/InstallerPartials.cs
@@ -29,7 +29,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     /// Partial InstallerManifest class for defining a string type ReleaseDateTimeField.
     /// Workaround for issue with model generating ReleaseDate with DateTimeOffset type.
     /// </summary>
+#pragma warning disable SA1402 // File may only contain a single type
     public partial class InstallerManifest
+#pragma warning restore SA1402 // File may only contain a single type
     {
         /// <summary>
         /// Gets or sets the Release Date time.
@@ -43,7 +45,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     /// Partial Installer class for defining a string type ReleaseDateTime field.
     /// Workaround for issue with model generating ReleaseDate with DateTimeOffset type.
     /// </summary>
+#pragma warning disable SA1402 // File may only contain a single type
     public partial class Installer
+#pragma warning restore SA1402 // File may only contain a single type
     {
         /// <summary>
         /// Gets or sets the Release Date time.
@@ -59,7 +63,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     /// Because of this, the Markets and Markets array classes do not get generated, therefore we need to define them here
     /// under the default NSwag generated name "Markets2".
     /// </summary>
+#pragma warning disable SA1402 // File may only contain a single type
     public partial class Markets2
+#pragma warning restore SA1402 // File may only contain a single type
     {
         /// <summary>
         /// Gets or sets the list of allowed installer target markets.

--- a/src/WingetCreateCore/Models/Partials/SingletonPartials.cs
+++ b/src/WingetCreateCore/Models/Partials/SingletonPartials.cs
@@ -23,7 +23,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     /// Partial SingletonManifest class for defining a string type ReleaseDateTime field.
     /// Workaround for issue with model generating ReleaseDate with DateTimeOffset type.
     /// </summary>
+#pragma warning disable SA1402 // File may only contain a single type
     public partial class SingletonManifest
+#pragma warning restore SA1402 // File may only contain a single type
     {
         /// <summary>
         /// Gets or sets the Release Date time.
@@ -37,7 +39,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     /// Partial Installer class for defining a string type ReleaseDateTime field.
     /// Workaround for issue with model generating ReleaseDate with DateTimeOffset type.
     /// </summary>
+#pragma warning disable SA1402 // File may only contain a single type
     public partial class Installer
+#pragma warning restore SA1402 // File may only contain a single type
     {
         /// <summary>
         /// Gets or sets the Release Date time.
@@ -53,7 +57,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     /// Because of this, the Markets and Markets array classes do not get generated, therefore we need to define them here
     /// under the default NSwag generated name "Markets2".
     /// </summary>
+#pragma warning disable SA1402 // File may only contain a single type
     public partial class Markets2
+#pragma warning restore SA1402 // File may only contain a single type
     {
         /// <summary>
         /// Gets or sets the list of allowed installer target markets.

--- a/src/WingetCreateCore/Models/SingletonManifestModels.cs
+++ b/src/WingetCreateCore/Models/SingletonManifestModels.cs
@@ -104,6 +104,39 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
     }
     
+    /// <summary>Enumeration of supported nested installer types contained inside an archive file</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum NestedInstallerType
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"msix")]
+        Msix = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"msi")]
+        Msi = 1,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"appx")]
+        Appx = 2,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"exe")]
+        Exe = 3,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"inno")]
+        Inno = 4,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"nullsoft")]
+        Nullsoft = 5,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"wix")]
+        Wix = 6,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"burn")]
+        Burn = 7,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"portable")]
+        Portable = 8,
+    
+    }
+    
     /// <summary>The installer target architecture</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public enum Architecture
@@ -308,6 +341,32 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
     }
     
+    /// <summary>Details about the installation. Used for deeper installation detection.</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class InstallationMetadata 
+    {
+        /// <summary>Represents the default installed package location. Used for deeper installation detection.</summary>
+        [Newtonsoft.Json.JsonProperty("DefaultInstallLocation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048, MinimumLength = 1)]
+        public string DefaultInstallLocation { get; set; }
+    
+        /// <summary>List of installed files.</summary>
+        [Newtonsoft.Json.JsonProperty("Files", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(2048)]
+        public System.Collections.Generic.List<Files> Files { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
+    
+    }
+    
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class Installer 
     {
@@ -332,6 +391,14 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("InstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public InstallerType? InstallerType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("NestedInstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public NestedInstallerType? NestedInstallerType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("NestedInstallerFiles", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(1024)]
+        public System.Collections.Generic.List<NestedInstallerFile> NestedInstallerFiles { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Scope", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
@@ -422,6 +489,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("RequireExplicitUpgrade", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? RequireExplicitUpgrade { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("DisplayInstallWarnings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? DisplayInstallWarnings { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
     
@@ -436,6 +506,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ElevationRequirement? ElevationRequirement { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("InstallationMetadata", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public InstallationMetadata InstallationMetadata { get; set; }
+    
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
         [Newtonsoft.Json.JsonExtensionData]
@@ -448,14 +521,14 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
     }
     
-    /// <summary>A representation of a single-file manifest representing an app in the OWC. v1.2.0</summary>
+    /// <summary>A representation of a single-file manifest representing an app in the OWC. v1.4.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class SingletonManifest 
     {
         [Newtonsoft.Json.JsonProperty("PackageIdentifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,3}$")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,7}$")]
         public string PackageIdentifier { get; set; }
     
         [Newtonsoft.Json.JsonProperty("PackageVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -605,6 +678,14 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public InstallerType? InstallerType { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("NestedInstallerType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public NestedInstallerType? NestedInstallerType { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("NestedInstallerFiles", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.MaxLength(1024)]
+        public System.Collections.Generic.List<NestedInstallerFile> NestedInstallerFiles { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("Scope", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public Scope? Scope { get; set; }
@@ -676,6 +757,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("RequireExplicitUpgrade", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? RequireExplicitUpgrade { get; set; }
     
+        [Newtonsoft.Json.JsonProperty("DisplayInstallWarnings", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? DisplayInstallWarnings { get; set; }
+    
         [Newtonsoft.Json.JsonProperty("UnsupportedOSArchitectures", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore, ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public System.Collections.Generic.List<UnsupportedOSArchitecture> UnsupportedOSArchitectures { get; set; }
     
@@ -689,6 +773,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ElevationRequirement", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ElevationRequirement? ElevationRequirement { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("InstallationMetadata", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public InstallationMetadata InstallationMetadata { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Installers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]
@@ -705,7 +792,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.2.0";
+        public string ManifestVersion { get; set; } = "1.4.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -725,13 +812,55 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("PackageIdentifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,3}$")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,7}$")]
         public string PackageIdentifier { get; set; }
     
         [Newtonsoft.Json.JsonProperty("MinimumVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\\/:\*\?""<>\|\x01-\x1f]+$")]
         public string MinimumVersion { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
+    
+    }
+    
+    /// <summary>Represents an installed file.</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class Files 
+    {
+        /// <summary>The relative path to the installed file.</summary>
+        [Newtonsoft.Json.JsonProperty("RelativeFilePath", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(2048, MinimumLength = 1)]
+        public string RelativeFilePath { get; set; }
+    
+        /// <summary>Optional Sha256 of the installed file.</summary>
+        [Newtonsoft.Json.JsonProperty("FileSha256", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[A-Fa-f0-9]{64}$")]
+        public string FileSha256 { get; set; }
+    
+        /// <summary>The optional installed file type. If not specified, the file is treated as other.</summary>
+        [Newtonsoft.Json.JsonProperty("FileType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FilesFileType? FileType { get; set; }
+    
+        /// <summary>Optional parameter for invocable files.</summary>
+        [Newtonsoft.Json.JsonProperty("InvocationParameter", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(2048, MinimumLength = 1)]
+        public string InvocationParameter { get; set; }
+    
+        /// <summary>Optional display name for invocable files.</summary>
+        [Newtonsoft.Json.JsonProperty("DisplayName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(256, MinimumLength = 1)]
+        public string DisplayName { get; set; }
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -753,6 +882,33 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     
         [System.Runtime.Serialization.EnumMember(Value = @"Windows.Universal")]
         Windows_Universal = 1,
+    
+    }
+    
+    /// <summary>A nested installer file contained inside an archive</summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public partial class NestedInstallerFile 
+    {
+        /// <summary>The relative path to the nested installer file</summary>
+        [Newtonsoft.Json.JsonProperty("RelativeFilePath", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required]
+        [System.ComponentModel.DataAnnotations.StringLength(512, MinimumLength = 1)]
+        public string RelativeFilePath { get; set; }
+    
+        /// <summary>The command alias to be used for calling the package. Only applies to the nested portable package</summary>
+        [Newtonsoft.Json.JsonProperty("PortableCommandAlias", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(40, MinimumLength = 1)]
+        public string PortableCommandAlias { get; set; }
+    
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+    
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+    
     
     }
     
@@ -828,55 +984,72 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
+    public enum FilesFileType
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"launch")]
+        Launch = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"uninstall")]
+        Uninstall = 1,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"other")]
+        Other = 2,
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public enum ExpectedReturnCodeReturnResponse
     {
         [System.Runtime.Serialization.EnumMember(Value = @"packageInUse")]
         PackageInUse = 0,
     
+        [System.Runtime.Serialization.EnumMember(Value = @"packageInUseByApplication")]
+        PackageInUseByApplication = 1,
+    
         [System.Runtime.Serialization.EnumMember(Value = @"installInProgress")]
-        InstallInProgress = 1,
+        InstallInProgress = 2,
     
         [System.Runtime.Serialization.EnumMember(Value = @"fileInUse")]
-        FileInUse = 2,
+        FileInUse = 3,
     
         [System.Runtime.Serialization.EnumMember(Value = @"missingDependency")]
-        MissingDependency = 3,
+        MissingDependency = 4,
     
         [System.Runtime.Serialization.EnumMember(Value = @"diskFull")]
-        DiskFull = 4,
+        DiskFull = 5,
     
         [System.Runtime.Serialization.EnumMember(Value = @"insufficientMemory")]
-        InsufficientMemory = 5,
+        InsufficientMemory = 6,
     
         [System.Runtime.Serialization.EnumMember(Value = @"noNetwork")]
-        NoNetwork = 6,
+        NoNetwork = 7,
     
         [System.Runtime.Serialization.EnumMember(Value = @"contactSupport")]
-        ContactSupport = 7,
+        ContactSupport = 8,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredToFinish")]
-        RebootRequiredToFinish = 8,
+        RebootRequiredToFinish = 9,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredForInstall")]
-        RebootRequiredForInstall = 9,
+        RebootRequiredForInstall = 10,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootInitiated")]
-        RebootInitiated = 10,
+        RebootInitiated = 11,
     
         [System.Runtime.Serialization.EnumMember(Value = @"cancelledByUser")]
-        CancelledByUser = 11,
+        CancelledByUser = 12,
     
         [System.Runtime.Serialization.EnumMember(Value = @"alreadyInstalled")]
-        AlreadyInstalled = 12,
+        AlreadyInstalled = 13,
     
         [System.Runtime.Serialization.EnumMember(Value = @"downgrade")]
-        Downgrade = 13,
+        Downgrade = 14,
     
         [System.Runtime.Serialization.EnumMember(Value = @"blockedByPolicy")]
-        BlockedByPolicy = 14,
+        BlockedByPolicy = 15,
     
         [System.Runtime.Serialization.EnumMember(Value = @"custom")]
-        Custom = 15,
+        Custom = 16,
     
     }
     

--- a/src/WingetCreateCore/Models/VersionManifestModels.cs
+++ b/src/WingetCreateCore/Models/VersionManifestModels.cs
@@ -8,7 +8,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
 {
     #pragma warning disable // Disable all warnings
 
-    /// <summary>A representation of a multi-file manifest representing an app version in the OWC. v1.2.0</summary>
+    /// <summary>A representation of a multi-file manifest representing an app version in the OWC. v1.4.0</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.4.3.0 (Newtonsoft.Json v11.0.0.0)")]
     public partial class VersionManifest 
     {
@@ -16,7 +16,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
         [Newtonsoft.Json.JsonProperty("PackageIdentifier", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(128)]
-        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,3}$")]
+        [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}(\.[^\.\s\\/:\*\?""<>\|\x01-\x1f]{1,32}){1,7}$")]
         public string PackageIdentifier { get; set; }
     
         /// <summary>The package version</summary>
@@ -42,7 +42,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.2.0";
+        public string ManifestVersion { get; set; } = "1.4.0";
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
     <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.0" />
     <!--https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#generatepathproperty-->
-    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.3.2" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.3.6" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="NSwag.MSBuild" Version="13.11.1">
@@ -49,11 +49,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.defaultLocale.1.2.0.json" ModelName="DefaultLocale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.installer.1.2.0.json" ModelName="Installer" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.locale.1.2.0.json" ModelName="Locale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.version.1.2.0.json" ModelName="Version" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.2.0\manifest.singleton.1.2.0.json" ModelName="Singleton" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.4.0\manifest.defaultLocale.1.4.0.json" ModelName="DefaultLocale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.4.0\manifest.installer.1.4.0.json" ModelName="Installer" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.4.0\manifest.locale.1.4.0.json" ModelName="Locale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.4.0\manifest.version.1.4.0.json" ModelName="Version" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.4.0\manifest.singleton.1.4.0.json" ModelName="Singleton" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Inputs="@(SchemaFiles)" Outputs="@(SchemaFiles -> '$(ProjectDir)Models\%(ModelName)ManifestModels.cs')">

--- a/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.WingetCreateE2ETests
         [TestCase(TestConstants.TestMsiPackageIdentifier, TestConstants.TestMsiManifest, TestConstants.TestMsiInstaller)]
         [TestCase(TestConstants.TestMultifileMsixPackageIdentifier, TestConstants.TestMultifileMsixManifestDir, TestConstants.TestMsixInstaller)]
         [TestCase(TestConstants.TestPortablePackageIdentifier, TestConstants.TestPortableManifest, TestConstants.TestExeInstaller)]
+        [TestCase(TestConstants.TestZipPackageIdentifier, TestConstants.TestZipManifest, TestConstants.TestZipInstaller)]
         public async Task SubmitAndUpdateInstaller(string packageId, string manifestName, string installerName)
         {
             await this.RunSubmitAndUpdateFlow(packageId, TestUtils.GetTestFile(manifestName), installerName);

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullSingleton1_4.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullSingleton1_4.yaml
@@ -1,4 +1,4 @@
-﻿PackageIdentifier: TestPublisher.FullSingleton1_2
+﻿PackageIdentifier: TestPublisher.FullSingleton1_4
 PackageVersion: 0.1.2.3
 PackageLocale: en-US
 DefaultLocale: en-US
@@ -7,7 +7,7 @@ PublisherUrl: https://fakeTestUrl.com
 PublisherSupportUrl: https://fakeTestUrl.com
 PrivacyUrl: https://fakeTestUrl.com
 Author: fakeAuthor
-PackageName: Full Singleton 1.2 Test
+PackageName: Full Singleton 1.4 Test
 PackageUrl: https://fakeTestUrl.com
 License: MIT
 LicenseUrl: https://fakeTestUrl.com
@@ -85,6 +85,16 @@ Installers:
   UnsupportedArguments:
   - log
   - location
+  NestedInstallerFiles:
+  - RelativeFilePath: RelativeFilePath
+    PortableCommandAlias: PortableCommandAlias  
+  InstallationMetadata:
+    DefaultInstallLocation: "%ProgramFiles%\\TestApp"
+    Files:
+    - RelativeFilePath: "main.exe"
+      FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+      FileType: launch
+      InvocationParameter: "/arg"
 ManifestType: singleton
-ManifestVersion: 1.2.0
+ManifestVersion: 1.4.0
 

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.InvalidRelativeFilePath.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.InvalidRelativeFilePath.yaml
@@ -1,0 +1,17 @@
+﻿PackageIdentifier: TestPublisher.InvalidRelativeFilePath
+PackageVersion: 0.1.2
+PackageName: Test zip app with and invalid relative path
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used for testing a zip package with an invalid relative file path.
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: exe
+  NestedInstallerFiles:
+  - RelativeFilePath: fakeRelativeFilePath.exe
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.SameInstallerDiffArch.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.SameInstallerDiffArch.yaml
@@ -1,0 +1,27 @@
+﻿PackageIdentifier: TestPublisher.SameInstallerDiffArch
+PackageVersion: 0.1.2
+PackageName: Same installer different architecture test
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used to test the update command with a single exe installer.
+InstallerLocale: en-US
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+    ProductCode: FakeProductCode
+    PackageFamilyName: FakePackageFamilyName
+    Platform:
+    - Windows.Desktop
+  - Architecture: x86
+    InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+    ProductCode: FakeProductCode
+    PackageFamilyName: FakePackageFamilyName
+    Platform:
+    - Windows.Desktop
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipMultipleInstallers.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipMultipleInstallers.yaml
@@ -1,0 +1,24 @@
+﻿PackageIdentifier: TestPublisher.ZipMultipleArchitectures
+PackageVersion: 0.1.2
+PackageName: Test zip app
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used for testing a zip package.
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: exe
+  NestedInstallerFiles:
+  - RelativeFilePath: WingetCreateTestExeInstaller.exe
+- Architecture: x86
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: exe
+  NestedInstallerFiles:
+  - RelativeFilePath: WingetCreateTestExeInstaller.exe
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithExe.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithExe.yaml
@@ -1,0 +1,17 @@
+﻿PackageIdentifier: TestPublisher.ZipWithExe
+PackageVersion: 0.1.2
+PackageName: Test zip app with exe
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used for testing a zip package with an exe installer.
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: exe
+  NestedInstallerFiles:
+  - RelativeFilePath: WingetCreateTestExeInstaller.exe
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithMsi.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithMsi.yaml
@@ -1,0 +1,17 @@
+﻿PackageIdentifier: TestPublisher.ZipWithMsi
+PackageVersion: 0.1.2
+PackageName: Test zip app with msi
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used for testing a zip package with an msi installer.
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: msi
+  NestedInstallerFiles:
+  - RelativeFilePath: WingetCreateTestMsiInstaller.msi
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithMsix.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithMsix.yaml
@@ -1,0 +1,24 @@
+﻿PackageIdentifier: TestPublisher.ZipWithMsix
+PackageVersion: 0.1.2
+PackageName: Test zip app with msix
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used for testing a zip package with an msix installer.
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: msix
+  NestedInstallerFiles:
+  - RelativeFilePath: WingetCreateTestMsixInstaller.msixbundle
+- Architecture: x86
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: msix
+  NestedInstallerFiles:
+  - RelativeFilePath: WingetCreateTestMsixInstaller.msixbundle
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithPortable.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.ZipWithPortable.yaml
@@ -1,0 +1,18 @@
+﻿PackageIdentifier: TestPublisher.ZipWithPortable
+PackageVersion: 0.1.2
+PackageName: Test zip app with exe
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest used for testing a zip package with a portable installer.
+Installers:
+- Architecture: x64
+  InstallerType: zip
+  InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+  InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+  NestedInstallerType: portable
+  NestedInstallerFiles:
+  - RelativeFilePath: WingetCreateTestExeInstaller.exe
+    PortableCommandAlias: testAlias.exe
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/WingetCreateE2E.ZipTest.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/WingetCreateE2E.ZipTest.yaml
@@ -1,0 +1,27 @@
+﻿PackageIdentifier: WingetCreateE2E.ZipTest
+PackageName: ZipTest
+PackageVersion: 1.2.3.4
+Publisher: WingetCreateE2E
+Author: Microsoft
+License: MIT
+LicenseUrl: https://github.com/microsoft/winget-create
+MinimumOSVersion: 10.0.0.0
+ShortDescription: Testing WingetCreate with a zip
+PackageLocale: en-US
+Tags: 
+  - Windows Package Manager
+  - winget create
+  - package manager
+  - utility
+  - tool
+  - test
+InstallerType: zip
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://fakedomain.com/WingetCreateTestMsiInstaller.msi
+    InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+    NestedInstallerType: msi
+    NestedInstallerFiles:
+    - RelativeFilePath: WingetCreateTestMsiInstaller.msi
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/WingetCreateE2E.ZipTest.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/WingetCreateE2E.ZipTest.yaml
@@ -18,7 +18,7 @@ Tags:
 InstallerType: zip
 Installers:
   - Architecture: x64
-    InstallerUrl: https://fakedomain.com/WingetCreateTestMsiInstaller.msi
+    InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
     InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
     NestedInstallerType: msi
     NestedInstallerFiles:

--- a/src/WingetCreateTests/WingetCreateTests/TestConstants.cs
+++ b/src/WingetCreateTests/WingetCreateTests/TestConstants.cs
@@ -39,6 +39,11 @@ namespace Microsoft.WingetCreateTests
         public const string TestMsixInstaller = "WingetCreateTestMsixInstaller.msixbundle";
 
         /// <summary>
+        /// File name of the test ZIP installer.
+        /// </summary>
+        public const string TestZipInstaller = "WingetCreateTestZipInstaller.zip";
+
+        /// <summary>
         /// PackageIdentifier for test exe.
         /// </summary>
         public const string TestExePackageIdentifier = "WingetCreateE2E.ExeTest";
@@ -59,6 +64,11 @@ namespace Microsoft.WingetCreateTests
         public const string TestPortablePackageIdentifier = "WingetCreateE2E.PortableTest";
 
         /// <summary>
+        /// PackageIdentifier for test zip.
+        /// </summary>
+        public const string TestZipPackageIdentifier = "WingetCreateE2E.ZipTest";
+
+        /// <summary>
         /// File name of the test exe manifest.
         /// </summary>
         public const string TestExeManifest = "WingetCreateE2E.ExeTest.yaml";
@@ -77,5 +87,10 @@ namespace Microsoft.WingetCreateTests
         /// Path of the directory with the multifile msix test manifests.
         /// </summary>
         public const string TestMultifileMsixManifestDir = "Multifile.MsixTest";
+
+        /// <summary>
+        ///  File name of the test zip manifest.
+        /// </summary>
+        public const string TestZipManifest = "WingetCreateE2E.ZipTest.yaml";
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -5,7 +5,6 @@ namespace Microsoft.WingetCreateUnitTests
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel.DataAnnotations;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -538,6 +538,19 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Ensures that all fields from the Singleton v1.4. manifest can be deserialized and updated correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateFullSingletonVersion1_4()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullSingleton1_4", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+        }
+
+        /// <summary>
         /// Ensures that version specific fields are reset after an update.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -346,6 +346,36 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Verifies that using the same installerURL with multiple architecture overrides can successfully update multiple installers.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateSameInstallerWithDifferentArchitectures()
+        {
+            TestUtils.InitializeMockDownload();
+            TestUtils.SetMockHttpResponseContent(TestConstants.TestExeInstaller);
+            string installerUrl = $"https://fakedomain.com/{TestConstants.TestExeInstaller}";
+            (UpdateCommand command, var initialManifestContent) =
+                GetUpdateCommandAndManifestData("TestPublisher.SameInstallerDiffArch", "1.2.3.4", this.tempPath, new[] { $"{installerUrl}|x64", $"{installerUrl}|x86" });
+
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+
+            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
+            var initialFirstInstaller = initialManifests.SingletonManifest.Installers[0];
+            var initialSecondInstaller = initialManifests.SingletonManifest.Installers[1];
+
+            var updatedFirstInstaller = updatedManifests.InstallerManifest.Installers[0];
+            var updatedSecondInstaller = updatedManifests.InstallerManifest.Installers[1];
+
+            Assert.AreEqual(Architecture.X64, updatedFirstInstaller.Architecture, $"Architecture should be preserved.");
+            Assert.AreEqual(Architecture.X86, updatedSecondInstaller.Architecture, $"Architecture should be preserved.");
+
+            Assert.AreNotEqual(initialFirstInstaller.InstallerSha256, updatedFirstInstaller.InstallerSha256, $"InstallerSha256 should be updated.");
+            Assert.AreNotEqual(initialSecondInstaller.InstallerSha256, updatedSecondInstaller.InstallerSha256, $"InstallerSha256 should be updated.");
+        }
+
+        /// <summary>
         /// Verifies that if a matching failure occurs when trying to perform an architecture override, a warning message is displayed.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
@@ -592,20 +622,50 @@ namespace Microsoft.WingetCreateUnitTests
             Assert.IsTrue(updatedInstaller.Commands[0] == "portableCommand", "Command value should be preserved.");
         }
 
+        /// <summary>
+        /// Ensures that updating a zip package containing an single exe installer works as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         [Test]
-        public async Task UpdateZipNonPortable()
+        public async Task UpdateZipWithExe()
         {
             TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller);
-            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.Zip", null, this.tempPath, null);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.ZipWithExe", null, this.tempPath, null);
             var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
             Assert.IsNotNull(updatedManifests, "Command should have succeeded");
 
             InstallerManifest updatedInstallerManifest = updatedManifests.InstallerManifest;
             var updatedInstaller = updatedInstallerManifest.Installers.First();
 
-            Assert.IsTrue(updatedInstaller.InstallerType == InstallerType.Zip, "InstallerType should be zip");
-            Assert.IsTrue(updatedInstaller.NestedInstallerType == NestedInstallerType.Exe, "NestedInstallerType should be exe");
+            Assert.IsTrue(updatedInstaller.InstallerType == InstallerType.Zip, "InstallerType should be ZIP");
+            Assert.IsTrue(updatedInstaller.NestedInstallerType == NestedInstallerType.Exe, "NestedInstallerType should be EXE");
 
+            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
+            var initialInstaller = initialManifests.SingletonManifest.Installers.First();
+            var initialNestedInstallerFile = initialInstaller.NestedInstallerFiles.First();
+
+            var updatedNestedInstallerFile = updatedInstaller.NestedInstallerFiles.First();
+            Assert.IsTrue(initialNestedInstallerFile.RelativeFilePath == updatedNestedInstallerFile.RelativeFilePath, "RelativeFilePath should be preserved.");
+            Assert.IsTrue(initialInstaller.InstallerSha256 != updatedInstaller.InstallerSha256, "InstallerSha256 should be updated");
+        }
+
+        /// <summary>
+        /// Ensures that updating a zip package containing an single portable installer works as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateZipWithPortable()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.ZipWithPortable", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+
+            InstallerManifest updatedInstallerManifest = updatedManifests.InstallerManifest;
+            var updatedInstaller = updatedInstallerManifest.Installers.First();
+
+            Assert.IsTrue(updatedInstaller.InstallerType == InstallerType.Zip, "InstallerType should be ZIP");
+            Assert.IsTrue(updatedInstaller.NestedInstallerType == NestedInstallerType.Portable, "NestedInstallerType should be PORTABLE");
 
             var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
             var initialInstaller = initialManifests.SingletonManifest.Installers.First();
@@ -614,7 +674,84 @@ namespace Microsoft.WingetCreateUnitTests
             var updatedNestedInstallerFile = updatedInstaller.NestedInstallerFiles.First();
             Assert.IsTrue(initialNestedInstallerFile.RelativeFilePath == updatedNestedInstallerFile.RelativeFilePath, "RelativeFilePath should be preserved.");
             Assert.IsTrue(initialNestedInstallerFile.PortableCommandAlias == updatedNestedInstallerFile.PortableCommandAlias, "PortableCommandAlias should be preserved.");
-            Assert.IsTrue
+            Assert.IsTrue(initialInstaller.InstallerSha256 != updatedInstaller.InstallerSha256, "InstallerSha256 should be updated");
+        }
+
+        /// <summary>
+        /// Ensures that updating a zip package containing an single msi installer works as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateZipWithMsi()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.ZipWithMsi", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+
+            InstallerManifest updatedInstallerManifest = updatedManifests.InstallerManifest;
+            var updatedInstaller = updatedInstallerManifest.Installers.First();
+
+            Assert.IsTrue(updatedInstaller.InstallerType == InstallerType.Zip, "InstallerType should be ZIP");
+            Assert.IsTrue(updatedInstaller.NestedInstallerType == NestedInstallerType.Msi, "NestedInstallerType should be MSI");
+
+            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
+            var initialInstaller = initialManifests.SingletonManifest.Installers.First();
+
+            Assert.IsTrue(initialInstaller.NestedInstallerFiles[0].RelativeFilePath == updatedInstaller.NestedInstallerFiles[0].RelativeFilePath, "RelativeFilePath should be preserved.");
+            Assert.IsTrue(initialInstaller.InstallerSha256 != updatedInstaller.InstallerSha256, "InstallerSha256 should be updated");
+            Assert.IsNotNull(updatedInstaller.ProductCode, "ProductCode should be updated.");
+        }
+
+        /// <summary>
+        /// Ensures that updating a zip package containing an single msix installer works as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateZipWithMsix()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.ZipWithMsix", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+
+            InstallerManifest updatedInstallerManifest = updatedManifests.InstallerManifest;
+            var updatedFirstInstaller = updatedInstallerManifest.Installers[0];
+            var updatedSecondInstaller = updatedInstallerManifest.Installers[1];
+
+            Assert.IsTrue(updatedFirstInstaller.InstallerType == InstallerType.Zip, "InstallerType should be ZIP");
+            Assert.IsTrue(updatedFirstInstaller.NestedInstallerType == NestedInstallerType.Msix, "NestedInstallerType should be MSIX");
+            Assert.IsTrue(updatedSecondInstaller.InstallerType == InstallerType.Zip, "InstallerType should be ZIP");
+            Assert.IsTrue(updatedSecondInstaller.NestedInstallerType == NestedInstallerType.Msix, "NestedInstallerType should be MSIX");
+
+            var initialManifests = Serialization.DeserializeManifestContents(initialManifestContent);
+            var initialInstallers = initialManifests.SingletonManifest.Installers;
+            var initialFirstInstaller = initialInstallers[0];
+            var initialSecondInstaller = initialInstallers[1];
+
+            Assert.IsTrue(initialFirstInstaller.NestedInstallerFiles[0].RelativeFilePath == updatedFirstInstaller.NestedInstallerFiles[0].RelativeFilePath, "RelativeFilePath should be preserved.");
+            Assert.IsTrue(initialSecondInstaller.NestedInstallerFiles[0].RelativeFilePath == updatedSecondInstaller.NestedInstallerFiles[0].RelativeFilePath, "RelativeFilePath should be preserved.");
+
+            Assert.IsNotNull(updatedFirstInstaller.SignatureSha256, "SignatureSha256 should be updated.");
+            Assert.IsNotNull(updatedSecondInstaller.SignatureSha256, "SignatureSha256 should be updated.");
+
+            Assert.IsTrue(initialFirstInstaller.InstallerSha256 != updatedFirstInstaller.InstallerSha256, "InstallerSha256 should be updated");
+            Assert.IsTrue(initialSecondInstaller.InstallerSha256 != updatedSecondInstaller.InstallerSha256, "InstallerSha256 should be updated");
+        }
+
+        /// <summary>
+        /// Verifies that the appropriate error message is displayed if the nested installer is not found.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateZipInvalidRelativeFilePath()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.InvalidRelativeFilePath", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNull(updatedManifests, "Command should have failed");
+            string result = this.sw.ToString();
+            Assert.That(result, Does.Contain(string.Format(Resources.NestedInstallerFileNotFound_Error, "fakeRelativeFilePath.exe")), "Failed to show warning for invalid relative file path.");
         }
 
         private static (UpdateCommand UpdateCommand, List<string> InitialManifestContent) GetUpdateCommandAndManifestData(string id, string version, string outputDir, IEnumerable<string> installerUrls, bool isMultifile = false)

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -36,6 +36,27 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-US.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.InvalidRelativeFilePath.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.ZipWithPortable.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.ZipWithMsix.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.ZipWithMsi.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.SameInstallerDiffArch.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.ZipMultipleInstallers.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.ZipWithExe.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.FullSingleton1_4.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -111,5 +111,8 @@
     <None Update="Resources\TestPublisher.MultipleInstallerApp.yaml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\WingetCreateTestZipInstaller.zip">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -108,6 +108,9 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\WingetCreateE2E.ZipTest.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\WingetCreateE2E.PortableTest.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -36,6 +36,9 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-US.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.FullSingleton1_4.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.Portable.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixes #307 
Resolves #309
Resolves #310

This PR implements the functionality for generating and updating zip manifests.

Changes:
- Updated the manifest version to v1.4
- New command supports extracting a zip file and displaying the available installers to the user if more than one exists. Will skip the installer selection prompt if only one installer exists.
- Update command also supports extracting a zip file. Will check that the relativeFilePaths from the existing manifest point to a valid file in the new installer URL. The updated hash comes from the zip and not from the individual nested installer files.
- Error will be displayed to the user if the zip is not valid, if the zip does not contain any installers, or if the relativeFilePath does not point to an actual file (Update command).
- Updated schema url to an official `aka.ms` vanity url.

Tests:
- Updating a valid and full v1.4 manifest
- Updating a zip with exe
- Updating a zip with msi
- Updating a zip with portable
- Updating a zip with msix
- Updating a zip with an invalid relative file path (does not point to a actual file in the zip)
- E2E test for zip
- Verified new command manually with different zip packages.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/311)