### PR TITLE
Add link to GitHub Token instruction to Update doc

### DIFF
--- a/doc/update.md
+++ b/doc/update.md
@@ -51,7 +51,7 @@ The following arguments are available:
 | **-o, --out** |  The output directory where the newly created manifests will be saved locally
 | **-s, --submit** |  Boolean value for submitting to the Windows Package Manager repo. If true, updated manifest will be submitted directly using the provided GitHub Token
 | **-p, --prtitle** |  The title of the pull request submitted to GitHub. Default is "{PackageId} version {Version}"
-| **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.
+| **-t, --token** |  [GitHub personal access token](https://github.com/microsoft/winget-create#github-personal-access-token-classic-permissions) used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. 
 | **-?, --help** |  Gets additional help on this command. |
 
 ## Submit 


### PR DESCRIPTION
Added link to https://github.com/microsoft/winget-create#github-personal-access-token-classic-permissions on the argument line so that people can find it more easily!

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/winget-create/pull/376)