### PR TITLE
Prompt for RelativeFilePaths in interactive update

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -613,7 +613,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             }
             else if (matchingFiles.Count > 1)
             {
-                if (this.Interactive == true)
+                if (this.Interactive)
                 {
                     Console.WriteLine();
                     Logger.WarnLocalized(nameof(Resources.MultipleMatchingNestedInstallersFound_Warning), fileName, Path.GetFileName(archiveName));
@@ -625,7 +625,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             }
             else
             {
-                if (this.Interactive == true)
+                if (this.Interactive)
                 {
                     List<string> sameExtensionFiles = Directory.GetFiles(directory, $"*{Path.GetExtension(oldRelativeFilePath)}", SearchOption.AllDirectories)
                         .Select(filePath => filePath = Path.GetRelativePath(directory, filePath))
@@ -824,8 +824,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                         continue;
                     }
 
-                    string pathToNestedInstaller = Path.Combine(extractDirectory, installer.NestedInstallerFiles.First().RelativeFilePath);
-                    packageFile = pathToNestedInstaller;
+                    packageFile = Path.Combine(extractDirectory, installer.NestedInstallerFiles.First().RelativeFilePath);
                 }
 
                 if (!PackageParser.ParsePackageAndUpdateInstallerNode(installer, packageFile, url))

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1501,11 +1501,20 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multiple matches found for &quot;{0}&quot; from {1}.
+        ///   Looks up a localized string similar to Multiple matches found for &quot;{0}&quot; from {1}. Please use the interactive mode to update this package..
         /// </summary>
         public static string MultipleMatchingNestedInstallersFound_Error {
             get {
                 return ResourceManager.GetString("MultipleMatchingNestedInstallersFound_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple matches found for &quot;{0}&quot; from {1}..
+        /// </summary>
+        public static string MultipleMatchingNestedInstallersFound_Warning {
+            get {
+                return ResourceManager.GetString("MultipleMatchingNestedInstallersFound_Warning", resourceCulture);
             }
         }
         
@@ -1537,11 +1546,20 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nested installer not found in zip archive: {0}.
+        ///   Looks up a localized string similar to Nested installer not found in zip archive: {0}. Please use the interactive mode to update this package..
         /// </summary>
         public static string NestedInstallerFileNotFound_Error {
             get {
                 return ResourceManager.GetString("NestedInstallerFileNotFound_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nested installer not found in zip archive: {0}.
+        /// </summary>
+        public static string NestedInstallerFileNotFound_Warning {
+            get {
+                return ResourceManager.GetString("NestedInstallerFileNotFound_Warning", resourceCulture);
             }
         }
         
@@ -1569,6 +1587,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string NestedInstallerType_KeywordDescription {
             get {
                 return ResourceManager.GetString("NestedInstallerType_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The zip archive does not contain a matching installer type with the old relative path..
+        /// </summary>
+        public static string NestedInstallerTypeNotFound_Error {
+            get {
+                return ResourceManager.GetString("NestedInstallerTypeNotFound_Error", resourceCulture);
             }
         }
         
@@ -2190,6 +2217,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string SelectPropertyToEdit_Message {
             get {
                 return ResourceManager.GetString("SelectPropertyToEdit_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the new relative file path.
+        /// </summary>
+        public static string SelectRelativeFilePath_Message {
+            get {
+                return ResourceManager.GetString("SelectRelativeFilePath_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -964,7 +964,7 @@
     {1} - will be replaced by the InstallerUrl</comment>
   </data>
   <data name="NestedInstallerFileNotFound_Error" xml:space="preserve">
-    <value>Nested installer not found in zip archive: {0}</value>
+    <value>Nested installer not found in zip archive: {0}. Please use the interactive mode to update this package.</value>
     <comment>{0} - represents the relative file path of the nested installer file.</comment>
   </data>
   <data name="NestedInstallerFiles_KeywordDescription" xml:space="preserve">
@@ -1031,6 +1031,18 @@
     <value>The url of the hosted icon file</value>
   </data>
   <data name="MultipleMatchingNestedInstallersFound_Error" xml:space="preserve">
-    <value>Multiple matches found for "{0}" from {1}</value>
+    <value>Multiple matches found for "{0}" from {1}. Please use the interactive mode to update this package.</value>
+  </data>
+  <data name="MultipleMatchingNestedInstallersFound_Warning" xml:space="preserve">
+    <value>Multiple matches found for "{0}" from {1}.</value>
+  </data>
+  <data name="NestedInstallerFileNotFound_Warning" xml:space="preserve">
+    <value>Nested installer not found in zip archive: {0}</value>
+  </data>
+  <data name="NestedInstallerTypeNotFound_Error" xml:space="preserve">
+    <value>The zip archive does not contain a matching installer type with the old relative path.</value>
+  </data>
+  <data name="SelectRelativeFilePath_Message" xml:space="preserve">
+    <value>Select the new relative file path</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1032,12 +1032,19 @@
   </data>
   <data name="MultipleMatchingNestedInstallersFound_Error" xml:space="preserve">
     <value>Multiple matches found for "{0}" from {1}. Please use the interactive mode to update this package.</value>
+    <comment>{0} - will be replaced by the name of the nested installer file
+
+{1} - will be replaced by the name of the zip archive.</comment>
   </data>
   <data name="MultipleMatchingNestedInstallersFound_Warning" xml:space="preserve">
     <value>Multiple matches found for "{0}" from {1}.</value>
+    <comment>{0} - will be replaced by the name of the nested installer file
+
+{1} - will be replaced by the name of the zip archive.</comment>
   </data>
   <data name="NestedInstallerFileNotFound_Warning" xml:space="preserve">
     <value>Nested installer not found in zip archive: {0}</value>
+    <comment>{0} - represents the relative file path of the nested installer file.</comment>
   </data>
   <data name="NestedInstallerTypeNotFound_Error" xml:space="preserve">
     <value>The zip archive does not contain a matching installer type with the old relative path.</value>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #430

	
Examples manifests to test with are included in the linked issue

Unmatched RelativeFilePaths can be categorized into 2 types with this PR


### CASE-I Same binary name, different directory name

#### a. Single match for `example.exe` in the new archive
e.g. `Example-1.2\example.exe` -> `Example-1.3\example.exe`

In this case the autonomous and interactive update logic will auto-detect the new binary from the archive and user does not have to do anything.

#### b. Multiple matches for `example.exe` in the new archive
e.g. `Example-1.2\win64\example.exe` matches with `Example-1.3\win64\example.exe` and `Example-1.3\win32\example.exe` in the new archive.

In this case the autonomous update will fail as it cannot disambiguate which `example.exe` to use as the new RelativeFilePath (although the above example makes it seem obvious which to choose but we need a way to generalize for any case). Interactive update will match for all `example.exe` in the new archive and prompt the user to select one


### CASE-II Different binary name under different directories
 
e.g. `Example-1.2\example-1.2.exe` -> `Example-1.3\example-1.3.exe`

Autonomous update will fail again for same reasons. Interactive update will now scan for all `.exe` (old relativefilepath extension) in the new archive and prompt the user to select one of them as new RelativeFilePath. If there are no `.exe` files in the new archive, the interactive update can't move any forward and an appropriate message is printed.



-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/431&drop=dogfoodAlpha