### PR TITLE
Bump YamlDotNet to 13.2.0

### DIFF
--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WingetCreateCore
         {
             var serializer = new SerializerBuilder()
                 .WithNamingConvention(PascalCaseNamingConvention.Instance)
-                .WithDefaultScalarStyle(ScalarStyle.DoubleQuoted)
+                .WithDefaultScalarStyle(ScalarStyle.SingleQuoted)
                 .WithTypeConverter(new YamlStringEnumConverter())
                 .WithEmissionPhaseObjectGraphVisitor(args => new YamlSkipPropertyVisitor(args.InnerVisitor))
                 .WithEventEmitter(nextEmitter => new MultilineScalarFlowStyleEmitter(nextEmitter))

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -42,6 +42,7 @@ namespace Microsoft.WingetCreateCore
         {
             var serializer = new SerializerBuilder()
                 .WithNamingConvention(PascalCaseNamingConvention.Instance)
+                .WithDefaultScalarStyle(ScalarStyle.DoubleQuoted)
                 .WithTypeConverter(new YamlStringEnumConverter())
                 .WithEmissionPhaseObjectGraphVisitor(args => new YamlSkipPropertyVisitor(args.InnerVisitor))
                 .WithEventEmitter(nextEmitter => new MultilineScalarFlowStyleEmitter(nextEmitter))

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WingetCreateCore
         {
             var serializer = new SerializerBuilder()
                 .WithNamingConvention(PascalCaseNamingConvention.Instance)
-               .WithQuotingNecessaryStrings()
+                .WithQuotingNecessaryStrings()
                 .WithTypeConverter(new YamlStringEnumConverter())
                 .WithEmissionPhaseObjectGraphVisitor(args => new YamlSkipPropertyVisitor(args.InnerVisitor))
                 .WithEventEmitter(nextEmitter => new MultilineScalarFlowStyleEmitter(nextEmitter))

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WingetCreateCore
         {
             var serializer = new SerializerBuilder()
                 .WithNamingConvention(PascalCaseNamingConvention.Instance)
-                .WithDefaultScalarStyle(ScalarStyle.SingleQuoted)
+               .WithQuotingNecessaryStrings()
                 .WithTypeConverter(new YamlStringEnumConverter())
                 .WithEmissionPhaseObjectGraphVisitor(args => new YamlSkipPropertyVisitor(args.InnerVisitor))
                 .WithEventEmitter(nextEmitter => new MultilineScalarFlowStyleEmitter(nextEmitter))

--- a/src/WingetCreateCore/Common/Serialization.cs
+++ b/src/WingetCreateCore/Common/Serialization.cs
@@ -41,8 +41,8 @@ namespace Microsoft.WingetCreateCore
         public static ISerializer CreateSerializer()
         {
             var serializer = new SerializerBuilder()
-                .WithNamingConvention(PascalCaseNamingConvention.Instance)
                 .WithQuotingNecessaryStrings()
+                .WithNamingConvention(PascalCaseNamingConvention.Instance)
                 .WithTypeConverter(new YamlStringEnumConverter())
                 .WithEmissionPhaseObjectGraphVisitor(args => new YamlSkipPropertyVisitor(args.InnerVisitor))
                 .WithEventEmitter(nextEmitter => new MultilineScalarFlowStyleEmitter(nextEmitter))

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Vestris.ResourceLib" Version="2.1.0" />
     <PackageReference Include="WiX" Version="3.11.2" />
-    <PackageReference Include="YamlDotNet" Version="11.1.1" />
+    <PackageReference Include="YamlDotNet" Version="13.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #417
	
This change now wraps all string values in the manifest around ~double quotes~ single quotes, we can choose from either but I went with one that looks cleaner. Single quotes don't parse escape sequences (not that it matters for our use case i think). (though imo this change makes the overall manifest look ugly now with everything quoted but that's just personal preference 😄)

Tested manually with

```powershell
wingetcreate update Cockos.REAPER --urls "https://www.reaper.fm/files/6.x/reaper681_x64-install.exe|x64" "https://www.reaper.fm/files/6.x/reaper681-install.exe|x86"
```

```powershell
wingetcreate update OpenAL.OpenAL --urls "https://www.openal.org/downloads/oalinst.zip"
```

-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/433&drop=dogfoodAlpha