### PR TITLE
Updated localization pipeline to use federated credentials

### DIFF
--- a/pipelines/azure-pipelines.loc.yml
+++ b/pipelines/azure-pipelines.loc.yml
@@ -43,12 +43,12 @@ extends:
           variables:
             skipComponentGovernanceDetection: true
           steps:
-          - task: MicrosoftTDBuild.tdbuild-task.tdbuild-task.TouchdownBuildTask@1
+          - task: TouchdownBuildTask@4
             displayName: Send resources to Touchdown Build
             inputs:
               teamId: 25160
-              authId: cd9fc0c7-0aaa-461f-a098-6c97c3b1cfb1
-              authKey: $(LocServiceKey)
+              authId: FederatedIdentity
+              FederatedIdentityServiceConnection: WingetCreateTDBuild
               isPreview: false
               relativePathRoot: src\WingetCreateCLI\Properties
               resourceFilePath: "*.resx"

--- a/pipelines/azure-pipelines.loc.yml
+++ b/pipelines/azure-pipelines.loc.yml
@@ -47,7 +47,7 @@ extends:
             displayName: Send resources to Touchdown Build
             inputs:
               teamId: 25160
-              authId: FederatedIdentity
+              authType: FederatedIdentity
               FederatedIdentityServiceConnection: WingetCreateTDBuild
               isPreview: false
               relativePathRoot: src\WingetCreateCLI\Properties


### PR DESCRIPTION
Updates the touchdown build task to use the latest federated credential auth type. Remove's service key secret
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/535)