### PR TITLE
Null check for sequences comparison

### DIFF
--- a/src/WingetCreateCore/Models/Partials/InstallerPartials.cs
+++ b/src/WingetCreateCore/Models/Partials/InstallerPartials.cs
@@ -93,10 +93,10 @@ namespace Microsoft.WingetCreateCore.Models.Installer
             }
 
             Dependencies other = (Dependencies)obj;
-            return this.WindowsFeatures.ToList().SequenceEqual(other.WindowsFeatures) &&
-                this.WindowsLibraries.ToList().SequenceEqual(this.WindowsLibraries) &&
-                this.PackageDependencies.ToList().SequenceEqual(other.PackageDependencies) &&
-                this.ExternalDependencies.ToList().SequenceEqual(other.ExternalDependencies);
+            return (this.PackageDependencies != null ? this.PackageDependencies.SequenceEqual(other.PackageDependencies) : true) &&
+                (this.WindowsLibraries != null ? this.WindowsLibraries.SequenceEqual(other.WindowsLibraries) : true) &&
+                (this.WindowsFeatures != null ? this.WindowsFeatures.SequenceEqual(other.WindowsFeatures) : true) &&
+                (this.ExternalDependencies != null ? this.ExternalDependencies.SequenceEqual(other.ExternalDependencies) : true);
         }
     }
 
@@ -150,7 +150,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
 
             InstallationMetadata other = (InstallationMetadata)obj;
             return this.DefaultInstallLocation == other.DefaultInstallLocation &&
-                this.Files.ToList().SequenceEqual(other.Files);
+                (this.Files != null ? this.Files.SequenceEqual(other.Files) : true);
         }
     }
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #429

The exception is thrown at https://github.com/microsoft/winget-create/blob/44a102acd07793d89be2c1bf5e135d04ae17488c/src/WingetCreateCore/Common/GitHub.cs#L155
then
https://github.com/microsoft/winget-create/blob/44a102acd07793d89be2c1bf5e135d04ae17488c/src/WingetCreateCore/Common/Serialization.cs#L100

 The installer manifest contains dependencies object with some null List sequences (WindowsFeatures, WindowsLibraries, ExternalDependencies). The Equals() method for Dependencies seems to be used externally while serializing the manifest and because null values are not handled properly, an exception is thrown.

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/432&drop=dogfoodAlpha