### PR TITLE
Check if string prompt result is null before setting value

### DIFF
--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -300,7 +300,11 @@ namespace Microsoft.WingetCreateCLI
             if (instanceType == typeof(string))
             {
                 string result = Prompt.Input<string>(message, property.GetValue(model), new[] { FieldValidation.ValidateProperty(model, memberName, instance) });
-                property.SetValue(model, result.Trim());
+
+                if (!string.IsNullOrEmpty(result))
+                {
+                    property.SetValue(model, result.Trim());
+                }
             }
             else if (instanceType == typeof(long))
             {


### PR DESCRIPTION
Changes:

- Checks if the result from a string prompt is empty or null before setting the property. This fixes a bug where a null reference exception was being thrown when attempting to set a null value to one of the string properties.

Verified manually.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/338)