### PR TITLE
Use NestedInstallerFiles for generating installer nodes in New Command

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -179,7 +179,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                             {
                                 InstallerUrl = installerUrl,
                                 PackageFile = packageFile,
-                                RelativeFilePaths = new List<string> { installer },
+                                NestedInstallerFiles = new List<NestedInstallerFile> { new NestedInstallerFile { RelativeFilePath = installer } },
                                 IsZipFile = true,
                                 ExtractedDirectory = extractDirectory,
                             });


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	Resolves #435. This is also one of the regressions from an earlier PR #415 (sorry 😢). New command for zip installers got broken since PackageParser now uses NestedInstallerFiles to generate installer nodes
	
https://github.com/microsoft/winget-create/blob/44a102acd07793d89be2c1bf5e135d04ae17488c/src/WingetCreateCore/Common/PackageParser.cs#L500

New command needs to be updated to populate the installerMetadata with NestedInstallerFiles now instead of RelativeFilePaths

### Manifests to test with

```powershell
wingetcreate new "https://download.sysinternals.com/files/ZoomIt.zip"
```

```powershell
wingetcreate new "https://github.com/istio/istio/releases/download/1.17.3/istioctl-1.17.3-win.zip"
```
```powershell
wingetcreate new "https://github.com/junegunn/fzf/releases/download/0.39.0/fzf-0.39.0-windows_amd64.zip"
```
```powershell
wingetcreate new "https://github.com/sharkdp/fd/releases/download/v8.7.0/fd-v8.7.0-i686-pc-windows-msvc.zip"
```


-----

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/winget-create/pull/434&drop=dogfoodAlpha