### PR TITLE
Update regex for finding architecture from URL

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -653,16 +653,22 @@ namespace Microsoft.WingetCreateCore
                 archMatches.Add(Architecture.Arm);
             }
 
-            if (Regex.Match(url, "x64|winx?64|_64|64-?bit|ia64|amd64|x86(-|_)64", RegexOptions.IgnoreCase).Success)
+            if (Regex.Match(url, "x64|winx?64|_64|64-?bit|ia64|amd64", RegexOptions.IgnoreCase).Success)
             {
                 archMatches.Add(Architecture.X64);
             }
 
-            if (Regex.Match(url, @"x86|win32|winx86|_86|32-?bit|ia32|i[3456]86|\b[3456]86\b", RegexOptions.IgnoreCase).Success)
+            // x86 must only be checked if the URL doesn't match an x86_64 like pattern, which is for x64
+            if (Regex.Match(url, "x86(-|_)x?64", RegexOptions.IgnoreCase).Success)
+            {
+                archMatches.Add(Architecture.X64);
+            }
+            else if (Regex.Match(url, @"x86|win32|winx86|_86|32-?bit|ia32|i[3456]86|\b[3456]86\b", RegexOptions.IgnoreCase).Success)
             {
                 archMatches.Add(Architecture.X86);
             }
 
+            archMatches = archMatches.Distinct().ToList();
             return archMatches.Count == 1 ? archMatches.Single() : null;
         }
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

With how the current logic for matching arch from URL works, an `x86_x64` type pattern would always match both `x64` and `x86` and fail to get a unique match. This PR updates the pattern matching to only check for x86 if it doesn't match an `x86_64` or similar pattern

Issue can be repro with an example manifest:

```
wingetcreate update version-fox.vfox --version 1.0.0  --urls https://github.com/version-fox/vfox/releases/download/v0.5.4/vfox_0.5.4_windows_setup_i386.exe https://github.com/version-fox/vfox/releases/download/v0.5.4/vfox_0.5.4_windows_setup_x86_64.exe https://github.com/version-fox/vfox/releases/download/v0.5.4/vfox_0.5.4_windows_setup_aarch64.exe
```

If you run it with interactive update, it will result in a manifest with duplicate architectures.


-----
