### PR TITLE
Fix wingetcreate update step in release pipeline to handle multiple installer urls

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -230,7 +230,8 @@ jobs:
       manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
       appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
       vcLibsBundleFile: "Microsoft.VCLibs.x64.14.00.Desktop.appx"
-      packageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
+      msixPackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
+      portablePackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/wingetcreate.exe"
     steps:
       - checkout: none
 
@@ -246,5 +247,5 @@ jobs:
           # Download, install, and execute update.
           iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
           Add-AppxPackage $(appxBundleFile)
-          wingetcreate update Microsoft.WingetCreate -u $(packageUrl) -v $(manifestVersion) -t $(GITHUB_PAT) --submit
+          wingetcreate update Microsoft.WingetCreate --urls $(msixPackageUrl) '$(portablePackageUrl)|x64' '$(portablePackageUrl)|x86' -v $(manifestVersion) -t $(GITHUB_PAT) --submit
         displayName: Update package manifest in the OWC


### PR DESCRIPTION
Currently, the release pipeline will fail because the number of installer urls (1 installer (msix)) does not match the number of installer urls currently specified in the winget pkgs repository (3 installers (msix, portable x64, portable x86)). 

This change includes those installers using the override argument so that the update will succeed and submit to the repo.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/393&drop=dogfoodAlpha