### PR TITLE
Support auto-fetching metadata from GitHub API and add manual args

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -235,6 +235,17 @@ namespace Microsoft.WingetCreateCLI.Commands
                     }
 
                     ShiftRootFieldsToInstallerLevel(manifests.InstallerManifest);
+                    try
+                    {
+                        Logger.InfoLocalized(nameof(Resources.PopulatingGitHubMetadata_Message));
+                        await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                    }
+                    catch (Octokit.ApiException)
+                    {
+                        // Print a warning, but continue with the update.
+                        Logger.ErrorLocalized(nameof(Resources.CouldNotPopulateGitHubMetadata_Warning));
+                    }
+
                     PromptManifestProperties(manifests);
                     MergeNestedInstallerFilesIfApplicable(manifests.InstallerManifest);
                     ShiftInstallerFieldsToRootLevel(manifests.InstallerManifest);

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -238,7 +238,10 @@ namespace Microsoft.WingetCreateCLI.Commands
                     try
                     {
                         Logger.InfoLocalized(nameof(Resources.PopulatingGitHubMetadata_Message));
-                        await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                        if (this.GitHubClient != null)
+                        {
+                            await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                        }
                     }
                     catch (Octokit.ApiException)
                     {

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -245,7 +245,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     }
                     catch (Octokit.ApiException)
                     {
-                        // Print a warning, but continue with the update.
+                        // Print a warning, but continue with the command flow.
                         Logger.ErrorLocalized(nameof(Resources.CouldNotPopulateGitHubMetadata_Warning));
                     }
 

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.WingetCreateCLI.Commands
     using Microsoft.WingetCreateCore.Models.Installer;
     using Microsoft.WingetCreateCore.Models.Locale;
     using Microsoft.WingetCreateCore.Models.Version;
+    using Octokit;
     using Sharprompt;
 
     /// <summary>
@@ -164,6 +165,19 @@ namespace Microsoft.WingetCreateCLI.Commands
                 }
 
                 bool submitFlagMissing = !this.SubmitToGitHub && (!string.IsNullOrEmpty(this.PRTitle) || this.Replace);
+
+                if (!string.IsNullOrEmpty(this.ReleaseNotesUrl))
+                {
+                    Uri uriResult;
+                    bool isValid = Uri.TryCreate(this.ReleaseNotesUrl, UriKind.Absolute, out uriResult) &&
+                        (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+
+                    if (!isValid)
+                    {
+                        Logger.ErrorLocalized(nameof(Resources.SentenceBadFormatConversionErrorOption), nameof(this.ReleaseNotesUrl));
+                        return false;
+                    }
+                }
 
                 if (submitFlagMissing)
                 {

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -452,6 +452,17 @@ namespace Microsoft.WingetCreateCLI.Commands
                 PackageParser.UpdateInstallerNodesAsync(installerMetadataList, installerManifest);
                 DisplayArchitectureWarnings(installerMetadataList);
                 ResetVersionSpecificFields(manifests);
+                try
+                {
+                    Logger.InfoLocalized(nameof(Resources.PopulatingGitHubMetadata_Message));
+                    await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                }
+                catch (Octokit.ApiException)
+                {
+                    // Print a warning, but continue with the update.
+                    Logger.ErrorLocalized(nameof(Resources.CouldNotPopulateGitHubMetadata_Warning));
+                }
+
                 this.AddVersionSpecificMetadata(manifests);
                 ShiftInstallerFieldsToRootLevel(manifests.InstallerManifest);
             }
@@ -904,6 +915,17 @@ namespace Microsoft.WingetCreateCLI.Commands
                 await this.UpdateInstallersInteractively(manifests.InstallerManifest.Installers);
                 ShiftInstallerFieldsToRootLevel(manifests.InstallerManifest);
                 ResetVersionSpecificFields(manifests);
+                try
+                {
+                    Logger.InfoLocalized(nameof(Resources.PopulatingGitHubMetadata_Message));
+                    await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                }
+                catch (Octokit.ApiException)
+                {
+                    // Print a warning, but continue with the update.
+                    Logger.ErrorLocalized(nameof(Resources.CouldNotPopulateGitHubMetadata_Warning));
+                }
+
                 this.AddVersionSpecificMetadata(manifests);
                 DisplayManifestPreview(manifests);
                 ValidateManifestsInTempDir(manifests);

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -25,7 +25,6 @@ namespace Microsoft.WingetCreateCLI.Commands
     using Microsoft.WingetCreateCore.Models.Installer;
     using Microsoft.WingetCreateCore.Models.Locale;
     using Microsoft.WingetCreateCore.Models.Version;
-    using Octokit;
     using Sharprompt;
 
     /// <summary>

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -455,7 +455,11 @@ namespace Microsoft.WingetCreateCLI.Commands
                 try
                 {
                     Logger.InfoLocalized(nameof(Resources.PopulatingGitHubMetadata_Message));
-                    await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+
+                    if (this.GitHubClient != null)
+                    {
+                        await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                    }
                 }
                 catch (Octokit.ApiException)
                 {
@@ -918,7 +922,10 @@ namespace Microsoft.WingetCreateCLI.Commands
                 try
                 {
                     Logger.InfoLocalized(nameof(Resources.PopulatingGitHubMetadata_Message));
-                    await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                    if (this.GitHubClient != null)
+                    {
+                        await this.GitHubClient.PopulateGitHubMetadata(manifests, this.Format.ToString());
+                    }
                 }
                 catch (Octokit.ApiException)
                 {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -2473,6 +2473,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Date to be used when updating the release date field. Expected format is &quot;YYYY-MM-DD&quot;..
+        /// </summary>
+        public static string ReleaseDate_HelpText {
+            get {
+                return ResourceManager.GetString("ReleaseDate_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The installer release date.
         /// </summary>
         public static string ReleaseDate_KeywordDescription {
@@ -2496,6 +2505,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string ReleaseNotes_KeywordDescription {
             get {
                 return ResourceManager.GetString("ReleaseNotes_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to URL to be used when updating the release notes url field..
+        /// </summary>
+        public static string ReleaseNotesUrl_HelpText {
+            get {
+                return ResourceManager.GetString("ReleaseNotesUrl_HelpText", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -403,6 +403,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not populate manifest metadata through GitHub&apos;s API..
+        /// </summary>
+        public static string CouldNotPopulateGitHubMetadata_Warning {
+            get {
+                return ResourceManager.GetString("CouldNotPopulateGitHubMetadata_Warning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Would you like to create another locale?.
         /// </summary>
         public static string CreateAnotherLocale_Message {
@@ -2298,6 +2307,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string Platform_KeywordDescription {
             get {
                 return ResourceManager.GetString("Platform_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GitHub URL detected. The CLI will automatically fill some manifests fields..
+        /// </summary>
+        public static string PopulatingGitHubMetadata_Message {
+            get {
+                return ResourceManager.GetString("PopulatingGitHubMetadata_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1371,6 +1371,12 @@
   <data name="InstallerWithMultipleDisplayVersions_Warning" xml:space="preserve">
     <value>Single installer with multiple display versions detected. Winget-Create will only update the first DisplayVersion for a given installer.</value>
   </data>
+  <data name="CouldNotPopulateGitHubMetadata_Warning" xml:space="preserve">
+    <value>Could not populate manifest metadata through GitHub's API.</value>
+  </data>
+  <data name="PopulatingGitHubMetadata_Message" xml:space="preserve">
+    <value>GitHub URL detected. The CLI will automatically fill some manifests fields.</value>
+  </data>
   <data name="ReleaseDate_HelpText" xml:space="preserve">
     <value>Date to be used when updating the release date field. Expected format is "YYYY-MM-DD".</value>
   </data>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1371,4 +1371,10 @@
   <data name="InstallerWithMultipleDisplayVersions_Warning" xml:space="preserve">
     <value>Single installer with multiple display versions detected. Winget-Create will only update the first DisplayVersion for a given installer.</value>
   </data>
+  <data name="ReleaseDate_HelpText" xml:space="preserve">
+    <value>Date to be used when updating the release date field. Expected format is "YYYY-MM-DD".</value>
+  </data>
+  <data name="ReleaseNotesUrl_HelpText" xml:space="preserve">
+    <value>URL to be used when updating the release notes url field.</value>
+  </data>
 </root>

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -550,7 +550,8 @@ namespace Microsoft.WingetCreateCore.Common
                 }
 
                 // Tags
-                manifests.DefaultLocaleManifest.Tags ??= githubRepo.Topics?.ToList();
+                // 16 is the maximum number of tags allowed in the manifest
+                manifests.DefaultLocaleManifest.Tags ??= githubRepo.Topics?.Take(count: 16).ToList();
 
                 // ReleaseNotesUrl
                 if (string.IsNullOrEmpty(manifests.DefaultLocaleManifest.ReleaseNotesUrl))

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -12,6 +12,8 @@ namespace Microsoft.WingetCreateCore.Common
     using Jose;
     using Microsoft.WingetCreateCore.Common.Exceptions;
     using Microsoft.WingetCreateCore.Models;
+    using Microsoft.WingetCreateCore.Models.DefaultLocale;
+    using Microsoft.WingetCreateCore.Models.Installer;
     using Octokit;
     using Polly;
 
@@ -227,6 +229,21 @@ namespace Microsoft.WingetCreateCore.Common
         {
             string path = Constants.WingetManifestRoot + '/' + $"{char.ToLowerInvariant(packageId[0])}";
             return await this.FindPackageIdRecursive(packageId.Split('.'), path, string.Empty, 0);
+        }
+
+        /// <summary>
+        /// Uses the GitHub API to retrieve and populate metadata for manifests in the provided <see cref="Manifests"/> object.
+        /// </summary>
+        /// <param name="manifests">Wrapper object for manifest object models to be populated with GitHub metadata.</param>
+        /// <param name="serializerFormat">The output format of the manifest serializer.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task PopulateGitHubMetadata(Manifests manifests, string serializerFormat)
+        {
+            // Only populate metadata if we have a valid GitHub token.
+            if (this.github.Credentials.AuthenticationType != AuthenticationType.Anonymous)
+            {
+                await GitHubManifestMetadata.PopulateManifestMetadata(manifests, serializerFormat, this.github);
+            }
         }
 
         /// <summary>
@@ -478,6 +495,135 @@ namespace Microsoft.WingetCreateCore.Common
                 string newBranchNameHeads = $"heads/{pullRequest.Head.Ref}";
                 await this.github.Git.Reference.Delete(this.wingetRepoOwner, this.wingetRepo, newBranchNameHeads);
             }
+        }
+
+        private static class GitHubManifestMetadata
+        {
+            public static async Task PopulateManifestMetadata(Manifests manifests, string serializerFormat, GitHubClient client)
+            {
+                // Get owner and repo from the installer manifest
+                GitHubUrlMetadata? metadata = GetMetadataFromGitHubUrl(manifests.InstallerManifest);
+
+                if (metadata == null)
+                {
+                    // Could not populate GitHub metadata.
+                    return;
+                }
+
+                string owner = metadata.Value.Owner;
+                string repo = metadata.Value.Repo;
+                string tag = metadata.Value.ReleaseTag;
+
+                var githubRepo = await client.Repository.Get(owner, repo);
+                var githubRelease = await client.Repository.Release.Get(owner, repo, tag);
+
+                // License
+                if (string.IsNullOrEmpty(manifests.DefaultLocaleManifest.License))
+                {
+                    // License will only ever be empty in new command flow
+                    manifests.DefaultLocaleManifest.License = githubRepo.License?.SpdxId ?? githubRepo.License?.Name;
+                }
+
+                // ShortDescription
+                if (string.IsNullOrEmpty(manifests.DefaultLocaleManifest.ShortDescription))
+                {
+                    // ShortDescription will only ever be empty in new command flow
+                    manifests.DefaultLocaleManifest.ShortDescription = githubRepo.Description;
+                }
+
+                // PackageUrl
+                if (string.IsNullOrEmpty(manifests.DefaultLocaleManifest.PackageUrl))
+                {
+                    manifests.DefaultLocaleManifest.PackageUrl = githubRepo.HtmlUrl;
+                }
+
+                // PublisherUrl
+                if (string.IsNullOrEmpty(manifests.DefaultLocaleManifest.PublisherUrl))
+                {
+                    manifests.DefaultLocaleManifest.PublisherUrl = githubRepo.Owner.HtmlUrl;
+                }
+
+                // PublisherSupportUrl
+                if (string.IsNullOrEmpty(manifests.DefaultLocaleManifest.PublisherSupportUrl) && githubRepo.HasIssues)
+                {
+                    manifests.DefaultLocaleManifest.PublisherSupportUrl = $"{githubRepo.HtmlUrl}/issues";
+                }
+
+                // Tags
+                manifests.DefaultLocaleManifest.Tags ??= githubRepo.Topics?.ToList();
+
+                // ReleaseNotesUrl
+                if (string.IsNullOrEmpty(manifests.DefaultLocaleManifest.ReleaseNotesUrl))
+                {
+                    manifests.DefaultLocaleManifest.ReleaseNotesUrl = githubRelease.HtmlUrl;
+                }
+
+                // ReleaseDate
+                SetReleaseDate(manifests, serializerFormat, githubRelease);
+
+                // Documentations
+                if (manifests.DefaultLocaleManifest.Documentations == null && githubRepo.HasWiki)
+                {
+                    manifests.DefaultLocaleManifest.Documentations = new List<Documentation>
+                    {
+                        new()
+                        {
+                            DocumentLabel = "Wiki",
+                            DocumentUrl = $"{githubRepo.HtmlUrl}/wiki",
+                        },
+                    };
+                }
+            }
+
+            private static void SetReleaseDate(Manifests manifests, string serializerFormat, Release githubRelease)
+            {
+                DateTimeOffset? releaseDate = githubRelease.PublishedAt;
+                if (releaseDate == null)
+                {
+                    return;
+                }
+
+                switch (serializerFormat.ToLower())
+                {
+                    case "yaml":
+                        manifests.InstallerManifest.ReleaseDateTime = releaseDate.Value.ToString("yyyy-MM-dd");
+                        break;
+                    case "json":
+                        manifests.InstallerManifest.ReleaseDate = releaseDate;
+                        break;
+                }
+            }
+
+            private static GitHubUrlMetadata? GetMetadataFromGitHubUrl(InstallerManifest installerManifest)
+            {
+                // Get all GitHub URLs from the installer manifest
+                List<string> gitHubUrls = installerManifest.Installers
+                    .Where(x => x.InstallerUrl.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
+                    .Select(x => x.InstallerUrl)
+                    .ToList();
+
+                if (gitHubUrls.Count != installerManifest.Installers.Count)
+                {
+                    // No GitHub URLs found OR not all manifest InstallerUrls are GitHub URLs.
+                    return null;
+                }
+
+                string domainTrimmed = gitHubUrls.First().Replace("https://github.com/", string.Empty);
+                string[] parts = domainTrimmed.Split("/");
+                string owner = parts[0];
+                string repo = parts[1];
+                string tag = domainTrimmed.Replace($"{owner}/{repo}/releases/download/", string.Empty).Split("/")[0];
+
+                // Check if all GitHub URLs have the same owner, repo and tag
+                if (gitHubUrls.Any(x => !x.StartsWith($"https://github.com/{owner}/{repo}/releases/download/{tag}", StringComparison.OrdinalIgnoreCase)))
+                {
+                    return null;
+                }
+
+                return new GitHubUrlMetadata(owner, repo, tag);
+            }
+
+            private record struct GitHubUrlMetadata(string Owner, string Repo, string ReleaseTag);
         }
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.installer.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.installer.json
@@ -1,0 +1,14 @@
+﻿{
+  "PackageIdentifier": "Multifile.Json.GitHubAutoFillTest",
+  "PackageVersion": "1.2.3.4",
+  "Installers": [
+    {
+      "Architecture": "x64",
+      "InstallerUrl": "https://fakedomain.com/WingetCreateTestExeInstaller.exe",
+      "InstallerType": "exe",
+      "InstallerSha256": "A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC"
+    }
+  ],
+  "ManifestType": "installer",
+  "ManifestVersion": "1.0.0"
+}

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.json
@@ -1,0 +1,7 @@
+﻿{
+  "PackageIdentifier": "Multifile.Json.GitHubAutoFillTest",
+  "PackageVersion": "1.2.3.4",
+  "DefaultLocale": "en-US",
+  "ManifestType": "version",
+  "ManifestVersion": "1.0.0"
+}

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.locale.en-US.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.locale.en-US.json
@@ -4,9 +4,6 @@
   "PackageLocale": "en-US",
   "Publisher": "Multifile",
   "PackageName": "MsixTest",
-  // Will be auto-filled through GitHub's API
-  //"License": "MIT",
-  //"ShortDescription": "Testing metadata auto-fill through GitHub's API",
   "ManifestType": "defaultLocale",
   "ManifestVersion": "1.0.0"
 }

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.locale.en-US.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Json.GitHubAutoFillTest/Multifile.Json.GitHubAutoFillTest.locale.en-US.json
@@ -1,0 +1,12 @@
+﻿{
+  "PackageIdentifier": "Multifile.Json.GitHubAutoFillTest",
+  "PackageVersion": "1.2.3.4",
+  "PackageLocale": "en-US",
+  "Publisher": "Multifile",
+  "PackageName": "MsixTest",
+  // Will be auto-filled through GitHub's API
+  //"License": "MIT",
+  //"ShortDescription": "Testing metadata auto-fill through GitHub's API",
+  "ManifestType": "defaultLocale",
+  "ManifestVersion": "1.0.0"
+}

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Yaml.GitHubAutoFillTest/Multifile.Yaml.GitHubAutoFillTest.installer.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Yaml.GitHubAutoFillTest/Multifile.Yaml.GitHubAutoFillTest.installer.yaml
@@ -1,0 +1,10 @@
+﻿PackageIdentifier: Multifile.Yaml.GitHubAutoFillTest
+PackageVersion: 1.2.3.4
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+    InstallerType: exe
+    InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+    Scope: user
+ManifestType: installer
+ManifestVersion: 1.0.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Yaml.GitHubAutoFillTest/Multifile.Yaml.GitHubAutoFillTest.locale.en-US.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Yaml.GitHubAutoFillTest/Multifile.Yaml.GitHubAutoFillTest.locale.en-US.yaml
@@ -1,0 +1,10 @@
+﻿PackageIdentifier: Multifile.Yaml.GitHubAutoFillTest
+PackageVersion: 1.2.3.4
+PackageLocale: en-US
+Publisher: Multifile
+PackageName: MsixTest
+# Will be auto-filled through GitHub's API
+# License: MIT
+# ShortDescription: Testing metadata auto-fill through GitHub's API
+ManifestType: defaultLocale
+ManifestVersion: 1.0.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Yaml.GitHubAutoFillTest/Multifile.Yaml.GitHubAutoFillTest.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/Multifile.Yaml.GitHubAutoFillTest/Multifile.Yaml.GitHubAutoFillTest.yaml
@@ -1,0 +1,5 @@
+﻿PackageIdentifier: Multifile.Yaml.GitHubAutoFillTest
+PackageVersion: 1.2.3.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.0.0

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/GitHubTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/GitHubTests.cs
@@ -5,11 +5,13 @@ namespace Microsoft.WingetCreateUnitTests
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.WingetCreateCLI.Commands;
     using Microsoft.WingetCreateCLI.Logging;
     using Microsoft.WingetCreateCLI.Models.Settings;
+    using Microsoft.WingetCreateCLI.Telemetry.Events;
     using Microsoft.WingetCreateCore;
     using Microsoft.WingetCreateCore.Common;
     using Microsoft.WingetCreateCore.Models;
@@ -34,17 +36,38 @@ namespace Microsoft.WingetCreateUnitTests
         private const string TitleMismatch = "Pull request title does not match test title.";
 
         private GitHub gitHub;
+        private StringWriter sw;
 
         /// <summary>
         /// Setup for the GitHub.cs unit tests.
         /// </summary>
         [OneTimeSetUp]
-        public void Setup()
+        public void OneTimeSetup()
         {
             this.gitHub = new GitHub(this.GitHubApiKey, this.WingetPkgsTestRepoOwner, this.WingetPkgsTestRepo);
             Serialization.ProducedBy = "WingetCreateUnitTests";
             Serialization.ManifestSerializer = new YamlSerializer();
             Logger.Initialize();
+        }
+
+        /// <summary>
+        /// Setup method for each individual test.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            this.sw = new StringWriter();
+            Console.SetOut(this.sw);
+        }
+
+        /// <summary>
+        /// Teardown method for each individual test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.sw.Dispose();
+            PackageParser.SetHttpMessageHandler(null);
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/LocalizationTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/LocalizationTests.cs
@@ -7,9 +7,11 @@ namespace Microsoft.WingetCreateUnitTests
     using System.Collections;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
     using System.Reflection;
     using Microsoft.WingetCreateCLI.Properties;
+    using Microsoft.WingetCreateCore;
     using Microsoft.WingetCreateCore.Models.DefaultLocale;
     using Microsoft.WingetCreateCore.Models.Installer;
     using Microsoft.WingetCreateCore.Models.Locale;
@@ -30,6 +32,28 @@ namespace Microsoft.WingetCreateUnitTests
             nameof(WingetCreateCore.Models.DefaultLocale.Agreement.Agreement1),
             nameof(WingetCreateCore.Models.Installer.Installer.ReleaseDate),
         };
+
+        private StringWriter sw;
+
+        /// <summary>
+        /// Setup method for each individual test.
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            this.sw = new StringWriter();
+            Console.SetOut(this.sw);
+        }
+
+        /// <summary>
+        /// Teardown method for each individual test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            this.sw.Dispose();
+            PackageParser.SetHttpMessageHandler(null);
+        }
 
         /// <summary>
         /// Verifies that all localized strings exist for every property that exists

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -27,6 +27,24 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Resources\Multifile.Json.GitHubAutoFillTest\Multifile.Json.GitHubAutoFillTest.installer.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Multifile.Json.GitHubAutoFillTest\Multifile.Json.GitHubAutoFillTest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Multifile.Json.GitHubAutoFillTest\Multifile.Json.GitHubAutoFillTest.locale.en-US.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Multifile.Yaml.GitHubAutoFillTest\Multifile.Yaml.GitHubAutoFillTest.installer.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Multifile.Yaml.GitHubAutoFillTest\Multifile.Yaml.GitHubAutoFillTest.locale.en-US.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Multifile.Yaml.GitHubAutoFillTest\Multifile.Yaml.GitHubAutoFillTest.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Multifile.Yaml.MsixTest\Multifile.Yaml.MsixTest.locale.en-GB.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #157


This PR adds support for auto-populating metadata from GitHub API. Also adds two new args `--release-notes-url` and `--release-date` for explicitly specifying the metadata. These args take precedence over any auto-populated values

We only hit the GitHub API if we have a valid GitHub token specified. There's an issue with serializing `ReleaseDate` with our yaml serializer, so we update `ReleaseDateTime` for that instead. 


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/543)