### PR TITLE
Fix singleton check + docs for show command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ choco install wingetcreate
 | [New](doc/new.md)      | Command for creating a new manifest from scratch |
 | [Update](doc/update.md)  | Command for updating an existing manifest |
 | [Submit](doc/submit.md)  | Command for submitting an existing PR  |
+| [Show](doc/show.md)      | Command for displaying existing manifests  |
 | [Token](doc/token.md)   | Command for managing cached GitHub personal access tokens |
 | [Settings](doc/settings.md) | Command for editing the settings file configurations |
 | [Cache](doc/cache.md) | Command for managing downloaded installers stored in cache

--- a/src/WingetCreateCLI/Commands/ShowCommand.cs
+++ b/src/WingetCreateCLI/Commands/ShowCommand.cs
@@ -176,17 +176,17 @@ namespace Microsoft.WingetCreateCLI.Commands
 
         private void ParseArgumentsAndShowManifest(Manifests manifests)
         {
+            if (manifests.SingletonManifest != null)
+            {
+                DisplaySingletonManifest(manifests.SingletonManifest);
+                return;
+            }
+
             bool showAll = !this.ShowInstallerManifest && !this.ShowDefaultLocaleManifest && !this.ShowLocaleManifests && !this.ShowVersionManifest;
 
             if (showAll)
             {
                 ShowAllManifests(manifests);
-                return;
-            }
-
-            if (manifests.SingletonManifest != null)
-            {
-                DisplaySingletonManifest(manifests.SingletonManifest);
                 return;
             }
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?


### Steps to reproduce

`wingetcreate show NSIS.NSIS` ---> Throws an exception

Singleton check should be the first one to prevent going into show all manifests flow

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/441)