### PR TITLE
Extend regex for determining arch from URL

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -555,7 +555,6 @@ namespace Microsoft.WingetCreateCore
             if (!parseMsixResult)
             {
                 var urlArchitecture = installerMetadata.UrlArchitecture = GetArchFromUrl(baseInstaller.InstallerUrl);
-                installerMetadata.UrlArchitecture = GetArchFromUrl(baseInstaller.InstallerUrl);
                 installerMetadata.BinaryArchitecture = baseInstaller.Architecture;
 
                 var overrideArch = installerMetadata.OverrideArchitecture;
@@ -587,17 +586,17 @@ namespace Microsoft.WingetCreateCore
             {
                 archMatches.Add(Architecture.Arm64);
             }
-            else if (Regex.Match(url, @"\barm\b", RegexOptions.IgnoreCase).Success)
+            else if (Regex.Match(url, @"\barm\b|armv[567]", RegexOptions.IgnoreCase).Success)
             {
                 archMatches.Add(Architecture.Arm);
             }
 
-            if (Regex.Match(url, "x64|win64|_64|64-bit", RegexOptions.IgnoreCase).Success)
+            if (Regex.Match(url, "x64|win64|_64|64-bit|amd64", RegexOptions.IgnoreCase).Success)
             {
                 archMatches.Add(Architecture.X64);
             }
 
-            if (Regex.Match(url, "x86|win32|ia32|_86|32-bit", RegexOptions.IgnoreCase).Success)
+            if (Regex.Match(url, @"x86|win32|ia32|_86|32-bit|i386|\b386\b", RegexOptions.IgnoreCase).Success)
             {
                 archMatches.Add(Architecture.X86);
             }


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

Also removed a redundant call to GetArchFromUrl function

### winget-pkgs examples

- `amd64` pattern (Total: 2567 examples)

```
j\JanDeDobbeleer\OhMyPosh\10.1.0\JanDeDobbeleer.OhMyPosh.installer.yaml:  InstallerUrl: https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v10.1.0/install-amd64.exe
b\BellSoft\LibericaJDK\11\11.0.9.11\BellSoft.LibericaJDK.11.installer.yaml:  InstallerUrl: https://download.bell-sw.com/java/11.0.9+11/bellsoft-jdk11.0.9+11-windows-amd64.msi
h\Helm\Helm\3.12.0\Helm.Helm.installer.yaml:  InstallerUrl: https://get.helm.sh/helm-v3.12.0-windows-amd64.zip
```
[full_output_amd64.txt](https://github.com/microsoft/winget-create/files/12568506/full_output_amd64.txt) 


- `\b386\b` pattern (Total: 1013 examples)

```
g\GoLang\Go\1.17.2\GoLang.Go.installer.yaml:  InstallerUrl: https://dl.google.com/go/go1.17.2.windows-386.msi
c\Cloudflare\cloudflared\2023.8.1\Cloudflare.cloudflared.installer.yaml:  InstallerUrl: https://github.com/cloudflare/cloudflared/releases/download/2023.8.1/cloudflared-windows-386.msi
d\DigitalOcean\Doctl\1.96.0\DigitalOcean.Doctl.installer.yaml:  InstallerUrl: https://github.com/digitalocean/doctl/releases/download/v1.96.0/doctl-1.96.0-windows-386.zip
```

[full_output_386.txt](https://github.com/microsoft/winget-create/files/12568517/full_output_386.txt) 


- `i386` pattern (Total: 156 examples)

```
t\twpayne\chezmoi\2.33.0\twpayne.chezmoi.installer.yaml:  InstallerUrl: https://github.com/twpayne/chezmoi/releases/download/v2.33.0/chezmoi_2.33.0_windows_i386.zip
q\Qalculate\Qalculate\4.8.0\Qalculate.Qalculate.installer.yaml:  InstallerUrl: https://github.com/Qalculate/libqalculate/releases/download/v4.8.0/qalculate-4.8.0-i386.msi
a\alexx2000\DoubleCommander\1.0.8\alexx2000.DoubleCommander.installer.yaml:  InstallerUrl: https://github.com/doublecmd/doublecmd/releases/download/v1.0.8/doublecmd-1.0.8.i386-win32.msi
```

[full_output_i386.txt](https://github.com/microsoft/winget-create/files/12568509/full_output_i386.txt) 


- `armv[567]` pattern (Total: 32 examples)

```
m\muesli\duf\0.8.1\muesli.duf.installer.yaml:  InstallerUrl: https://github.com/muesli/duf/releases/download/v0.8.1/duf_0.8.1_Windows_armv7.zip
n\nektos\act\0.2.48\nektos.act.installer.yaml:  InstallerUrl: https://github.com/nektos/act/releases/download/v0.2.48/act_Windows_armv7.zip
j\JesseDuffield\lazygit\0.40.0\JesseDuffield.lazygit.installer.yaml:  InstallerUrl: https://github.com/jesseduffield/lazygit/releases/download/v0.40.0/lazygit_0.40.0_Windows_armv6.zip
```

[full_output_armv567.txt](https://github.com/microsoft/winget-create/files/12568501/full_output_armv567.txt) 






-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/445)