### PR TITLE
Trim string results from prompt

### DIFF
--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -297,9 +297,15 @@ namespace Microsoft.WingetCreateCLI
             Type instanceType = typeof(T);
             Type elementType;
 
-            if (instanceType == typeof(string) || instanceType == typeof(long))
+            if (instanceType == typeof(string))
             {
-                var result = Prompt.Input<T>(message, property.GetValue(model), new[] { FieldValidation.ValidateProperty(model, memberName, instance) });
+
+                string result = Prompt.Input<string>(message, property.GetValue(model), new[] { FieldValidation.ValidateProperty(model, memberName, instance) });
+                property.SetValue(model, result.Trim());
+            }
+            else if (instanceType == typeof(long))
+            {
+                long result = Prompt.Input<long>(message, property.GetValue(model), new[] { FieldValidation.ValidateProperty(model, memberName, instance) });
                 property.SetValue(model, result);
             }
             else if (instanceType.IsEnum)

--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -299,7 +299,6 @@ namespace Microsoft.WingetCreateCLI
 
             if (instanceType == typeof(string))
             {
-
                 string result = Prompt.Input<string>(message, property.GetValue(model), new[] { FieldValidation.ValidateProperty(model, memberName, instance) });
                 property.SetValue(model, result.Trim());
             }


### PR DESCRIPTION
Fixes #316 

Trims the result of the prompt if the type is a string.

Verified manually with repro case in related bug issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/317)