### PR TITLE
Improve ZIP handling in interactive update

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -280,32 +280,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                     // Obtain all possible relative file paths and check if there is a match.
                     List<string> relativeFilePaths = installerManifest.Installers.SelectMany(i => i.NestedInstallerFiles.Select(x => x.RelativeFilePath)).Distinct().ToList();
-                    string extractDirectory = Path.Combine(PackageParser.InstallerDownloadPath, Path.GetFileNameWithoutExtension(packageFile));
-
-                    if (Directory.Exists(extractDirectory))
-                    {
-                        Directory.Delete(extractDirectory, true);
-                    }
-
-                    try
-                    {
-                        ZipFile.ExtractToDirectory(packageFile, extractDirectory, true);
-                    }
-                    catch (Exception ex)
-                    {
-                        if (ex is InvalidDataException || ex is IOException || ex is NotSupportedException)
-                        {
-                            Logger.ErrorLocalized(nameof(Resources.InvalidZipFile_ErrorMessage), ex);
-                            return null;
-                        }
-                        else if (ex is PathTooLongException)
-                        {
-                            Logger.ErrorLocalized(nameof(Resources.ZipPathExceedsMaxLength_ErrorMessage), ex);
-                            return null;
-                        }
-
-                        throw;
-                    }
+                    string extractDirectory = ExtractArchiveAndRetrieveDirectoryPath(packageFile);
 
                     installerUpdate.RelativeFilePaths = new List<string>();
 
@@ -408,6 +383,37 @@ namespace Microsoft.WingetCreateCLI.Commands
             }
 
             return manifests;
+        }
+
+        private static string ExtractArchiveAndRetrieveDirectoryPath(string packageFilePath)
+        {
+            string extractDirectory = Path.Combine(PackageParser.InstallerDownloadPath, Path.GetFileNameWithoutExtension(packageFilePath));
+
+            if (Directory.Exists(extractDirectory))
+            {
+                Directory.Delete(extractDirectory, true);
+            }
+
+            try
+            {
+                ZipFile.ExtractToDirectory(packageFilePath, extractDirectory, true);
+                return extractDirectory;
+            }
+            catch (Exception ex)
+            {
+                if (ex is InvalidDataException || ex is IOException || ex is NotSupportedException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.InvalidZipFile_ErrorMessage), ex);
+                    return null;
+                }
+                else if (ex is PathTooLongException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.ZipPathExceedsMaxLength_ErrorMessage), ex);
+                    return null;
+                }
+
+                throw;
+            }
         }
 
         private static Manifests ConvertSingletonToMultifileManifest(WingetCreateCore.Models.Singleton.SingletonManifest singletonManifest)
@@ -659,6 +665,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             // Clone the list of installers in order to preserve initial values.
             Manifests originalManifest = new Manifests { InstallerManifest = new InstallerManifest() };
+            ShiftFieldsFromRootToInstallerLevel(manifests.InstallerManifest);
             originalManifest.InstallerManifest.Installers = manifests.CloneInstallers();
 
             do
@@ -721,7 +728,24 @@ namespace Microsoft.WingetCreateCLI.Commands
                 {
                     continue;
                 }
-                else if (!PackageParser.ParsePackageAndUpdateInstallerNode(installer, packageFile, url))
+
+                if (packageFile.IsZipFile())
+                {
+                    string extractDirectory = ExtractArchiveAndRetrieveDirectoryPath(packageFile);
+                    string relativeFilePath = installer.NestedInstallerFiles.First().RelativeFilePath;
+                    string pathToNestedInstaller = Path.Combine(extractDirectory, relativeFilePath);
+                    if (File.Exists(pathToNestedInstaller))
+                    {
+                        packageFile = pathToNestedInstaller;
+                    }
+                    else
+                    {
+                        Logger.ErrorLocalized(nameof(Resources.UnmatchedNestedInstaller_Error), relativeFilePath, url);
+                        continue;
+                    }
+                }
+
+                if (!PackageParser.ParsePackageAndUpdateInstallerNode(installer, packageFile, url))
                 {
                     Logger.ErrorLocalized(nameof(Resources.PackageParsing_Error), url);
                     Console.WriteLine();

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1472,17 +1472,6 @@ namespace Microsoft.WingetCreateCLI.Properties {
                 return ResourceManager.GetString("Name_KeywordDescription", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Parsing nested installer &apos;{0}&apos; from {1}.
-        /// </summary>
-        public static string NestedInstallerParsing_HelpText
-        {
-            get
-            {
-                return ResourceManager.GetString("NestedInstallerParsing_HelpText", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to Nested installer not found in zip archive: {0}.
@@ -1499,6 +1488,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string NestedInstallerFiles_KeywordDescription {
             get {
                 return ResourceManager.GetString("NestedInstallerFiles_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parsing nested installer &apos;{0}&apos; from {1}.
+        /// </summary>
+        public static string NestedInstallerParsing_HelpText {
+            get {
+                return ResourceManager.GetString("NestedInstallerParsing_HelpText", resourceCulture);
             }
         }
         
@@ -1881,7 +1879,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The title of the pull request submitted to GitHub.
+        ///   Looks up a localized string similar to The title of the pull request submitted to GitHub..
         /// </summary>
         public static string PullRequestTitle_HelpText {
             get {
@@ -2363,6 +2361,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string UnmatchedInstaller_Error {
             get {
                 return ResourceManager.GetString("UnmatchedInstaller_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No matches found for &quot;{0}&quot; from {1}.
+        /// </summary>
+        public static string UnmatchedNestedInstaller_Error {
+            get {
+                return ResourceManager.GetString("UnmatchedNestedInstaller_Error", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1009,4 +1009,7 @@
   <data name="Example_UpdateCommand_OverrideScope" xml:space="preserve">
     <value>Override the scope of an installer</value>
   </data>
+  <data name="UnmatchedNestedInstaller_Error" xml:space="preserve">
+    <value>No matches found for "{0}" from {1}</value>
+  </data>
 </root>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
   - #397
   
This change makes it so that the zip archive is extracted in interactive update as well and the path to the nested installer is used in other functions. Made the logic of extracting and determining path of the nested installer into a function as it's common between autonomous and interactive updates.

The logic is based off of the fact that if InstallerType is ZIP, there will always be atleast one NestedInstallerFile node in the manifest that contains RelativeFilePath key and the first matching RelativeFilePath from an older manifest is used as the path to the nested installer. Multiple RelativeFilePath nodes under NestedInstallerFiles are only possible if the NestedInstallerType is portable. In this PR, we do not check the InstallerType of all RelativeFilePath nodes for NestedInstallerType: portable. The assumption is that it's very rare that if an older version contained all portable RelativeFilePath objects, then one of them has changed in newer version to be an another InstallerType (e.g. MSI, nullsoft etc). In case of portables as well, only the first matching RelativeFilePath object is passed to determine the InstallerType to keep the logic simple.

Shifting of values from root to installer is needed in cases where the NestedInstallerFiles object is common between all installer nodes and is present in the root of the manifest instead for better readability. One of the many examples of such manifests is [junnegun.fzf](https://github.com/microsoft/winget-pkgs/blob/master/manifests/j/junegunn/fzf/0.42.0/junegunn.fzf.installer.yaml). Since the interactive update only works by reading the `Installers` node under the installer manifest, we need a way to read the NestedInstallerFiles in the root of the manifest. I did it by shifting all related values to installer level at the start of the interactive update. Ofcourse this comes at a cost of slightly more verbose manifest, but I think it's okay for now considering the benefit of a successful update. We can make another function ShiftInstallerValuesToRoot to take out common fields to the root level but I think that's beyond the scope of this PR as it's applicable to `new`, autonomous `update` commands as well and being tracked in issue https://github.com/microsoft/winget-create/issues/185

   
-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/398&drop=dogfoodAlpha