### PR TITLE
Improve handling of multiple nested installers

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -457,21 +457,18 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 if (!string.IsNullOrEmpty(portableCommandAlias))
                 {
-                    List<string> portableCommands = new List<string> { portableCommandAlias };
+                    List<string> portableCommands = new List<string> { portableCommandAlias.Trim() };
                     installer.Commands = portableCommands;
                 }
             }
 
             if (installer.NestedInstallerType == NestedInstallerType.Portable)
             {
-                foreach (NestedInstallerFile nestedInstallerFile in installer.NestedInstallerFiles)
-                {
-                    string portableCommandAlias = Prompt.Input<string>(Resources.PortableCommandAlias_Message);
+                string portableCommandAlias = Prompt.Input<string>(Resources.PortableCommandAlias_Message);
 
-                    if (!string.IsNullOrEmpty(portableCommandAlias))
-                    {
-                        nestedInstallerFile.PortableCommandAlias = portableCommandAlias;
-                    }
+                if (!string.IsNullOrEmpty(portableCommandAlias))
+                {
+                    installer.NestedInstallerFiles.First().PortableCommandAlias = portableCommandAlias.Trim();
                 }
             }
         }

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1472,6 +1472,17 @@ namespace Microsoft.WingetCreateCLI.Properties {
                 return ResourceManager.GetString("Name_KeywordDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Parsing nested installer &apos;{0}&apos; from {1}.
+        /// </summary>
+        public static string NestedInstallerParsing_HelpText
+        {
+            get
+            {
+                return ResourceManager.GetString("NestedInstallerParsing_HelpText", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Nested installer not found in zip archive: {0}.

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -958,6 +958,11 @@
   <data name="InvocationParameter_KeywordDescription" xml:space="preserve">
     <value>The optional parameter for invocable files</value>
   </data>
+  <data name="NestedInstallerParsing_HelpText" xml:space="preserve">
+    <value>Parsing nested installer '{0}' from {1}</value>
+    <comment>{0} - will be replaced with RelativeFilePath of the nested installer
+    {1} - will be replaced by the InstallerUrl</comment>
+  </data>
   <data name="NestedInstallerFileNotFound_Error" xml:space="preserve">
     <value>Nested installer not found in zip archive: {0}</value>
     <comment>{0} - represents the relative file path of the nested installer file.</comment>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
   - #371

### Brief Description

1. Allocate a new installer object for each nested installer so that changes in one nested installer object do not propagate into another
2. As a consequence of the above change, logic needs to be added for merging nested installer files into a single installer in case of `NestedInstallerType: portable`. This is done as:
   * If two (or more) nested portable installers have the same architecture and hash, the only difference would be of RelativeFilePath in both of them; so we merge the two installers
3. Display name of NestedInstallerFile for better clarity before a prompt asking for additional metadata or asking whether the package is a portable.
4. Refactor PortableCommandAliasIfApplicable() as we expect a single NestedInstallerFiles node for each installer inside the method body now.

I've listed some test URLs/manifests in the linked issue

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/372)