### PR TITLE
Add ARM machine types

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -52,6 +52,9 @@ namespace Microsoft.WingetCreateCore
         {
             X86 = 0x014c,
             X64 = 0x8664,
+            Arm = 0x01c0,
+            Armv7 = 0x01c4,
+            Arm64 = 0xaa64,
         }
 
         private enum CompatibilitySet
@@ -628,12 +631,23 @@ namespace Microsoft.WingetCreateCore
                     {
                         MachineType machineType = (MachineType)bw.ReadUInt16();
 
-                        return machineType;
+                        return GetCompatibleMachineType(machineType);
                     }
                 }
             }
 
             return null;
+        }
+
+        private static MachineType GetCompatibleMachineType(MachineType type)
+        {
+            switch (type)
+            {
+                case MachineType.Armv7:
+                    return MachineType.Arm;
+                default:
+                    return type;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
   - Resolves #406

Reference: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#machine-types

In cases where we don't get the architecture from URL, winget-create parses the portable exe for the architecture. Need to add these extra values so that we can correctly parse out ARM packages.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/407&drop=dogfoodAlpha