### PR TITLE
Add null contitional operator to installers.installer.InstallerType

### DIFF
--- a/src/WingetCreateCLI/PromptHelper.cs
+++ b/src/WingetCreateCLI/PromptHelper.cs
@@ -477,7 +477,7 @@ namespace Microsoft.WingetCreateCLI
                 var installerTuple = string.Join(" | ", new[]
                     {
                         installer.Architecture.ToEnumAttributeValue(),
-                        installer.InstallerType.ToEnumAttributeValue(),
+                        installer.InstallerType?.ToEnumAttributeValue(),
                         installer.Scope?.ToEnumAttributeValue(),
                         installer.InstallerLocale,
                         installer.InstallerUrl,


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
https://github.com/microsoft/winget-create/issues/466 - Noticed separate from this issue, but found when looking for existing issues

-----

- Adds a Null Conditional Operator to installers.installer.InstallerType.
  - InstallerType is a required field, but is not always defined in the installer list. It may be defined for all lists earlier in the schema, so it should be _potentially_ null here.

Additionally tested against `NoMachine.NoMachine` (The package I noticed this on) and `Microsoft.WindowsSDK.10.0.22621` (The package from #466).

`Microsoft.WindowsSDK.10.0.22621` before this change:
![image](https://github.com/user-attachments/assets/1bc8368c-059d-44d3-895a-c8f7dd2d3774)

`Microsoft.WindowsSDK.10.0.22621` after this change:
![image](https://github.com/user-attachments/assets/1e269bcb-4787-4498-a555-346894424038)
