### PR TITLE
User/masudars/microsoft winget create azure pipelines loc migration to 1 es

### DIFF
--- a/pipelines/azure-pipelines.loc.yml
+++ b/pipelines/azure-pipelines.loc.yml
@@ -20,35 +20,54 @@ pr: none
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 
-jobs:
-  - job: Localize
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
     pool:
-      vmImage: windows-latest
-    variables:
-      skipComponentGovernanceDetection: true
-    steps:
-      - task: MicrosoftTDBuild.tdbuild-task.tdbuild-task.TouchdownBuildTask@1
-        displayName: Send resources to Touchdown Build
-        inputs:
-          teamId: 25160
-          authId: cd9fc0c7-0aaa-461f-a098-6c97c3b1cfb1
-          authKey: $(LocServiceKey)
-          isPreview: false
-          relativePathRoot: src\WingetCreateCLI\Properties
-          resourceFilePath: "*.resx"
-          outputDirectoryRoot: Localization\Resources
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
-      - script: |
-          cd $(Build.SourcesDirectory)
-          git add -A
-          git diff --cached --exit-code
-          echo ##vso[task.setvariable variable=hasChanges]%errorlevel%
-          git diff --cached > $(Build.ArtifactStagingDirectory)\LocalizedStrings.patch
-        displayName: Check for changes and create patch file
+    stages:
+    - stage: Localize
+      jobs:
+        - job: Localize
+          variables:
+            skipComponentGovernanceDetection: true
+          steps:
+            - task: MicrosoftTDBuild.tdbuild-task.tdbuild-task.TouchdownBuildTask@1
+              displayName: Send resources to Touchdown Build
+              inputs:
+                teamId: 25160
+                authId: cd9fc0c7-0aaa-461f-a098-6c97c3b1cfb1
+                authKey: $(LocServiceKey)
+                isPreview: false
+                relativePathRoot: src\WingetCreateCLI\Properties
+                resourceFilePath: "*.resx"
+                outputDirectoryRoot: Localization\Resources
 
-      - task: PublishPipelineArtifact@0
-        displayName: Publish patch file as artifact
-        condition: eq(variables['hasChanges'], '1')
-        inputs:
-          artifactName: Patch
-          targetPath: $(Build.ArtifactStagingDirectory)
+            - task: CmdLine@2
+              displayName: Check for changes and create patch file
+              inputs:
+                script: |
+                  cd $(Build.SourcesDirectory)
+                  git add -A
+                  git diff --cached --exit-code
+                  echo ##vso[task.setvariable variable=hasChanges]%errorlevel%
+                  git diff --cached > $(Build.ArtifactStagingDirectory)\LocalizedStrings.patch
+
+            templateContext:
+              outputs:
+              - output: pipelineArtifact
+                displayName: 'Publish patch file as artifact'
+                condition: eq(variables['hasChanges'], '1')
+                artifactName: Patch
+                targetPath: $(Build.ArtifactStagingDirectory)

--- a/pipelines/azure-pipelines.loc.yml
+++ b/pipelines/azure-pipelines.loc.yml
@@ -43,31 +43,31 @@ extends:
           variables:
             skipComponentGovernanceDetection: true
           steps:
-            - task: MicrosoftTDBuild.tdbuild-task.tdbuild-task.TouchdownBuildTask@1
-              displayName: Send resources to Touchdown Build
-              inputs:
-                teamId: 25160
-                authId: cd9fc0c7-0aaa-461f-a098-6c97c3b1cfb1
-                authKey: $(LocServiceKey)
-                isPreview: false
-                relativePathRoot: src\WingetCreateCLI\Properties
-                resourceFilePath: "*.resx"
-                outputDirectoryRoot: Localization\Resources
+          - task: MicrosoftTDBuild.tdbuild-task.tdbuild-task.TouchdownBuildTask@1
+            displayName: Send resources to Touchdown Build
+            inputs:
+              teamId: 25160
+              authId: cd9fc0c7-0aaa-461f-a098-6c97c3b1cfb1
+              authKey: $(LocServiceKey)
+              isPreview: false
+              relativePathRoot: src\WingetCreateCLI\Properties
+              resourceFilePath: "*.resx"
+              outputDirectoryRoot: Localization\Resources
 
-            - task: CmdLine@2
-              displayName: Check for changes and create patch file
-              inputs:
-                script: |
-                  cd $(Build.SourcesDirectory)
-                  git add -A
-                  git diff --cached --exit-code
-                  echo ##vso[task.setvariable variable=hasChanges]%errorlevel%
-                  git diff --cached > $(Build.ArtifactStagingDirectory)\LocalizedStrings.patch
+          - task: CmdLine@2
+            displayName: Check for changes and create patch file
+            inputs:
+              script: |
+                cd $(Build.SourcesDirectory)
+                git add -A
+                git diff --cached --exit-code
+                echo ##vso[task.setvariable variable=hasChanges]%errorlevel%
+                git diff --cached > $(Build.ArtifactStagingDirectory)\LocalizedStrings.patch
 
-            templateContext:
-              outputs:
-              - output: pipelineArtifact
-                displayName: 'Publish patch file as artifact'
-                condition: eq(variables['hasChanges'], '1')
-                artifactName: Patch
-                targetPath: $(Build.ArtifactStagingDirectory)
+          templateContext:
+            outputs:
+            - output: pipelineArtifact
+              displayName: 'Publish patch file as artifact'
+              condition: eq(variables['hasChanges'], '1')
+              artifactName: Patch
+              targetPath: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
This PR migrates the following winget-create pipelines to 1ESPipeline.

- azure-pipelines.loc.yml

[How Validated:]
- Initiate the [pipeline](https://dev.azure.com/microsoft/Apps/_build/results?buildId=82768538&view=results) manually from the topic branch that includes these changes and confirm that the pipeline functions as it did before.
- Compare the artifacts generated by the pipeline before and after the migration to ensure that they match.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/471)