### PR TITLE
Shift fields back to installer level for re-run

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -233,6 +233,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                         }
                     }
 
+                    ShiftRootFieldsToInstallerLevel(manifests.InstallerManifest);
                     PromptManifestProperties(manifests);
                     MergeNestedInstallerFilesIfApplicable(manifests.InstallerManifest);
                     ShiftInstallerFieldsToRootLevel(manifests.InstallerManifest);


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #438

The common installer fields get shifted to root level after running through the new command once. But if a user requests a re-run / retry, the internal logic fails as it expects fields at the installer level. Updated the code to shift fields back to installer level for re-run

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/439)