### PR TITLE
User/masudars/microsoft winget create azure pipelines release migration to 1 es

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -208,7 +208,7 @@ extends:
             - task: CopyFiles@2
               displayName: Copy files to be published to staging directory
               inputs:
-                targetFolder: $(Build.ArtifactStagingDirectory)
+                targetFolder: $(Build.ArtifactStagingDirectory)/wingetcreate
                 flattenFolders: true
                 contents: |
                   $(exePathFrameworkDependent)
@@ -218,7 +218,7 @@ extends:
 
             - task: 1ES.PublishPipelineArtifact@1
               inputs:
-                targetPath: $(Build.ArtifactStagingDirectory)
+                targetPath: $(Build.ArtifactStagingDirectory)/wingetcreate
                 artifactName: wingetcreate
                 displayName: Publish appx, exe, and hash files
 
@@ -231,7 +231,7 @@ extends:
                 tag: v$(version)
                 isPreRelease: true
                 isDraft: true # After running this step, visit the new draft release, edit, and publish.
-                assets: $(Build.ArtifactStagingDirectory)/*
+                assets: $(Build.ArtifactStagingDirectory)/wingetcreate/*
 
         - job: Wait
           displayName: Wait for vanity URL to be manually updated

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -22,230 +22,257 @@ variables:
   # Build platform
   buildPlatform: "x64"
 
-jobs:
-  - job: GetVersion
-    variables:
-      runCodesignValidationInjection: ${{ false }}
-      skipComponentGovernanceDetection: ${{ true }}
-    steps:
-      - powershell: |
-          [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
-          $version = @($project.Project.PropertyGroup)[0].Version
-          echo "##vso[task.setvariable variable=majorMinorVersion;isOutput=true]$version"
-        name: GetVersionStep
-        displayName: Get version from CLI project
-
-  - job: Build
-    displayName: Build
-    dependsOn: GetVersion
-    variables:
-      majorMinorVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorVersion']]
-      buildVersion: $[counter(variables['majorMinorVersion'], 1)]
-      version: "$(majorMinorVersion).$(buildVersion).0"
-      appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
-      appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
-      exeDirFrameworkDependent: '$(appxPackageDir)\dependent'
-      exePathFrameworkDependent: '$(exeDirFrameworkDependent)\WingetCreateCLI\wingetcreate.exe'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
     pool:
-      vmImage: $(vmImageName)
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
-    steps:
-      - checkout: self
-        lfs: "true"
+    stages:
+    - stage: __default
 
-      - powershell: |
-          echo $(version)
-          echo $(appxBundlePath)
-          echo $(appxBundleFile)
-          echo $(exePathFrameworkDependent)
-          echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
-          echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
-        name: OutputVersionStep
-        displayName: Set output variables for UpdateManifest job
+      jobs:
+        - job: GetVersion
+          variables:
+            runCodesignValidationInjection: ${{ false }}
+            skipComponentGovernanceDetection: ${{ true }}
+          steps:
+            - task: PowerShell@2
+              name: GetVersionStep
+              displayName: Get version from CLI project
+              inputs:
+                targetType: inline
+                script: |
+                  [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
+                  $version = @($project.Project.PropertyGroup)[0].Version
+                  echo "##vso[task.setvariable variable=majorMinorVersion;isOutput=true]$version"
 
-      - powershell: |
-          [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
-          $manifest.Package.Identity.Version = "$(version)"
-          $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
+        - job: Build
+          displayName: Build
+          dependsOn: GetVersion
+          variables:
+            majorMinorVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorVersion']]
+            buildVersion: $[counter(variables['majorMinorVersion'], 1)]
+            version: "$(majorMinorVersion).$(buildVersion).0"
+            appxBundleFile: "Microsoft.WindowsPackageManagerManifestCreator_$(version)_8wekyb3d8bbwe.msixbundle"
+            appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
+            exeDirFrameworkDependent: '$(appxPackageDir)\dependent'
+            exePathFrameworkDependent: '$(exeDirFrameworkDependent)\WingetCreateCLI\wingetcreate.exe'
 
-          [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
-          @($project.Project.PropertyGroup)[0].Version = "$(version)"
-          $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
-        displayName: "Update cli and package manifest version"
+          steps:
+            - checkout: self
+              lfs: "true"
 
-      - task: DeleteFiles@1
-        displayName: "Delete existing stubbed TelemetryEventSources.cs. Not necessary, but will cause build to fail if fetch fails."
-        inputs:
-          Contents: '$(workingDirectory)\WingetCreateCLI\Telemetry\TelemetryEventSource.cs'
+            - task: PowerShell@2
+              name: OutputVersionStep
+              displayName: Set output variables for UpdateManifest job
+              inputs:
+                targetType: inline
+                script: |
+                  echo $(version)
+                  echo $(appxBundlePath)
+                  echo $(appxBundleFile)
+                  echo $(exePathFrameworkDependent)
+                  echo "##vso[task.setvariable variable=manifestVersion;isOutput=true]$(version)"
+                  echo "##vso[task.setvariable variable=appxBundleFile;isOutput=true]$(appxBundleFile)"
 
-      - task: PkgESGitFetch@10
-        displayName: "Fetch TelemetryEventSource.cs from OS repo and overwrite stubbed version"
-        inputs:
-          repository: "https://microsoft.visualstudio.com/os/_git/os.2020"
-          branch: official/main
-          source: 'minkernel\published\internal\telemetry\TelemetryEventSource.cs'
-          destination: '$(workingDirectory)\WingetCreateCLI\Telemetry\'
+            - task: PowerShell@2
+              displayName: "Update cli and package manifest version"
+              inputs:
+                targetType: inline
+                script: |
+                  [xml]$manifest = get-content "$(workingDirectory)/WingetCreatePackage/Package.appxmanifest"
+                  $manifest.Package.Identity.Version = "$(version)"
+                  $manifest.save("$(workingDirectory)/WingetCreatePackage/Package.appxmanifest")
 
-      # Copies binary dependencies from VCLibs package to be included in standalone exe     
-      - task: PowerShell@2
-        displayName: Download VCLibs package
-        inputs:
-          targetType: 'inline'
-          script: | 
-            iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
+                  [xml]$project = get-content "$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj"
+                  @($project.Project.PropertyGroup)[0].Version = "$(version)"
+                  $project.save("$(workingDirectory)/WingetCreateCLI/WingetCreateCLI.csproj")
 
-      - task: ExtractFiles@1
-        displayName: Extract files from VCLibs appx
-        inputs:
-          archiveFilePatterns: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
-          destinationFolder: '$(workingDirectory)\WingetCreateCLI'
-          cleanDestinationFolder: false
-          overwriteExistingFiles: false                 
+            - task: DeleteFiles@1
+              displayName: "Delete existing stubbed TelemetryEventSources.cs. Not necessary, but will cause build to fail if fetch fails."
+              inputs:
+                Contents: '$(workingDirectory)\WingetCreateCLI\Telemetry\TelemetryEventSource.cs'
 
-      - task: DotNetCoreCLI@2
-        displayName: Restore
-        inputs:
-          command: restore
-          feedsToUse: config
-          nugetConfigPath: "nuget.config"
-          projects: $(workingDirectory)/**/*.csproj
+            - task: PkgESGitFetch@10
+              displayName: "Fetch TelemetryEventSource.cs from OS repo and overwrite stubbed version"
+              inputs:
+                repository: "https://microsoft.visualstudio.com/os/_git/os.2020"
+                branch: official/main
+                source: 'minkernel\published\internal\telemetry\TelemetryEventSource.cs'
+                destination: '$(workingDirectory)\WingetCreateCLI\Telemetry\'
 
-      - task: DotNetCoreCLI@2
-        displayName: Build standalone, framework-dependent exe
-        inputs:
-          command: publish
-          publishWebProjects: false
-          zipAfterPublish: false
-          projects: $(workingDirectory)/**/WingetCreateCLI.csproj
-          arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
+            # Copies binary dependencies from VCLibs package to be included in standalone exe     
+            - task: PowerShell@2
+              displayName: Download VCLibs package
+              inputs:
+                targetType: 'inline'
+                script: | 
+                  iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
 
-      - task: MSBuild@1
-        displayName: Build Solution
-        inputs:
-          platform: "$(buildPlatform)"
-          solution: "$(solution)"
-          configuration: "$(buildConfiguration)"
-          msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
-            /p:AppxBundle=Always
-            /p:UapAppxPackageBuildMode=SideloadOnly
-            /p:AppxPackageSigningEnabled=false'
+            - task: ExtractFiles@1
+              displayName: Extract files from VCLibs appx
+              inputs:
+                archiveFilePatterns: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
+                destinationFolder: '$(workingDirectory)\WingetCreateCLI'
+                cleanDestinationFolder: false
+                overwriteExistingFiles: false                 
 
-      - task: UseDotNet@2
-        displayName: 'Install .NET Core SDK required for ESRPCodeSigning'
-        inputs:
-          packageType: sdk
-          version: '6.x'      
+            - task: DotNetCoreCLI@2
+              displayName: Restore
+              inputs:
+                command: restore
+                feedsToUse: config
+                nugetConfigPath: "nuget.config"
+                projects: $(workingDirectory)/**/*.csproj
 
-      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-        displayName: "ESRP CodeSigning"
-        inputs:
-          ConnectedServiceName: "PeetPackageEs2"
-          FolderPath: $(appxPackageDir)
-          Pattern: |
-            $(appxBundleFile)
-            **/WingetCreateCLI.exe
-          UseMinimatch: true
-          signConfigType: inlineSignParams
-          inlineOperation: |
-            [
-              {
-                  "KeyCode" : "CP-230012",
-                  "OperationCode" : "SigntoolSign",
-                  "Parameters" : {
-                      "OpusName" : "Microsoft",
-                      "OpusInfo" : "http://www.microsoft.com",
-                      "FileDigest" : "/fd \"SHA256\"",
-                      "PageHash" : "/NPH",
-                      "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                  },
-                  "ToolName" : "sign",
-                  "ToolVersion" : "1.0"
-              },
-              {
-                  "KeyCode" : "CP-230012",
-                  "OperationCode" : "SigntoolVerify",
-                  "Parameters" : {},
-                  "ToolName" : "sign",
-                  "ToolVersion" : "1.0"
-              }
-            ]
+            - task: DotNetCoreCLI@2
+              displayName: Build standalone, framework-dependent exe
+              inputs:
+                command: publish
+                publishWebProjects: false
+                zipAfterPublish: false
+                projects: $(workingDirectory)/**/WingetCreateCLI.csproj
+                arguments: "--configuration Release --runtime=win-x64 --output $(exeDirFrameworkDependent) -p:DebugType=None -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true --self-contained=false"
 
-      - powershell: |
-          ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
-          (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
-          (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
-        displayName: "Create hash files"
+            - task: MSBuild@1
+              displayName: Build Solution
+              inputs:
+                platform: "$(buildPlatform)"
+                solution: "$(solution)"
+                configuration: "$(buildConfiguration)"
+                msbuildArguments: '/p:AppxBundleOutput="$(appxBundlePath)"
+                  /p:AppxBundle=Always
+                  /p:UapAppxPackageBuildMode=SideloadOnly
+                  /p:AppxPackageSigningEnabled=false'
 
-      - task: CopyFiles@2
-        displayName: Copy files to be published to staging directory
-        inputs:
-          targetFolder: $(Build.ArtifactStagingDirectory)
-          flattenFolders: true
-          contents: |
-            $(exePathFrameworkDependent)
-            $(exePathFrameworkDependent).txt
-            $(appxBundlePath)
-            $(appxBundlePath).txt
+            - task: UseDotNet@2
+              displayName: 'Install .NET Core SDK required for ESRPCodeSigning'
+              inputs:
+                packageType: sdk
+                version: '6.x'      
 
-      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        displayName: 'Generate SBOM'
-        inputs:
-            BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+            - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+              displayName: "ESRP CodeSigning"
+              inputs:
+                ConnectedServiceName: "PeetPackageEs2"
+                FolderPath: $(appxPackageDir)
+                Pattern: |
+                  $(appxBundleFile)
+                  **/WingetCreateCLI.exe
+                UseMinimatch: true
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                    {
+                        "KeyCode" : "CP-230012",
+                        "OperationCode" : "SigntoolSign",
+                        "Parameters" : {
+                            "OpusName" : "Microsoft",
+                            "OpusInfo" : "http://www.microsoft.com",
+                            "FileDigest" : "/fd \"SHA256\"",
+                            "PageHash" : "/NPH",
+                            "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                        },
+                        "ToolName" : "sign",
+                        "ToolVersion" : "1.0"
+                    },
+                    {
+                        "KeyCode" : "CP-230012",
+                        "OperationCode" : "SigntoolVerify",
+                        "Parameters" : {},
+                        "ToolName" : "sign",
+                        "ToolVersion" : "1.0"
+                    }
+                  ]
 
-      - publish: $(Build.ArtifactStagingDirectory)
-        artifact: wingetcreate
-        displayName: Publish appx, exe, and hash files
+            - task: PowerShell@2
+              displayName: "Create hash files"
+              inputs:
+                targetType: inline
+                script: |
+                  ren "$(exeDirFrameworkDependent)\WingetCreateCLI\WingetCreateCLI.exe" wingetcreate.exe
+                  (Get-FileHash -Algorithm SHA256 -Path $(exePathFrameworkDependent)).Hash > "$(exePathFrameworkDependent).txt"
+                  (Get-FileHash -Algorithm SHA256 -Path $(appxBundlePath)).Hash > "$(appxBundlePath).txt"
 
-      - task: GitHubRelease@1
-        displayName: Create GitHub release
-        inputs:
-          gitHubConnection: github
-          repositoryName: $(Build.Repository.Name)
-          tagSource: userSpecifiedTag
-          tag: v$(version)
-          isPreRelease: true
-          isDraft: true # After running this step, visit the new draft release, edit, and publish.
-          assets: $(Build.ArtifactStagingDirectory)/*
+            - task: CopyFiles@2
+              displayName: Copy files to be published to staging directory
+              inputs:
+                targetFolder: $(Build.ArtifactStagingDirectory)
+                flattenFolders: true
+                contents: |
+                  $(exePathFrameworkDependent)
+                  $(exePathFrameworkDependent).txt
+                  $(appxBundlePath)
+                  $(appxBundlePath).txt
 
-  - job: Wait
-    displayName: Wait for vanity URL to be manually updated
-    dependsOn: Build
-    pool: server
-    timeoutInMinutes: 1440 # job times out in 1 day
-    steps:
-      - task: ManualValidation@0
-        timeoutInMinutes: 1440 # task times out in 1 day
-        inputs:
-          instructions: "Please update aka.ms vanity URLs for latest release"
+            - task: 1ES.PublishPipelineArtifact@1
+              inputs:
+                targetPath: $(Build.ArtifactStagingDirectory)
+                artifactName: wingetcreate
+                displayName: Publish appx, exe, and hash files
 
-  - job: UpdateManifest
-    dependsOn:
-      - Build
-      - Wait
-    pool:
-      vmImage: $(vmImageName)
-    variables:
-      runCodesignValidationInjection: ${{ false }}
-      skipComponentGovernanceDetection: ${{ true }}
-      manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
-      appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
-      vcLibsBundleFile: "Microsoft.VCLibs.x64.14.00.Desktop.appx"
-      msixPackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
-      portablePackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/wingetcreate.exe"
-    steps:
-      - checkout: none
+            - task: GitHubRelease@1
+              displayName: Create GitHub release
+              inputs:
+                gitHubConnection: github
+                repositoryName: $(Build.Repository.Name)
+                tagSource: userSpecifiedTag
+                tag: v$(version)
+                isPreRelease: true
+                isDraft: true # After running this step, visit the new draft release, edit, and publish.
+                assets: $(Build.ArtifactStagingDirectory)/*
 
-      - powershell: |
-          # These are the steps you would run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-          # More information about using wingetcreate in your CI/CD pipeline can be found here:
-          # https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+        - job: Wait
+          displayName: Wait for vanity URL to be manually updated
+          dependsOn: Build
+          pool: server
+          timeoutInMinutes: 1440 # job times out in 1 day
+          steps:
+            - task: ManualValidation@0
+              timeoutInMinutes: 1440 # task times out in 1 day
+              inputs:
+                instructions: "Please update aka.ms vanity URLs for latest release"
 
-          # Download and install C++ Runtime framework package.
-          iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile $(vcLibsBundleFile)
-          Add-AppxPackage $(vcLibsBundleFile)
+        - job: UpdateManifest
+          dependsOn:
+            - Build
+            - Wait
+          variables:
+            runCodesignValidationInjection: ${{ false }}
+            skipComponentGovernanceDetection: ${{ true }}
+            manifestVersion: $[dependencies.Build.outputs['OutputVersionStep.manifestVersion']]
+            appxBundleFile: $[dependencies.Build.outputs['OutputVersionStep.appxBundleFile']]
+            vcLibsBundleFile: "Microsoft.VCLibs.x64.14.00.Desktop.appx"
+            msixPackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
+            portablePackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/wingetcreate.exe"
+          steps:
+            - checkout: none
+        
+          - task: PowerShell@2
+            displayName: Update package manifest in the OWC
+            inputs:
+              targetType: inline
+              script: |
+                # These are the steps you would run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+                # More information about using wingetcreate in your CI/CD pipeline can be found here:
+                # https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
 
-          # Download, install, and execute update.
-          iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
-          Add-AppxPackage $(appxBundleFile)
-          wingetcreate update Microsoft.WingetCreate --urls $(msixPackageUrl) '$(portablePackageUrl)|x64' '$(portablePackageUrl)|x86' -v $(manifestVersion) -t $(GITHUB_PAT) --submit
-        displayName: Update package manifest in the OWC
+                # Download and install C++ Runtime framework package.
+                iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile $(vcLibsBundleFile)
+                Add-AppxPackage $(vcLibsBundleFile)
+
+                # Download, install, and execute update.
+                iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
+                Add-AppxPackage $(appxBundleFile)
+                wingetcreate update Microsoft.WingetCreate --urls $(msixPackageUrl) '$(portablePackageUrl)|x64' '$(portablePackageUrl)|x86' -v $(manifestVersion) -t $(GITHUB_PAT) --submit

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -259,20 +259,20 @@ extends:
           steps:
             - checkout: none
         
-          - task: PowerShell@2
-            displayName: Update package manifest in the OWC
-            inputs:
-              targetType: inline
-              script: |
-                # These are the steps you would run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
-                # More information about using wingetcreate in your CI/CD pipeline can be found here:
-                # https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
+            - task: PowerShell@2
+              displayName: Update package manifest in the OWC
+              inputs:
+                targetType: inline
+                script: |
+                  # These are the steps you would run in your CI/CD pipeline to update your OWC manifest using wingetcreate.
+                  # More information about using wingetcreate in your CI/CD pipeline can be found here:
+                  # https://github.com/microsoft/winget-create#using-windows-package-manager-manifest-creator-in-a-cicd-pipeline
 
-                # Download and install C++ Runtime framework package.
-                iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile $(vcLibsBundleFile)
-                Add-AppxPackage $(vcLibsBundleFile)
+                  # Download and install C++ Runtime framework package.
+                  iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile $(vcLibsBundleFile)
+                  Add-AppxPackage $(vcLibsBundleFile)
 
-                # Download, install, and execute update.
-                iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
-                Add-AppxPackage $(appxBundleFile)
-                wingetcreate update Microsoft.WingetCreate --urls $(msixPackageUrl) '$(portablePackageUrl)|x64' '$(portablePackageUrl)|x86' -v $(manifestVersion) -t $(GITHUB_PAT) --submit
+                  # Download, install, and execute update.
+                  iwr https://aka.ms/wingetcreate/latest/msixbundle -OutFile $(appxBundleFile)
+                  Add-AppxPackage $(appxBundleFile)
+                  wingetcreate update Microsoft.WingetCreate --urls $(msixPackageUrl) '$(portablePackageUrl)|x64' '$(portablePackageUrl)|x86' -v $(manifestVersion) -t $(GITHUB_PAT) --submit


### PR DESCRIPTION
This PR migrates the following winget-create pipelines to 1ESPipeline.

- azure-pipelines.release

[How Validated:]
- Initiate the [pipeline](https://microsoft.visualstudio.com/Apps/_build/results?buildId=82874865&view=results) manually from the topic branch that includes these changes and confirm that the pipeline functions as it did before.
- Compare the artifacts generated by the pipeline before and after the migration to ensure that they match.

[TODO]:
Publish only the necessary artifacts by fixing the publishing path.


- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/472)