### PR TITLE
Fix pattern for getting same name files

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -181,7 +181,7 @@ namespace Microsoft.WingetCreateCore
             string fileExt = Path.GetExtension(desiredPath);
             string fileDir = Path.GetDirectoryName(desiredPath);
             DirectoryInfo dir = new DirectoryInfo(fileDir);
-            FileInfo[] existingFiles = dir.GetFiles(Path.ChangeExtension(fileName + "*", fileExt));
+            FileInfo[] existingFiles = dir.GetFiles(fileName + "*" + fileExt);
             return existingFiles.Length == 0 ? Path.Combine(fileDir, fileName + fileExt) : Path.Combine(fileDir, fileName + " (" + existingFiles.Length.ToString() + ")" + fileExt);
         }
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #333

Not sure why/how but the call to `Path.ChangeExtension()` incorrectly modifies the file name for some files. 
Instead of returning expected pattern `Thunderbird%20Setup%20102.6.0*` (for actual file name `Thunderbird%20Setup%20102.6.0.msi`), it returns `Thunderbird%20Setup%20102.6.msi` (truncating the '0' instead of the extension)

To fix this, manually concatenated the strings to form a matching pattern.

## Validation

Run `wingetcreate update Mozilla.Thunderbird --version 102.6.0 -i`

1) Give URL: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.6.0/win64/en-US/Thunderbird%20Setup%20102.6.0.msi
2) Then: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.6.0/win64/en-GB/Thunderbird%20Setup%20102.6.0.msi
3) Then: https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/102.6.0/win64/de/Thunderbird%20Setup%20102.6.0.msi

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/455)