### PR TITLE
Fix for Loading Invalid Manifests

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -765,12 +765,11 @@ namespace Microsoft.WingetCreateCore
         {
             try
             {
-                ManifestResource rc = new ManifestResource();
+                XmlDocument manifest = GetManifest(path);
                 InstallerType? installerTypeEnum;
                 try
                 {
-                    rc.LoadFrom(path);
-                    string installerType = rc.Manifest.DocumentElement
+                    string installerType = manifest?.DocumentElement?
                         .GetElementsByTagName("description")
                         .Cast<XmlNode>()
                         .FirstOrDefault()?
@@ -1048,6 +1047,27 @@ namespace Microsoft.WingetCreateCore
         private static string RemoveInvalidCharsFromString(string value)
         {
             return Regex.Replace(value, InvalidCharacters, string.Empty);
+        }
+
+        /// <summary>
+        /// Gets the manifest from the specified path.</summary>
+        /// <param name="path">The path to the manifest.</param>
+        /// <returns>XmlDocument of the manifest.</returns>
+        private static XmlDocument GetManifest(string path)
+        {
+            var rc = new ManifestResource();
+            var manifest = new XmlDocument();
+
+            try
+            {
+                rc.LoadFrom(path);
+                manifest = rc.Manifest;
+            }
+            catch (Exception ex)
+            {
+            }
+
+            return manifest;
         }
     }
 }


### PR DESCRIPTION
- Added new GetManifest, wrapped in try/catch.
- Updated ParseExeInstallerType to use GetManifest

- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----
