### PR TITLE
Add test for installer properties override

### DIFF
--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.OverrideInstallerFields.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.OverrideInstallerFields.yaml
@@ -1,0 +1,216 @@
+PackageIdentifier: TestPublisher.OverrideInstallerFields
+PackageVersion: 0.1.2
+PackageName: Override installer level fields by root fields
+Publisher: Test publisher
+License: MIT
+ShortDescription: A manifest that verifies that installer level fields are overridden by root fields.
+Description: |-
+  Expected flow:
+
+  1) Installer level fields are overridden by root fields at the start of the update.
+  2) The update flow modifies the installer level fields if needed. (e.g. ProductCode in case of MSI upgrade)
+  3) At the end of the update, the common installer fields are moved to the root level.
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: exe
+NestedInstallerFiles:
+- RelativeFilePath: WingetCreateTestExeInstaller.exe
+  PortableCommandAlias: PortableCommandAlias1
+AppsAndFeaturesEntries:
+- DisplayName: TestDisplayName1
+  Publisher: TestPublisher1
+  DisplayVersion: 1.0.1
+  ProductCode: TestProductCode1
+  UpgradeCode: TestUpgradeCode1
+  InstallerType: msi
+InstallerSwitches:
+  Silent: /silent1
+  SilentWithProgress: /silentwithprogress1
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: TestPackageDependency1
+  MinimumVersion: 1.0.1
+  WindowsFeatures:
+  - TestWindowsFeature1
+  ExternalDependencies:
+  - TestExternalDependency1
+  WindowsLibraries:
+  - TestWindowsLibrary1
+ExpectedReturnCodes:
+  - InstallerReturnCode: 1001
+    ReturnResponse: installInProgress
+MinimumOSVersion: 10.0.22000.0
+PackageFamilyName: TestPackageFamilyName1
+Platform:
+- Windows.Desktop
+Scope: machine
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+Commands:
+  - fakeCommand1
+Protocols:
+  - fakeProtocol1
+FileExtensions:
+  - .exe
+# Uncomment when installer model gets updated to support these fields
+#Markets:
+#  AllowedMarkets:
+#   - fakeAllowedMarket
+#  ExcludedMarkets:
+#    - fakeExcludedMarket
+InstallerAbortsTerminal: true
+InstallLocationRequired: true
+RequireExplicitUpgrade: true
+UnsupportedOSArchitectures:
+  - arm64
+DisplayInstallWarnings: true
+InstallerSuccessCodes:
+  - 1
+UnsupportedArguments:
+  - log
+  - location
+InstallationMetadata:
+  DefaultInstallLocation: "%ProgramFiles%\\TestApp1"
+  Files:
+  - RelativeFilePath: "main1.exe"
+    FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+    FileType: launch
+    InvocationParameter: "/arg1"
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+    InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+    NestedInstallerType: msi
+    NestedInstallerFiles:
+      - RelativeFilePath: WingetCreateTestExeInstaller.exe
+        PortableCommandAlias: PortableCommandAlias2
+    AppsAndFeaturesEntries:
+      - DisplayName: TestDisplayName2
+        Publisher: TestPublisher2
+        DisplayVersion: 1.0.2
+        ProductCode: TestProductCode2
+        UpgradeCode: TestUpgradeCode2
+        InstallerType: exe
+    InstallerSwitches:
+      Silent: /silent2
+      SilentWithProgress: /silentwithprogress2
+    Dependencies:
+      PackageDependencies:
+      - PackageIdentifier: TestPackageDependency2
+        MinimumVersion: 1.0.2
+      WindowsFeatures:
+        - TestWindowsFeature2
+      ExternalDependencies:
+        - TestExternalDependency2
+      WindowsLibraries:
+        - TestWindowsLibrary2
+    ExpectedReturnCodes:
+    - InstallerReturnCode: 1002
+      ReturnResponse: installInProgress
+    MinimumOSVersion: 10.0.17763.0
+    PackageFamilyName: TestPackageFamilyName2
+    Platform:
+    - Windows.Universal
+    Scope: user
+    UpgradeBehavior: uninstallPrevious
+    ElevationRequirement: elevatesSelf
+    Commands:
+      - fakeCommand2
+    Protocols:
+      - fakeProtocol2
+    FileExtensions:
+      - .msi
+    # Uncomment when installer model gets updated to support these fields
+    #Markets:
+    #  AllowedMarkets:
+    #   - fakeAllowedMarket
+    #  ExcludedMarkets:
+    #    - fakeExcludedMarket
+    InstallerAbortsTerminal: false
+    InstallLocationRequired: false
+    RequireExplicitUpgrade: false
+    UnsupportedOSArchitectures:
+      - arm
+    DisplayInstallWarnings: false
+    InstallerSuccessCodes:
+      - 2
+    UnsupportedArguments:
+      - log
+    InstallationMetadata:
+      DefaultInstallLocation: "%ProgramFiles%\\TestApp2"
+      Files:
+        - RelativeFilePath: "main2.exe"
+          FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+          FileType: launch
+          InvocationParameter: "/arg2"
+  - Architecture: x86
+    InstallerType: zip
+    InstallerUrl: https://fakedomain.com/WingetCreateTestZipInstaller.zip
+    InstallerSha256: 8A052767127A6E2058BAAE03B551A807777BB1B726650E2C7E92C3E92C8DF80D
+    NestedInstallerType: msi
+    NestedInstallerFiles:
+      - RelativeFilePath: WingetCreateTestExeInstaller.exe
+        PortableCommandAlias: PortableCommandAlias2
+    AppsAndFeaturesEntries:
+      - DisplayName: TestDisplayName2
+        Publisher: TestPublisher2
+        DisplayVersion: 1.0.2
+        ProductCode: TestProductCode2
+        UpgradeCode: TestUpgradeCode2
+        InstallerType: exe
+    InstallerSwitches:
+      Silent: /silent2
+      SilentWithProgress: /silentwithprogress2
+    Dependencies:
+      PackageDependencies:
+      - PackageIdentifier: TestPackageDependency2
+        MinimumVersion: 1.0.2
+      WindowsFeatures:
+        - TestWindowsFeature2
+      ExternalDependencies:
+        - TestExternalDependency2
+      WindowsLibraries:
+        - TestWindowsLibrary2
+    ExpectedReturnCodes:
+    - InstallerReturnCode: 1002
+      ReturnResponse: installInProgress
+    MinimumOSVersion: 10.0.17763.0
+    PackageFamilyName: TestPackageFamilyName2
+    Platform:
+    - Windows.Universal
+    Scope: user
+    UpgradeBehavior: uninstallPrevious
+    ElevationRequirement: elevatesSelf
+    Commands:
+      - fakeCommand2
+    Protocols:
+      - fakeProtocol2
+    FileExtensions:
+      - .msi
+    # Uncomment when installer model gets updated to support these fields
+    #Markets:
+    #  AllowedMarkets:
+    #   - fakeAllowedMarket
+    #  ExcludedMarkets:
+    #    - fakeExcludedMarket
+    InstallerAbortsTerminal: false
+    InstallLocationRequired: false
+    RequireExplicitUpgrade: false
+    UnsupportedOSArchitectures:
+      - arm
+    DisplayInstallWarnings: false
+    InstallerSuccessCodes:
+      - 2
+    UnsupportedArguments:
+      - log
+    InstallationMetadata:
+      DefaultInstallLocation: "%ProgramFiles%\\TestApp2"
+      Files:
+        - RelativeFilePath: "main2.exe"
+          FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+          FileType: launch
+          InvocationParameter: "/arg2"
+PackageLocale: en-US
+ManifestType: singleton
+ManifestVersion: 1.4.0

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -974,6 +974,93 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Verifies that installer fields are overridden by root fields in update scenario.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateOverridesInstallerFields()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller);
+            string installerUrl = $"https://fakedomain.com/{TestConstants.TestZipInstaller}";
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.OverrideInstallerFields", null, this.tempPath, new[] { $"{installerUrl}|x64", $"{installerUrl}|x86" });
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            Assert.IsNotNull(updatedManifests, "Command should have succeeded");
+
+            InstallerManifest updatedInstallerManifest = updatedManifests.InstallerManifest;
+
+            Assert.IsTrue(updatedInstallerManifest.InstallerType == InstallerType.Zip, "InstallerType at the root level should be ZIP");
+            Assert.IsTrue(updatedInstallerManifest.NestedInstallerType == NestedInstallerType.Exe, "NestedInstallerType at the root level should be EXE");
+            Assert.IsTrue(updatedInstallerManifest.Scope == Scope.Machine, "Scope at the root level should be machine");
+            Assert.IsTrue(updatedInstallerManifest.MinimumOSVersion == "10.0.22000.0", "MinimumOSVersion at the root level should be 10.0.22000.0");
+            Assert.IsTrue(updatedInstallerManifest.PackageFamilyName == "TestPackageFamilyName1", "PackageFamilyName at the root level should be TestPackageFamilyName");
+            Assert.IsTrue(updatedInstallerManifest.UpgradeBehavior == UpgradeBehavior.Install, "UpgradeBehavior at the root level should be install");
+            Assert.IsTrue(updatedInstallerManifest.ElevationRequirement == ElevationRequirement.ElevationRequired, "ElevationRequirement at the root level should be elevationRequired");
+            Assert.IsTrue(updatedInstallerManifest.InstallerAbortsTerminal == true, "InstallerAbortsTerminal at the root level should be true");
+            Assert.IsTrue(updatedInstallerManifest.InstallLocationRequired == true, "InstallLocation at the root level should be true");
+            Assert.IsTrue(updatedInstallerManifest.RequireExplicitUpgrade == true, "RequireExplicitUpgrade at the root level should be true");
+            Assert.IsTrue(updatedInstallerManifest.DisplayInstallWarnings == true, "DisplayInstallWarnings at the root level should be true");
+            Assert.IsNotNull(updatedInstallerManifest.NestedInstallerFiles, "NestedInstallerFiles at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.NestedInstallerFiles[0].PortableCommandAlias == "PortableCommandAlias1", "PortableCommandAlias at the root level should be PortableCommandAlias1");
+            Assert.IsNotNull(updatedInstallerManifest.InstallerSwitches, "InstallerSwitches at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.InstallerSwitches.Silent == "/silent1", "Silent installer switch at the root level should be /silent1");
+            Assert.IsNotNull(updatedInstallerManifest.Dependencies, "Dependencies at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.Dependencies.PackageDependencies[0].PackageIdentifier == "TestPackageDependency1", "PackageDependencies PackageIdentifier at the root level should be TestPackageDependency1");
+            Assert.IsNotNull(updatedInstallerManifest.AppsAndFeaturesEntries, "AppsAndFeaturesEntries at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.AppsAndFeaturesEntries[0].ProductCode == "TestProductCode1", "AppsAndFeaturesEntries ProductCode at the root level should be TestProduct1");
+            Assert.IsNotNull(updatedInstallerManifest.Platform, "Platform at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.Platform[0] == Platform.Windows_Desktop, "Platform at the root level should contain Windows.Desktop");
+            Assert.IsNotNull(updatedInstallerManifest.ExpectedReturnCodes, "ExpectedReturnCodes at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.ExpectedReturnCodes[0].InstallerReturnCode == 1001, "ExpectedReturnCodes InstallerReturnCode at the root level should be 1001");
+            Assert.IsNotNull(updatedInstallerManifest.Commands, "Commands at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.Commands[0] == "fakeCommand1", "Commands at the root level should contain fakeCommand1");
+            Assert.IsNotNull(updatedInstallerManifest.Protocols, "Protocols at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.Protocols[0] == "fakeProtocol1", "Protocols at the root level should contain fakeProtocol1");
+            Assert.IsNotNull(updatedInstallerManifest.FileExtensions, "FileExtensions at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.FileExtensions[0] == ".exe", "FileExtensions at the root level should contain .exe");
+
+            // TODO: Uncomment when installer model gets updated to support markets field.
+            // Assert.IsNotNull(updatedInstallerManifest.Markets, "Markets at the root level should not be null");
+            Assert.IsNotNull(updatedInstallerManifest.UnsupportedOSArchitectures, "UnsupportedOSArchitectures at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.UnsupportedOSArchitectures[0] == UnsupportedOSArchitecture.Arm64, "UnsupportedOSArchitectures at the root level should contain arm64");
+            Assert.IsNotNull(updatedInstallerManifest.InstallerSuccessCodes, "InstallerSuccessCodes at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.InstallerSuccessCodes[0] == 1, "InstallerSuccessCodes at the root level should contain 1");
+            Assert.IsNotNull(updatedInstallerManifest.UnsupportedArguments, "UnsupportedArguments at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.UnsupportedArguments[1] == UnsupportedArgument.Location, "UnsupportedArguments at the root level should contain location");
+            Assert.IsNotNull(updatedInstallerManifest.InstallationMetadata, "InstallationMetadata at the root level should not be null");
+            Assert.IsTrue(updatedInstallerManifest.InstallationMetadata.DefaultInstallLocation == "%ProgramFiles%\\TestApp1", "DefaultInstallLocation at the root level should be ProgramFiles/TestApp1");
+            foreach (var installer in updatedInstallerManifest.Installers)
+            {
+                Assert.IsNull(installer.InstallerType, "InstallerType at the installer level should be null");
+                Assert.IsNull(installer.NestedInstallerType, "NestedInstallerType at the installer level should be null");
+                Assert.IsNull(installer.Scope, "Scope at the installer level should be null");
+                Assert.IsNull(installer.MinimumOSVersion, "MinimumOSVersion at the installer level should be null");
+                Assert.IsNull(installer.PackageFamilyName, "PackageFamilyName at the installer level should be null");
+                Assert.IsNull(installer.UpgradeBehavior, "UpgradeBehavior at the installer level should be null");
+                Assert.IsNull(installer.ElevationRequirement, "ElevationRequirement at the installer level should be null");
+                Assert.IsNull(installer.InstallerAbortsTerminal, "InstallerAbortsTerminal at the installer level should be null");
+                Assert.IsNull(installer.InstallLocationRequired, "InstallLocation at the installer level should be null");
+                Assert.IsNull(installer.RequireExplicitUpgrade, "RequireExplicitUpgrade at the installer level should be null");
+                Assert.IsNull(installer.DisplayInstallWarnings, "DisplayInstallWarnings at the installer level should be null");
+                Assert.IsNull(installer.NestedInstallerFiles, "NestedInstallerFiles at the installer level should be null");
+                Assert.IsNull(installer.InstallerSwitches, "InstallerSwitches at the installer level should be null");
+                Assert.IsNull(installer.Dependencies, "Dependencies at the installer level should be null");
+                Assert.IsNull(installer.AppsAndFeaturesEntries, "AppsAndFeaturesEntries at the installer level should be null");
+                Assert.IsNull(installer.Platform, "Platform at the installer level should be null");
+                Assert.IsNull(installer.ExpectedReturnCodes, "ExpectedReturnCodes at the installer level should be null");
+                Assert.IsNull(installer.Commands, "Commands at the installer level should be null");
+                Assert.IsNull(installer.Protocols, "Protocols at the installer level should be null");
+                Assert.IsNull(installer.FileExtensions, "FileExtensions at the installer level should be null");
+
+                // TODO: Uncomment when installer model gets updated to support markets field.
+                // Assert.IsNull(installer.Markets, "Markets at the installer level should be null");
+                Assert.IsNull(installer.UnsupportedOSArchitectures, "UnsupportedOSArchitectures at the installer level should be null");
+                Assert.IsNull(installer.InstallerSuccessCodes, "InstallerSuccessCodes at the installer level should be null");
+                Assert.IsNull(installer.UnsupportedArguments, "UnsupportedArguments at the installer level should be null");
+                Assert.IsNull(installer.InstallationMetadata, "InstallationMetadata at the installer level should be null");
+            }
+        }
+
+        /// <summary>
         /// Verifies that the appropriate error message is displayed if the nested installer is not found.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -36,6 +36,9 @@
     <None Update="Resources\Multifile.MsixTest\Multifile.MsixTest.locale.en-US.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.OverrideInstallerFields.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.MoveInstallerFieldsToRoot.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
  Related to #211
  
After #409 got merged, I looked at the issue tracker and realized the PR also fixed another issue i.e., #211. PR #409 introduced the behavior that at the start of the update (both autonomous and interactive) the root fields are shifted to installer level and any previous values are overwritten by the root values.

Expected flow:
  1) Installer level fields are overridden by root fields at the start of the update.
  2) The update flow modifies the installer level fields if needed. (e.g. ProductCode in case of MSI upgrade)
  3) At the end of the update, the common installer fields are moved to the root level.
  
So now, you won't get a behavior of root fields and installer fields being different/not updated as described in the linked issue.

This PR simply adds a test case to verify this behavior. The root values are different from installer level and will become common between all installers after the override so they're shifted back to the root at the end of the update. I know I may been overkill with the assert statements but just wanted to be very sure 😄 Though I wish there was a way to update the ProductCode in the test update for more coverage.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/413&drop=dogfoodAlpha