### PR TITLE
Display error message during network connection failure.

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -7,6 +7,7 @@ namespace Microsoft.WingetCreateCLI.Commands
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.WingetCreateCLI.Logging;
@@ -108,6 +109,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                         Logger.Trace("No token found in cache, launching OAuth flow");
                         if (!await this.GetTokenFromOAuth())
                         {
+                            Logger.Trace("Failed to obtain token from OAuth flow.");
                             return false;
                         }
                     }
@@ -398,7 +400,16 @@ namespace Microsoft.WingetCreateCLI.Commands
             Logger.DebugLocalized(nameof(Resources.GitHubAccountMustBeLinked_Message));
             Logger.DebugLocalized(nameof(Resources.ExecutionPaused_Message));
             Console.WriteLine();
-            this.GitHubToken = await GitHubOAuthLoginFlow();
+
+            try
+            {
+                this.GitHubToken = await GitHubOAuthLoginFlow();
+            }
+            catch (WebException)
+            {
+                Logger.ErrorLocalized(nameof(Resources.NetworkConnectionFailure_Message));
+                return false;
+            }
 
             if (string.IsNullOrEmpty(this.GitHubToken))
             {

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -462,6 +462,14 @@ namespace Microsoft.WingetCreateCLI.Commands
                 {
                     Logger.ErrorLocalized(nameof(Resources.RepositoryNotFound_Error), this.WingetRepoOwner, this.WingetRepo);
                 }
+                else if (e is HttpRequestException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.NetworkConnectionFailure_Message));
+                }
+                else
+                {
+                    throw;
+                }
 
                 return false;
             }

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -459,6 +459,11 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <returns>Boolean value indicating whether the package identifier is a duplicate and already exists.</returns>
         private async Task<bool> IsDuplicatePackageIdentifier(string packageIdentifier)
         {
+            if (this.GitHubClient == null)
+            {
+                return false;
+            }
+
             try
             {
                 string exactMatch = await this.GitHubClient.FindPackageId(packageIdentifier);

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -5,7 +5,6 @@ namespace Microsoft.WingetCreateCLI
 {
     using System;
     using System.Linq;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using CommandLine;
     using CommandLine.Text;
@@ -65,10 +64,9 @@ namespace Microsoft.WingetCreateCLI
                             Console.WriteLine();
                         }
                     }
-                    catch (Exception ex) when (ex is Octokit.ApiException || ex is Octokit.RateLimitExceededException || ex is HttpRequestException)
+                    catch (Exception ex) when (ex is Octokit.ApiException || ex is Octokit.RateLimitExceededException)
                     {
                         // Since this is only notifying the user if an update is available, don't block if the token is invalid or a rate limit error is encountered.
-                        // HttpRequestException will occur if there is a network connection failure to GitHub which should not be blocking to allow for manifest generation.
                     }
                 }
                 else

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -5,6 +5,7 @@ namespace Microsoft.WingetCreateCLI
 {
     using System;
     using System.Linq;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using CommandLine;
     using CommandLine.Text;
@@ -64,14 +65,19 @@ namespace Microsoft.WingetCreateCLI
                             Console.WriteLine();
                         }
                     }
-                    catch (Exception ex) when (ex is Octokit.ApiException || ex is Octokit.RateLimitExceededException)
+                    catch (Exception ex) when (ex is Octokit.ApiException || ex is Octokit.RateLimitExceededException || ex is HttpRequestException)
                     {
                         // Since this is only notifying the user if an update is available, don't block if the token is invalid or a rate limit error is encountered.
+                        // HttpRequestException will occur if there is a network connection failure to GitHub which should not be blocking to allow for manifest generation.
                     }
                 }
                 else
                 {
-                    return 1;
+                    // Do not block creating a new manifest if loading the GitHub client fails. InstallerURL could point to a local network.
+                    if (command is not NewCommand)
+                    {
+                        return 1;
+                    }
                 }
             }
 

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1465,6 +1465,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to connect to GitHub. Check your network connection..
+        /// </summary>
+        public static string NetworkConnectionFailure_Message {
+            get {
+                return ResourceManager.GetString("NetworkConnectionFailure_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Press ENTER to submit the value for each question including accepting the (default) value..
         /// </summary>
         public static string NewCommand_Description {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -974,4 +974,7 @@
   <data name="ZipPathExceedsMaxLength_ErrorMessage" xml:space="preserve">
     <value>The downloaded zip contains path exceeding the system-defined maximum length.</value>
   </data>
+  <data name="NetworkConnectionFailure_Message" xml:space="preserve">
+    <value>Failed to connect to GitHub. Check your network connection.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #328 

Shows an explicit error message to the user if winget-create is unable to connect to GitHub when there is no network connection. The error is non-blocking in case connection to GitHub fails, but winget-create is still able to download from a local network.

Also displays the proper error message if GitHub oauth device login flow fails also fails to connect.

Verified behavior manually.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/330)