### PR TITLE
Update WindowsPackageManager.Utils to 1.3.8

### DIFF
--- a/src/WingetCreateCore/Models/InstallerManifestModels.cs
+++ b/src/WingetCreateCore/Models/InstallerManifestModels.cs
@@ -389,7 +389,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         public System.Collections.Generic.List<string> Commands { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Protocols", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(16)]
+        [System.ComponentModel.DataAnnotations.MaxLength(64)]
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -537,7 +537,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         public System.Collections.Generic.List<string> Commands { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Protocols", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(16)]
+        [System.ComponentModel.DataAnnotations.MaxLength(64)]
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -844,35 +844,41 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [System.Runtime.Serialization.EnumMember(Value = @"insufficientMemory")]
         InsufficientMemory = 6,
     
+        [System.Runtime.Serialization.EnumMember(Value = @"invalidParameter")]
+        InvalidParameter = 7,
+    
         [System.Runtime.Serialization.EnumMember(Value = @"noNetwork")]
-        NoNetwork = 7,
+        NoNetwork = 8,
     
         [System.Runtime.Serialization.EnumMember(Value = @"contactSupport")]
-        ContactSupport = 8,
+        ContactSupport = 9,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredToFinish")]
-        RebootRequiredToFinish = 9,
+        RebootRequiredToFinish = 10,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredForInstall")]
-        RebootRequiredForInstall = 10,
+        RebootRequiredForInstall = 11,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootInitiated")]
-        RebootInitiated = 11,
+        RebootInitiated = 12,
     
         [System.Runtime.Serialization.EnumMember(Value = @"cancelledByUser")]
-        CancelledByUser = 12,
+        CancelledByUser = 13,
     
         [System.Runtime.Serialization.EnumMember(Value = @"alreadyInstalled")]
-        AlreadyInstalled = 13,
+        AlreadyInstalled = 14,
     
         [System.Runtime.Serialization.EnumMember(Value = @"downgrade")]
-        Downgrade = 14,
+        Downgrade = 15,
     
         [System.Runtime.Serialization.EnumMember(Value = @"blockedByPolicy")]
-        BlockedByPolicy = 15,
+        BlockedByPolicy = 16,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"systemNotSupported")]
+        SystemNotSupported = 17,
     
         [System.Runtime.Serialization.EnumMember(Value = @"custom")]
-        Custom = 16,
+        Custom = 18,
     
     }
     

--- a/src/WingetCreateCore/Models/SingletonManifestModels.cs
+++ b/src/WingetCreateCore/Models/SingletonManifestModels.cs
@@ -446,7 +446,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         public System.Collections.Generic.List<string> Commands { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Protocols", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(16)]
+        [System.ComponentModel.DataAnnotations.MaxLength(64)]
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -714,7 +714,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         public System.Collections.Generic.List<string> Commands { get; set; }
     
         [Newtonsoft.Json.JsonProperty("Protocols", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [System.ComponentModel.DataAnnotations.MaxLength(16)]
+        [System.ComponentModel.DataAnnotations.MaxLength(64)]
         public System.Collections.Generic.List<string> Protocols { get; set; }
     
         [Newtonsoft.Json.JsonProperty("FileExtensions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -1021,35 +1021,41 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [System.Runtime.Serialization.EnumMember(Value = @"insufficientMemory")]
         InsufficientMemory = 6,
     
+        [System.Runtime.Serialization.EnumMember(Value = @"invalidParameter")]
+        InvalidParameter = 7,
+    
         [System.Runtime.Serialization.EnumMember(Value = @"noNetwork")]
-        NoNetwork = 7,
+        NoNetwork = 8,
     
         [System.Runtime.Serialization.EnumMember(Value = @"contactSupport")]
-        ContactSupport = 8,
+        ContactSupport = 9,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredToFinish")]
-        RebootRequiredToFinish = 9,
+        RebootRequiredToFinish = 10,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootRequiredForInstall")]
-        RebootRequiredForInstall = 10,
+        RebootRequiredForInstall = 11,
     
         [System.Runtime.Serialization.EnumMember(Value = @"rebootInitiated")]
-        RebootInitiated = 11,
+        RebootInitiated = 12,
     
         [System.Runtime.Serialization.EnumMember(Value = @"cancelledByUser")]
-        CancelledByUser = 12,
+        CancelledByUser = 13,
     
         [System.Runtime.Serialization.EnumMember(Value = @"alreadyInstalled")]
-        AlreadyInstalled = 13,
+        AlreadyInstalled = 14,
     
         [System.Runtime.Serialization.EnumMember(Value = @"downgrade")]
-        Downgrade = 14,
+        Downgrade = 15,
     
         [System.Runtime.Serialization.EnumMember(Value = @"blockedByPolicy")]
-        BlockedByPolicy = 15,
+        BlockedByPolicy = 16,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"systemNotSupported")]
+        SystemNotSupported = 17,
     
         [System.Runtime.Serialization.EnumMember(Value = @"custom")]
-        Custom = 16,
+        Custom = 18,
     
     }
     

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
     <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.0" />
     <!--https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#generatepathproperty-->
-    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.3.6" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.3.8" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="NSwag.MSBuild" Version="13.11.1">


### PR DESCRIPTION
Updates the Windows Package Manager Utils nuget package from 1.3.6 to 1.3.8 to pull in the latest manifest schema changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/320)