### PR TITLE
Add dotnet install step to release pipeline for esrp signing

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -130,6 +130,12 @@ jobs:
             /p:UapAppxPackageBuildMode=SideloadOnly
             /p:AppxPackageSigningEnabled=false'
 
+      - task: UseDotNet@2
+        displayName: 'Install .NET Core SDK required for ESRPCodeSigning'
+        inputs:
+          packageType: sdk
+          version: '6.x'      
+
       - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
         displayName: "ESRP CodeSigning"
         inputs:


### PR DESCRIPTION
Fixes an issue with ESRP signing by installing .NET Core SDK.

Verified by manually running branch with fix.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/340)