### PR TITLE
Support localization for parser messages

### DIFF
--- a/src/WingetCreateCLI/LocalizableSentenceBuilder.cs
+++ b/src/WingetCreateCLI/LocalizableSentenceBuilder.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI
+{
+    /* This implementation is taken from the CommandLineParser reference examples.
+     * https://github.com/commandlineparser/commandline/tree/master/demo/ReadText.LocalizedDemo
+     */
+
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using CommandLine;
+    using CommandLine.Text;
+
+    /// <inheritdoc/>
+    public class LocalizableSentenceBuilder : SentenceBuilder
+    {
+        /// <inheritdoc/>
+        public override Func<string> RequiredWord
+        {
+            get { return () => Properties.Resources.SentenceRequiredWord; }
+        }
+
+        /// <inheritdoc/>
+        public override Func<string> ErrorsHeadingText
+        {
+            // Cannot be pluralized
+            get { return () => Properties.Resources.SentenceErrorsHeadingText; }
+        }
+
+        /// <inheritdoc/>
+        public override Func<string> UsageHeadingText
+        {
+            get { return () => Properties.Resources.SentenceUsageHeadingText; }
+        }
+
+        /// <inheritdoc/>
+        public override Func<string> OptionGroupWord
+        {
+            get { return () => Properties.Resources.SentenceOptionGroupWord; }
+        }
+
+        /// <inheritdoc/>
+        public override Func<bool, string> HelpCommandText
+        {
+            get
+            {
+                return isOption => isOption
+                    ? Properties.Resources.SentenceHelpCommandTextOption
+                    : Properties.Resources.SentenceHelpCommandTextVerb;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Func<bool, string> VersionCommandText
+        {
+            get { return _ => Properties.Resources.SentenceVersionCommandText; }
+        }
+
+        /// <inheritdoc/>
+        public override Func<Error, string> FormatError
+        {
+            get
+            {
+                return error =>
+                {
+                    switch (error.Tag)
+                    {
+                        case ErrorType.BadFormatTokenError:
+                            return string.Format(Properties.Resources.SentenceBadFormatTokenError, ((BadFormatTokenError)error).Token);
+
+                        case ErrorType.MissingValueOptionError:
+                            return string.Format(Properties.Resources.SentenceMissingValueOptionError, ((MissingValueOptionError)error).NameInfo.NameText);
+
+                        case ErrorType.UnknownOptionError:
+                            return string.Format(Properties.Resources.SentenceUnknownOptionError, ((UnknownOptionError)error).Token);
+
+                        case ErrorType.MissingRequiredOptionError:
+                            var errMisssing = (MissingRequiredOptionError)error;
+                            return errMisssing.NameInfo.Equals(NameInfo.EmptyName) ? Properties.Resources.SentenceMissingRequiredValueError
+                                       : string.Format(Properties.Resources.SentenceMissingRequiredOptionError, errMisssing.NameInfo.NameText);
+
+                        case ErrorType.BadFormatConversionError:
+                            var badFormat = (BadFormatConversionError)error;
+                            return badFormat.NameInfo.Equals(NameInfo.EmptyName) ? Properties.Resources.SentenceBadFormatConversionErrorValue
+                                       : string.Format(Properties.Resources.SentenceBadFormatConversionErrorOption, badFormat.NameInfo.NameText);
+
+                        case ErrorType.SequenceOutOfRangeError:
+                            var seqOutRange = (SequenceOutOfRangeError)error;
+                            return seqOutRange.NameInfo.Equals(NameInfo.EmptyName) ? Properties.Resources.SentenceSequenceOutOfRangeErrorValue
+                                       : string.Format(Properties.Resources.SentenceSequenceOutOfRangeErrorOption, seqOutRange.NameInfo.NameText);
+
+                        case ErrorType.BadVerbSelectedError:
+                            return string.Format(Properties.Resources.SentenceBadVerbSelectedError, ((BadVerbSelectedError)error).Token);
+
+                        case ErrorType.NoVerbSelectedError:
+                            return Properties.Resources.SentenceNoVerbSelectedError;
+
+                        case ErrorType.RepeatedOptionError:
+                            return string.Format(Properties.Resources.SentenceRepeatedOptionError, ((RepeatedOptionError)error).NameInfo.NameText);
+
+                        case ErrorType.SetValueExceptionError:
+                            var setValueError = (SetValueExceptionError)error;
+                            return string.Format(Properties.Resources.SentenceSetValueExceptionError, setValueError.NameInfo.NameText, setValueError.Exception.Message);
+                    }
+
+                    throw new InvalidOperationException();
+                };
+            }
+        }
+
+        /// <inheritdoc/>
+        public override Func<IEnumerable<MutuallyExclusiveSetError>, string> FormatMutuallyExclusiveSetErrors
+        {
+            get
+            {
+                return errors =>
+                {
+                    var bySet = from e in errors
+                                group e by e.SetName into g
+                                select new { SetName = g.Key, Errors = g.ToList() };
+
+                    var msgs = bySet.Select(
+                        set =>
+                        {
+                            var names = string.Join(
+                                string.Empty,
+                                (from e in set.Errors select string.Format("'{0}', ", e.NameInfo.NameText)).ToArray());
+                            var namesCount = set.Errors.Count();
+
+                            var incompat = string.Join(
+                                string.Empty,
+                                (from x in
+                                     (from s in bySet where !s.SetName.Equals(set.SetName) from e in s.Errors select e)
+                                    .Distinct()
+                                 select string.Format("'{0}', ", x.NameInfo.NameText)).ToArray());
+
+                            // TODO: Pluralize by namesCount
+                            return string.Format(
+                                    Properties.Resources.SentenceMutuallyExclusiveSetErrors,
+                                    names.Substring(0, names.Length - 2),
+                                    incompat.Substring(0, incompat.Length - 2));
+                        }).ToArray();
+                    return string.Join(Environment.NewLine, msgs);
+                };
+            }
+        }
+    }
+}

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -27,6 +27,7 @@ namespace Microsoft.WingetCreateCLI
             Logger.Initialize();
             UserSettings.FirstRunTelemetryConsent();
             TelemetryEventListener.EventListener.IsTelemetryEnabled();
+            SentenceBuilder.Factory = () => new LocalizableSentenceBuilder();
 
             string arguments = string.Join(' ', Environment.GetCommandLineArgs());
             Logger.Trace($"Command line args: {arguments}");

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -2347,6 +2347,195 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; is defined with a bad format..
+        /// </summary>
+        public static string SentenceBadFormatConversionErrorOption {
+            get {
+                return ResourceManager.GetString("SentenceBadFormatConversionErrorOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A value not bound to option name is defined with a bad format..
+        /// </summary>
+        public static string SentenceBadFormatConversionErrorValue {
+            get {
+                return ResourceManager.GetString("SentenceBadFormatConversionErrorValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Token &apos;{0}&apos; is not recognized..
+        /// </summary>
+        public static string SentenceBadFormatTokenError {
+            get {
+                return ResourceManager.GetString("SentenceBadFormatTokenError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Verb &apos;{0}&apos; is not recognized..
+        /// </summary>
+        public static string SentenceBadVerbSelectedError {
+            get {
+                return ResourceManager.GetString("SentenceBadVerbSelectedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ERROR(S):.
+        /// </summary>
+        public static string SentenceErrorsHeadingText {
+            get {
+                return ResourceManager.GetString("SentenceErrorsHeadingText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Display this help screen..
+        /// </summary>
+        public static string SentenceHelpCommandTextOption {
+            get {
+                return ResourceManager.GetString("SentenceHelpCommandTextOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Display more information on a specific command..
+        /// </summary>
+        public static string SentenceHelpCommandTextVerb {
+            get {
+                return ResourceManager.GetString("SentenceHelpCommandTextVerb", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required option &apos;{0}&apos; is missing..
+        /// </summary>
+        public static string SentenceMissingRequiredOptionError {
+            get {
+                return ResourceManager.GetString("SentenceMissingRequiredOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A required value not bound to option name is missing..
+        /// </summary>
+        public static string SentenceMissingRequiredValueError {
+            get {
+                return ResourceManager.GetString("SentenceMissingRequiredValueError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; has no value..
+        /// </summary>
+        public static string SentenceMissingValueOptionError {
+            get {
+                return ResourceManager.GetString("SentenceMissingValueOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Options: {0} are not compatible with {1}..
+        /// </summary>
+        public static string SentenceMutuallyExclusiveSetErrors {
+            get {
+                return ResourceManager.GetString("SentenceMutuallyExclusiveSetErrors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No verb selected..
+        /// </summary>
+        public static string SentenceNoVerbSelectedError {
+            get {
+                return ResourceManager.GetString("SentenceNoVerbSelectedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Group.
+        /// </summary>
+        public static string SentenceOptionGroupWord {
+            get {
+                return ResourceManager.GetString("SentenceOptionGroupWord", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; is defined multiple times..
+        /// </summary>
+        public static string SentenceRepeatedOptionError {
+            get {
+                return ResourceManager.GetString("SentenceRepeatedOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required..
+        /// </summary>
+        public static string SentenceRequiredWord {
+            get {
+                return ResourceManager.GetString("SentenceRequiredWord", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A sequence option &apos;{0}&apos; is defined with fewer or more items than required..
+        /// </summary>
+        public static string SentenceSequenceOutOfRangeErrorOption {
+            get {
+                return ResourceManager.GetString("SentenceSequenceOutOfRangeErrorOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A sequence value not bound to option name is defined with fewer items than required..
+        /// </summary>
+        public static string SentenceSequenceOutOfRangeErrorValue {
+            get {
+                return ResourceManager.GetString("SentenceSequenceOutOfRangeErrorValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error setting value to option &apos;{0}&apos;: {1}.
+        /// </summary>
+        public static string SentenceSetValueExceptionError {
+            get {
+                return ResourceManager.GetString("SentenceSetValueExceptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; is unknown..
+        /// </summary>
+        public static string SentenceUnknownOptionError {
+            get {
+                return ResourceManager.GetString("SentenceUnknownOptionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to USAGE:.
+        /// </summary>
+        public static string SentenceUsageHeadingText {
+            get {
+                return ResourceManager.GetString("SentenceUsageHeadingText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Display version information..
+        /// </summary>
+        public static string SentenceVersionCommandText {
+            get {
+                return ResourceManager.GetString("SentenceVersionCommandText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open settings.
         /// </summary>
         public static string SettingsCommand_HelpText {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -691,15 +691,12 @@
   <data name="MultipleMatchedInstaller_Error" xml:space="preserve">
     <value>Multiple matches found for {0} {1} installer detected from the url: {2}</value>
     <comment>{0} - will be replaced with installer architecture
-
 {1} - will be replaced with the installer type
-
 {2} - will be replaced with the installer</comment>
   </data>
   <data name="UnmatchedInstaller_Error" xml:space="preserve">
     <value>No matches found for {0} {1} installer detected from url: {2}</value>
     <comment>{0} - will be replaced with installer architecture
-
 {1} - will be replaced with the installer type 
 {2} - will be replaced with the installer</comment>
   </data>
@@ -961,7 +958,7 @@
   <data name="NestedInstallerParsing_HelpText" xml:space="preserve">
     <value>Parsing nested installer '{0}' from {1}</value>
     <comment>{0} - will be replaced with RelativeFilePath of the nested installer
-    {1} - will be replaced by the InstallerUrl</comment>
+{1} - will be replaced by the InstallerUrl</comment>
   </data>
   <data name="NestedInstallerFileNotFound_Error" xml:space="preserve">
     <value>Nested installer not found in zip archive: {0}. Please use the interactive mode to update this package.</value>
@@ -1033,13 +1030,11 @@
   <data name="MultipleMatchingNestedInstallersFound_Error" xml:space="preserve">
     <value>Multiple matches found for "{0}" from {1}. Please use the interactive mode to update this package.</value>
     <comment>{0} - will be replaced by the name of the nested installer file
-
 {1} - will be replaced by the name of the zip archive.</comment>
   </data>
   <data name="MultipleMatchingNestedInstallersFound_Warning" xml:space="preserve">
     <value>Multiple matches found for "{0}" from {1}.</value>
     <comment>{0} - will be replaced by the name of the nested installer file
-
 {1} - will be replaced by the name of the zip archive.</comment>
   </data>
   <data name="NestedInstallerFileNotFound_Warning" xml:space="preserve">
@@ -1105,9 +1100,7 @@
   <data name="VersionDoesNotExist_Error" xml:space="preserve">
     <value>Version {0} does not exist for {1} in the Windows Package Manager repository.</value>
     <comment>{0} - will be replaced with the package version
-
-{1} - will be replaced with the package ID
-</comment>
+{1} - will be replaced with the package ID</comment>
   </data>
   <data name="ReplaceVersion_HelpText" xml:space="preserve">
     <value>Optional. Package version used in conjunction with the replace argument to replace an older version of the manifest from the Windows Package Manager repo.</value>
@@ -1156,7 +1149,6 @@
   <data name="SentenceMutuallyExclusiveSetErrors" xml:space="preserve">
     <value>Options: {0} are not compatible with {1}.</value>
     <comment>{0} - will be replaced with one or more provided command-line option(s)
-
 {1} - will be replaced with one or more provided command-line option(s)</comment>
   </data>
   <data name="SentenceNoVerbSelectedError" xml:space="preserve">
@@ -1182,7 +1174,6 @@
   <data name="SentenceSetValueExceptionError" xml:space="preserve">
     <value>Error setting value to option '{0}': {1}</value>
     <comment>{0} - will be replaced with the provided command-line option
-
 {1} - will be replaced with the provided value for the command-line option</comment>
   </data>
   <data name="SentenceUnknownOptionError" xml:space="preserve">

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1121,4 +1121,67 @@
   <data name="AutoReplacingPreviousVersion_Message" xml:space="preserve">
     <value>Vanity URL detected. The submission will automatically replace the previous version.</value>
   </data>
+  <data name="SentenceBadFormatConversionErrorOption" xml:space="preserve">
+    <value>Option '{0}' is defined with a bad format.</value>
+  </data>
+  <data name="SentenceBadFormatConversionErrorValue" xml:space="preserve">
+    <value>A value not bound to option name is defined with a bad format.</value>
+  </data>
+  <data name="SentenceBadFormatTokenError" xml:space="preserve">
+    <value>Token '{0}' is not recognized.</value>
+  </data>
+  <data name="SentenceBadVerbSelectedError" xml:space="preserve">
+    <value>Verb '{0}' is not recognized.</value>
+  </data>
+  <data name="SentenceErrorsHeadingText" xml:space="preserve">
+    <value>ERROR(S):</value>
+  </data>
+  <data name="SentenceHelpCommandTextOption" xml:space="preserve">
+    <value>Display this help screen.</value>
+  </data>
+  <data name="SentenceHelpCommandTextVerb" xml:space="preserve">
+    <value>Display more information on a specific command.</value>
+  </data>
+  <data name="SentenceMissingRequiredOptionError" xml:space="preserve">
+    <value>Required option '{0}' is missing.</value>
+  </data>
+  <data name="SentenceMissingValueOptionError" xml:space="preserve">
+    <value>Option '{0}' has no value.</value>
+  </data>
+  <data name="SentenceMutuallyExclusiveSetErrors" xml:space="preserve">
+    <value>Options: {0} are not compatible with {1}.</value>
+  </data>
+  <data name="SentenceNoVerbSelectedError" xml:space="preserve">
+    <value>No verb selected.</value>
+  </data>
+  <data name="SentenceOptionGroupWord" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="SentenceRepeatedOptionError" xml:space="preserve">
+    <value>Option '{0}' is defined multiple times.</value>
+  </data>
+  <data name="SentenceRequiredWord" xml:space="preserve">
+    <value>Required.</value>
+  </data>
+  <data name="SentenceSequenceOutOfRangeErrorOption" xml:space="preserve">
+    <value>A sequence option '{0}' is defined with fewer or more items than required.</value>
+  </data>
+  <data name="SentenceSequenceOutOfRangeErrorValue" xml:space="preserve">
+    <value>A sequence value not bound to option name is defined with fewer items than required.</value>
+  </data>
+  <data name="SentenceSetValueExceptionError" xml:space="preserve">
+    <value>Error setting value to option '{0}': {1}</value>
+  </data>
+  <data name="SentenceUnknownOptionError" xml:space="preserve">
+    <value>Option '{0}' is unknown.</value>
+  </data>
+  <data name="SentenceUsageHeadingText" xml:space="preserve">
+    <value>USAGE:</value>
+  </data>
+  <data name="SentenceVersionCommandText" xml:space="preserve">
+    <value>Display version information.</value>
+  </data>
+  <data name="SentenceMissingRequiredValueError" xml:space="preserve">
+    <value>A required value not bound to option name is missing.</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1123,15 +1123,18 @@
   </data>
   <data name="SentenceBadFormatConversionErrorOption" xml:space="preserve">
     <value>Option '{0}' is defined with a bad format.</value>
+    <comment>{0} - will be replaced with the provided command-line option</comment>
   </data>
   <data name="SentenceBadFormatConversionErrorValue" xml:space="preserve">
     <value>A value not bound to option name is defined with a bad format.</value>
   </data>
   <data name="SentenceBadFormatTokenError" xml:space="preserve">
     <value>Token '{0}' is not recognized.</value>
+    <comment>{0} - will be replaced with the unrecognized command-line token</comment>
   </data>
   <data name="SentenceBadVerbSelectedError" xml:space="preserve">
     <value>Verb '{0}' is not recognized.</value>
+    <comment>{0} - will be replaced with the unrecognized command-line verb</comment>
   </data>
   <data name="SentenceErrorsHeadingText" xml:space="preserve">
     <value>ERROR(S):</value>
@@ -1144,12 +1147,17 @@
   </data>
   <data name="SentenceMissingRequiredOptionError" xml:space="preserve">
     <value>Required option '{0}' is missing.</value>
+    <comment>{0} - will be replaced with the required command-line option</comment>
   </data>
   <data name="SentenceMissingValueOptionError" xml:space="preserve">
     <value>Option '{0}' has no value.</value>
+    <comment>{0} - will be replaced with the provided command-line option</comment>
   </data>
   <data name="SentenceMutuallyExclusiveSetErrors" xml:space="preserve">
     <value>Options: {0} are not compatible with {1}.</value>
+    <comment>{0} - will be replaced with the provided command-line option
+
+{1} - will be replaced with the provided command-line option</comment>
   </data>
   <data name="SentenceNoVerbSelectedError" xml:space="preserve">
     <value>No verb selected.</value>
@@ -1159,21 +1167,27 @@
   </data>
   <data name="SentenceRepeatedOptionError" xml:space="preserve">
     <value>Option '{0}' is defined multiple times.</value>
+    <comment>{0} - will be replaced with the repeated command-line option</comment>
   </data>
   <data name="SentenceRequiredWord" xml:space="preserve">
     <value>Required.</value>
   </data>
   <data name="SentenceSequenceOutOfRangeErrorOption" xml:space="preserve">
     <value>A sequence option '{0}' is defined with fewer or more items than required.</value>
+    <comment>{0} - will be replaced with the provided command-line option</comment>
   </data>
   <data name="SentenceSequenceOutOfRangeErrorValue" xml:space="preserve">
     <value>A sequence value not bound to option name is defined with fewer items than required.</value>
   </data>
   <data name="SentenceSetValueExceptionError" xml:space="preserve">
     <value>Error setting value to option '{0}': {1}</value>
+    <comment>{0} - will be replaced with the provided command-line option
+
+{1} - will be replaced with the provided value in the command-line</comment>
   </data>
   <data name="SentenceUnknownOptionError" xml:space="preserve">
     <value>Option '{0}' is unknown.</value>
+    <comment>{0} - will be replaced with the unrecognized command-line option</comment>
   </data>
   <data name="SentenceUsageHeadingText" xml:space="preserve">
     <value>USAGE:</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1155,9 +1155,9 @@
   </data>
   <data name="SentenceMutuallyExclusiveSetErrors" xml:space="preserve">
     <value>Options: {0} are not compatible with {1}.</value>
-    <comment>{0} - will be replaced with the provided command-line option
+    <comment>{0} - will be replaced with one or more provided command-line option(s)
 
-{1} - will be replaced with the provided command-line option</comment>
+{1} - will be replaced with one or more provided command-line option(s)</comment>
   </data>
   <data name="SentenceNoVerbSelectedError" xml:space="preserve">
     <value>No verb selected.</value>
@@ -1183,7 +1183,7 @@
     <value>Error setting value to option '{0}': {1}</value>
     <comment>{0} - will be replaced with the provided command-line option
 
-{1} - will be replaced with the provided value in the command-line</comment>
+{1} - will be replaced with the provided value for the command-line option</comment>
   </data>
   <data name="SentenceUnknownOptionError" xml:space="preserve">
     <value>Option '{0}' is unknown.</value>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #251

Reference implementation taken from the wiki: 

> To localize the keywords "Required,Default" and the error messages, add the the string expressions of the class SentenceBuilder to the resource files.

- https://github.com/commandlineparser/commandline/wiki/Help-Localization

- https://github.com/commandlineparser/commandline/blob/master/demo/ReadText.LocalizedDemo/LocalizableSentenceBuilder.cs
	
I modified the file to resolve any VS warnings

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/457)