### PR TITLE
Get new RelativeFilePaths if previous do not exist

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -291,15 +291,15 @@ namespace Microsoft.WingetCreateCLI.Commands
                         if (!File.Exists(Path.Combine(extractDirectory, nestedInstallerFile.RelativeFilePath)))
                         {
                             string relativeFilePath = ObtainMatchingRelativeFilePath(nestedInstallerFile.RelativeFilePath, extractDirectory, packageFile);
-                            if (relativeFilePath == null)
+                            if (string.IsNullOrEmpty(relativeFilePath))
                             {
                                 return null;
                             }
 
-                            List<string> relativeFilePathsInsideList = installerUpdate.NestedInstallerFiles.Select(x => x.RelativeFilePath).ToList();
+                            List<string> installerUpdateRelativeFilePathList = installerUpdate.NestedInstallerFiles.Select(x => x.RelativeFilePath).ToList();
 
-                            // Skip if the relative path is already in the list.
-                            if (!relativeFilePathsInsideList.Contains(relativeFilePath))
+                            // Skip if the relative path is already in the installer update list.
+                            if (!installerUpdateRelativeFilePathList.Contains(relativeFilePath))
                             {
                                 installerUpdate.NestedInstallerFiles.Add(new NestedInstallerFile
                                 {
@@ -448,7 +448,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             // If there is only one match in the archive, use that as the new relative file path.
             if (matchingFiles.Length == 1)
             {
-                string relativePath = matchingFiles.First().Replace(directory, string.Empty).TrimStart('\\');
+                string relativePath = matchingFiles.First().Replace(directory, string.Empty).TrimStart(Path.DirectorySeparatorChar);
                 return relativePath;
             }
             else if (matchingFiles.Length > 1)
@@ -802,7 +802,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                         foreach (NestedInstallerFile nestedInstaller in installer.NestedInstallerFiles)
                         {
                             nestedInstaller.RelativeFilePath = ObtainMatchingRelativeFilePath(nestedInstaller.RelativeFilePath, extractDirectory, packageFile);
-                            if (nestedInstaller.RelativeFilePath == null)
+                            if (string.IsNullOrEmpty(nestedInstaller.RelativeFilePath))
                             {
                                 continue;
                             }

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1501,6 +1501,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Multiple matches found for &quot;{0}&quot; from {1}.
+        /// </summary>
+        public static string MultipleMatchingNestedInstallersFound_Error {
+            get {
+                return ResourceManager.GetString("MultipleMatchingNestedInstallersFound_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Multiple nested installer architectures were detected for following archive packages:.
         /// </summary>
         public static string MultipleNestedArchitectures_Message {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1030,4 +1030,7 @@
   <data name="IconUrl_KeywordDescription" xml:space="preserve">
     <value>The url of the hosted icon file</value>
   </data>
+  <data name="MultipleMatchingNestedInstallersFound_Error" xml:space="preserve">
+    <value>Multiple matches found for "{0}" from {1}</value>
+  </data>
 </root>

--- a/src/WingetCreateCore/Models/InstallerMetadata.cs
+++ b/src/WingetCreateCore/Models/InstallerMetadata.cs
@@ -52,9 +52,14 @@ namespace Microsoft.WingetCreateCore.Models
         public bool IsZipFile { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets the nested installer files contained inside a zip.
+        /// Gets or sets the relative paths contained inside a zip.
         /// </summary>
         public List<string> RelativeFilePaths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the nested installer files coming from previous installer.
+        /// </summary>
+        public List<NestedInstallerFile> NestedInstallerFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the nested installers in a zip have multiple architectures.


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
  - #414

This change makes it so we take the last portion of the RelativeFilePath i.e., the file name and search that file name in the new archive for a match. If it is a unique match, we get its RelativeFilePath and use it for the update.

Known limitation is that there are some cases where there may be more than one match in the archive (An example of this being [DynamoRIO.DynamoRIO package](https://github.com/microsoft/winget-pkgs/blob/master/manifests/d/DynamoRIO/DynamoRIO/9.93.19518/DynamoRIO.DynamoRIO.installer.yaml)). This is not handled in this PR and we print out an appropriate message to the user. I'll create an issue for it if this PR gets accepted.

The change to use the whole NestedInstallerFile object instead of previous RelativeFilePaths is so that I can replace this whole object in UpdateInstallerMetadata() and have it updated.

### Test packages

Somes packages I found to test this PR with

```powershell
wingetcreate update Smallstep.step -v 18.0 --urls "https://github.com/smallstep/cli/releases/download/v0.24.4/step_windows_0.24.4_amd64.zip" "https://github.com/smallstep/cli/releases/download/v0.24.4/step_windows_0.24.4_arm64.zip"
```

```powershell
wingetcreate update Genymobile.scrcpy -v 18.0 --urls "https://github.com/Genymobile/scrcpy/releases/download/v1.25/scrcpy-win64-v1.25.zip" "https://github.com/Genymobile/scrcpy/releases/download/v1.25/scrcpy-win32-v1.25.zip"
```

Multiple matches for RelativeFilePaths (**not handled in this PR**)
```powershell
wingetcreate update DynamoRIO.DynamoRIO --version 18.0 --urls "https://github.com/DynamoRIO/dynamorio/releases/download/cronbuild-9.93.19557/DynamoRIO-Windows-9.93.19557.zip"
```

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/415&drop=dogfoodAlpha