### PR TITLE
Bump version to v1.5

### DIFF
--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
-    <Version>1.2</Version>
+    <Version>1.5</Version>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This PR increases the wingetcreate version from v1.2 to v1.5. 

The reason for this jump is so that the versioning matches the current manifest schema version that wingetcreate generates/updates. In the past, we have always bumped the minor version whenever the manifest schema changed.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/423&drop=dogfoodAlpha