### PR TITLE
Allow control over PR auto-open behavior

### DIFF
--- a/doc/new-locale.md
+++ b/doc/new-locale.md
@@ -27,8 +27,9 @@ The following arguments are available:
 | **-l, --locale** |  The package locale to create a new manifest for. If not provided, the tool will prompt you for this value.
 | **-r, --reference-locale** | Existing locale manifest to be used as reference for default values. If not provided, the default locale manifest will be used.
 | **-o, --out** |  The output directory where the newly created manifests will be saved locally.
-| **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-f, --format** |  Output format of the manifest. Default is "yaml". |
+| **-t, --token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-n, --no-open** |  Boolean value that controls whether the pull request should not be open in the browser on submission. Default is false, meaning the PR will be opened in the browser. |
 | **-?, --help** |  Gets additional help on this command |
 
 Instructions on setting up GitHub Token for Winget-Create can be found [here](../README.md#github-personal-access-token-classic-permissions).

--- a/doc/new.md
+++ b/doc/new.md
@@ -26,9 +26,10 @@ The following arguments are available:
 
 | Argument  | Description |
 |--------------|-------------|
-| **-o,--out** |  The output directory where the newly created manifests will be saved locally |
-| **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-o, --out** |  The output directory where the newly created manifests will be saved locally |
+| **-f, --format** |  Output format of the manifest. Default is "yaml". |
+| **-t, --token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-n, --no-open** |  Boolean value that controls whether the pull request should not be open in the browser on submission. Default is false, meaning the PR will be opened in the browser. |
 | **-?, --help** |  Gets additional help on this command |
 
 ## Winget-Create New Command flow

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -74,3 +74,31 @@ The `anonymizePaths` setting controls whether the paths of files and directories
         "anonymizePaths": true
     }
 ```
+
+## Manifest
+
+The `Manifest` settings control the behavior of the Winget-Create CLI when creating a manifest.
+
+### format
+
+The `format` setting specifies the format of the manifest file that will be created. By default, this is set to `yaml`. The other supported format is `json`. The `--format` argument provided inline with the command will take precedence over this setting.
+
+```json
+    "Manifest": {
+        "format": "yaml"
+    }
+```
+
+## PullRequest
+
+The `PullRequest` settings control the behavior of the Winget-Create CLI when creating a pull request on the Windows Package Manager repository.
+
+### openInBrowser
+
+```json
+    "PullRequest": {
+        "openInBrowser": false
+    },
+```
+
+If set to false, the `PullRequest.openInBrowser` setting will prevent the Winget-Create CLI from opening the pull request in the default browser after creating it. By default, this is set to true. The `--no-open` argument provided inline with the command will take precedence over this setting.

--- a/doc/submit.md
+++ b/doc/submit.md
@@ -18,6 +18,7 @@ The following arguments are available:
 | **-p, --prtitle** |  The title of the pull request submitted to GitHub.
 | **-r, --replace** |  Boolean value for replacing an existing manifest from the Windows Package Manager repo. Optionally provide a version or else the latest version will be replaced. Default is false.
 | **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.
+| **-n, --no-open** |  Boolean value that controls whether the pull request should not be open in the browser on submission. Default is false, meaning the PR will be opened in the browser. |
 | **-?, --help** |  Gets additional help on this command. |
 
 If you have provided your [GitHub token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) on the command line with the **submit** command and the device is registered with GitHub, **Winget-Create** will submit your PR to [Windows Package Manager repo](https://docs.microsoft.com/windows/package-manager/).

--- a/doc/update-locale.md
+++ b/doc/update-locale.md
@@ -26,8 +26,9 @@ The following arguments are available:
 | **-v, --version** |  The version of the package to update the locale for. Default is the latest version.
 | **-l, --locale** |  The package locale to update the manifest for. If not provided, the tool will prompt you a list of existing locales to choose from.
 | **-o, --out** |  The output directory where the newly created manifests will be saved locally.
-| **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-f, --format** |  Output format of the manifest. Default is "yaml". |
+| **-t, --token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-n, --no-open** |  Boolean value that controls whether the pull request should not be open in the browser on submission. Default is false, meaning the PR will be opened in the browser. |
 | **-?, --help** |  Gets additional help on this command |
 
 Instructions on setting up GitHub Token for Winget-Create can be found [here](../README.md#github-personal-access-token-classic-permissions).

--- a/doc/update.md
+++ b/doc/update.md
@@ -118,8 +118,9 @@ The following arguments are available:
 | **-s, --submit** |  Boolean value for submitting to the Windows Package Manager repo. If true, updated manifest will be submitted directly using the provided GitHub Token |
 | **-r, --replace** |  Boolean value for replacing an existing manifest from the Windows Package Manager repo. Optionally provide a version or else the latest version will be replaced. Default is false. |
 | **-i, --interactive** |  Boolean value for making the update command interactive. If true, the tool will prompt the user for input. Default is false. |
-| **-f,--format** |  Output format of the manifest. Default is "yaml". |
+| **-f, --format** |  Output format of the manifest. Default is "yaml". |
 | **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. |
+| **-n, --no-open** |  Boolean value that controls whether the pull request should not be open in the browser on submission. Default is false, meaning the PR will be opened in the browser. |
 | **-?, --help** |  Gets additional help on this command. |
 
 ## Submit

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -99,7 +99,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// Gets or sets a value indicating whether or not to automatically open the PR webpage in the browser after creation.
         /// </summary>
-        public bool OpenPRInBrowser { get; set; } = true;
+        public bool OpenPRInBrowser { get; set; } = UserSettings.OpenPRInBrowser;
 
         /// <summary>
         /// Gets the GitHubClient instance to use for interacting with GitHub from the CLI.
@@ -740,7 +740,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             try
             {
-                PullRequest pullRequest = await this.GitHubClient.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, prTitle, shouldReplace, replaceVersion);
+                Octokit.PullRequest pullRequest = await this.GitHubClient.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, prTitle, shouldReplace, replaceVersion);
                 this.PullRequestNumber = pullRequest.Number;
                 PullRequestEvent pullRequestEvent = new PullRequestEvent { IsSuccessful = true, PullRequestNumber = pullRequest.Number };
                 TelemetryManager.Log.WriteEvent(pullRequestEvent);

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -87,6 +87,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the PR should be opened automatically in the browser.
+        /// </summary>
+        [Option('n', "no-open", Required = false, HelpText = "NoOpenPRInBrowser_HelpText", ResourceType = typeof(Resources))]
+        public bool NoOpenPRInBrowser { get => !this.OpenPRInBrowser; set => this.OpenPRInBrowser = !value; }
+
+        /// <summary>
         /// Executes the new command flow.
         /// </summary>
         /// <returns>Boolean representing success or fail of the command.</returns>

--- a/src/WingetCreateCLI/Commands/NewLocaleCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewLocaleCommand.cs
@@ -99,6 +99,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the PR should be opened automatically in the browser.
+        /// </summary>
+        [Option('n', "no-open", Required = false, HelpText = "NoOpenPRInBrowser_HelpText", ResourceType = typeof(Resources))]
+        public bool NoOpenPRInBrowser { get => !this.OpenPRInBrowser; set => this.OpenPRInBrowser = !value; }
+
+        /// <summary>
         /// Executes the new-locale command flow.
         /// </summary>
         /// <returns>Boolean representing success or fail of the command.</returns>

--- a/src/WingetCreateCLI/Commands/SubmitCommand.cs
+++ b/src/WingetCreateCLI/Commands/SubmitCommand.cs
@@ -68,6 +68,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the PR should be opened automatically in the browser.
+        /// </summary>
+        [Option('n', "no-open", Required = false, HelpText = "NoOpenPRInBrowser_HelpText", ResourceType = typeof(Resources))]
+        public bool NoOpenPRInBrowser { get => !this.OpenPRInBrowser; set => this.OpenPRInBrowser = !value; }
+
+        /// <summary>
         /// Gets or sets the unbound arguments that exist after the first positional parameter.
         /// </summary>
         [Value(1, Hidden = true)]

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -128,6 +128,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the PR should be opened automatically in the browser.
+        /// </summary>
+        [Option('n', "no-open", Required = false, HelpText = "NoOpenPRInBrowser_HelpText", ResourceType = typeof(Resources))]
+        public bool NoOpenPRInBrowser { get => !this.OpenPRInBrowser; set => this.OpenPRInBrowser = !value; }
+
+        /// <summary>
         /// Gets or sets the new value(s) used to update the manifest installer elements.
         /// </summary>
         [Option('u', "urls", Required = false, HelpText = "InstallerUrl_HelpText", ResourceType = typeof(Resources))]
@@ -163,7 +169,10 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return false;
                 }
 
-                bool submitFlagMissing = !this.SubmitToGitHub && (!string.IsNullOrEmpty(this.PRTitle) || this.Replace);
+                bool submitFlagMissing = !this.SubmitToGitHub && (
+                    !string.IsNullOrEmpty(this.PRTitle) ||
+                    this.Replace ||
+                    this.NoOpenPRInBrowser);
 
                 if (!string.IsNullOrEmpty(this.ReleaseNotesUrl))
                 {

--- a/src/WingetCreateCLI/Commands/UpdateLocaleCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateLocaleCommand.cs
@@ -79,6 +79,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public override string GitHubToken { get => base.GitHubToken; set => base.GitHubToken = value; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the PR should be opened automatically in the browser.
+        /// </summary>
+        [Option('n', "no-open", Required = false, HelpText = "NoOpenPRInBrowser_HelpText", ResourceType = typeof(Resources))]
+        public bool NoOpenPRInBrowser { get => !this.OpenPRInBrowser; set => this.OpenPRInBrowser = !value; }
+
+        /// <summary>
         /// Executes the update-locale command flow.
         /// </summary>
         /// <returns>Boolean representing success or fail of the command.</returns>

--- a/src/WingetCreateCLI/Models/SettingsModel.cs
+++ b/src/WingetCreateCLI/Models/SettingsModel.cs
@@ -98,6 +98,21 @@ namespace Microsoft.WingetCreateCLI.Models.Settings
 
     }
 
+    /// <summary>
+    /// Pull request settings
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class PullRequest
+    {
+        /// <summary>
+        /// Controls whether the pull request is opened in the browser on submission
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("openInBrowser", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool OpenInBrowser { get; set; } = true;
+
+
+    }
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class SettingsManifest
     {
@@ -126,6 +141,10 @@ namespace Microsoft.WingetCreateCLI.Models.Settings
         [Newtonsoft.Json.JsonProperty("Visual", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]
         public Visual Visual { get; set; } = new Visual();
+
+        [Newtonsoft.Json.JsonProperty("PullRequest", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required]
+        public PullRequest PullRequest { get; set; } = new PullRequest();
 
 
     }

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -2122,6 +2122,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Boolean value that controls whether the pull request should not be open in the browser on submission. Default is false..
+        /// </summary>
+        public static string NoOpenPRInBrowser_HelpText {
+            get {
+                return ResourceManager.GetString("NoOpenPRInBrowser_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No token provided, submission to GitHub skipped..
         /// </summary>
         public static string NoTokenProvided_Message {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1395,4 +1395,7 @@
   <data name="ConfirmZippedBinary_Message" xml:space="preserve">
     <value>Does this executable depend on DLLs or any other files present in the zip archive?</value>
   </data>
+  <data name="NoOpenPRInBrowser_HelpText" xml:space="preserve">
+    <value>Boolean value that controls whether the pull request should not be open in the browser on submission. Default is false.</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Schemas/settings.schema.0.1.json
+++ b/src/WingetCreateCLI/Schemas/settings.schema.0.1.json
@@ -77,6 +77,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "PullRequest": {
+      "description": "Pull request settings",
+      "type": "object",
+      "properties": {
+        "openInBrowser": {
+          "description": "Controls whether the pull request is opened in the browser on submission",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "additionalProperties": false
     }
   },
   "type": "object",
@@ -90,14 +102,16 @@
     "CleanUp": { "$ref": "#/definitions/CleanUp" },
     "WindowsPackageManagerRepository": { "$ref": "#/definitions/WindowsPackageManagerRepository" },
     "Manifest": { "$ref": "#/definitions/Manifest" },
-    "Visual": { "$ref": "#/definitions/Visual" }
+    "Visual": { "$ref": "#/definitions/Visual" },
+    "PullRequest": { "$ref": "#/definitions/PullRequest" }
   },
   "required": [
     "Telemetry",
     "CleanUp",
     "WindowsPackageManagerRepository",
     "Manifest",
-    "Visual"
+    "Visual",
+    "PullRequest"
   ],
   "additionalProperties": false
 }

--- a/src/WingetCreateCLI/UserSettings.cs
+++ b/src/WingetCreateCLI/UserSettings.cs
@@ -133,6 +133,20 @@ namespace Microsoft.WingetCreateCLI
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the pull request should be opened automatically in the browser on submission.
+        /// </summary>
+        public static bool OpenPRInBrowser
+        {
+            get => Settings.PullRequest.OpenInBrowser;
+
+            set
+            {
+                Settings.PullRequest.OpenInBrowser = value;
+                SaveSettings();
+            }
+        }
+
         private static SettingsManifest Settings { get; set; }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/GitHubTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/GitHubTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.WingetCreateUnitTests
             manifests.SingletonManifest = Serialization.DeserializeFromString<SingletonManifest>(latestManifest.First());
             Assert.That(manifests.SingletonManifest.PackageIdentifier, Is.EqualTo(TestConstants.TestPackageIdentifier), FailedToRetrieveManifestFromId);
 
-            PullRequest pullRequest = await this.gitHub.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, TestConstants.TestPRTitle);
+            Octokit.PullRequest pullRequest = await this.gitHub.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, TestConstants.TestPRTitle);
             Assert.That(TestConstants.TestPRTitle, Is.EqualTo(pullRequest.Title), TitleMismatch);
             await this.gitHub.ClosePullRequest(pullRequest.Number);
             StringAssert.StartsWith(string.Format(GitHubPullRequestBaseUrl, this.WingetPkgsTestRepoOwner, this.WingetPkgsTestRepo), pullRequest.HtmlUrl, PullRequestFailedToGenerate);
@@ -121,7 +121,7 @@ namespace Microsoft.WingetCreateUnitTests
             Manifests manifests = Serialization.DeserializeManifestContents(manifestContents);
             Assert.That(manifests.SingletonManifest.PackageIdentifier, Is.EqualTo(packageId), FailedToRetrieveManifestFromId);
 
-            PullRequest pullRequest = new();
+            Octokit.PullRequest pullRequest = new();
             try
             {
                 pullRequest = await this.gitHub.SubmitPullRequestAsync(manifests, this.SubmitPRToFork);

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/SettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/SettingsCommandTests.cs
@@ -98,6 +98,7 @@ namespace Microsoft.WingetCreateUnitTests
             bool isTelemetryDisabled = UserSettings.TelemetryDisabled;
             bool isCleanUpDisabled = UserSettings.CleanUpDisabled;
             bool arePathsAnonymized = UserSettings.AnonymizePaths;
+            bool shouldPROpenInBrowser = UserSettings.OpenPRInBrowser;
             int cleanUpDays = 30;
             string testRepoOwner = "testRepoOwner";
             string testRepoName = "testRepoName";
@@ -105,6 +106,7 @@ namespace Microsoft.WingetCreateUnitTests
             UserSettings.TelemetryDisabled = !isTelemetryDisabled;
             UserSettings.CleanUpDisabled = !isCleanUpDisabled;
             UserSettings.AnonymizePaths = !arePathsAnonymized;
+            UserSettings.OpenPRInBrowser = !shouldPROpenInBrowser;
             UserSettings.CleanUpDays = cleanUpDays;
             UserSettings.WindowsPackageManagerRepositoryOwner = testRepoOwner;
             UserSettings.WindowsPackageManagerRepositoryName = testRepoName;
@@ -113,6 +115,7 @@ namespace Microsoft.WingetCreateUnitTests
             ClassicAssert.IsTrue(manifest.Telemetry.Disable == !isTelemetryDisabled, "Changed Telemetry setting was not reflected in the settings file.");
             ClassicAssert.IsTrue(manifest.CleanUp.Disable == !isCleanUpDisabled, "Changed CleanUp.Disable setting was not reflected in the settings file.");
             ClassicAssert.IsTrue(manifest.Visual.AnonymizePaths == !arePathsAnonymized, "Changed Visual.AnonymizePaths setting was not reflected in the settings file.");
+            ClassicAssert.IsTrue(manifest.PullRequest.OpenInBrowser == !shouldPROpenInBrowser, "Changed PullRequest.OpenPRInBrowser setting was not reflected in the settings file.");
             ClassicAssert.IsTrue(manifest.CleanUp.IntervalInDays == cleanUpDays, "Changed CleanUp.IntervalInDays setting was not reflected in the settings file.");
             ClassicAssert.IsTrue(manifest.WindowsPackageManagerRepository.Owner == testRepoOwner, "Changed WindowsPackageManagerRepository.Owner setting was not reflected in the settings file.");
             ClassicAssert.IsTrue(manifest.WindowsPackageManagerRepository.Name == testRepoName, "Changed WindowsPackageManagerRepository.Name setting was not reflected in the settings file.");

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -318,6 +318,38 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Verify that update command warns if submit arguments are provided without submit flag being set.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task UpdateChecksMissingSubmitFlagWithNoOpenPR()
+        {
+            string packageId = "TestPublisher.TestPackageId";
+            string version = "1.2.3.4";
+
+            UpdateCommand command = new UpdateCommand
+            {
+                Id = packageId,
+                Version = version,
+                InstallerUrls = new[] { "https://fakedomain.com/fakeinstaller.exe" },
+                SubmitToGitHub = false,
+                NoOpenPRInBrowser = true,
+            };
+
+            try
+            {
+                await command.Execute();
+            }
+            catch (Exception)
+            {
+                // Expected exception
+            }
+
+            string result = this.sw.ToString();
+            Assert.That(result, Does.Contain(Resources.SubmitFlagMissing_Warning), "Submit flag missing warning should be shown");
+        }
+
+        /// <summary>
         /// Since some installers are incorrectly labeled on the manifest, resort to using the installer URL to find matches.
         /// This unit test uses a msi installer that is not an arm64 installer, but because the installer URL includes "arm64", it should find a match.
         /// </summary>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves a part of #569 / #568

PR adds a CLI arg `--no-open` and a user setting to control whether the pull request is open in the browser post submission. Added tests and updated docs for the user setting and arg


-----
