### PR TITLE
Don't set ARP entries in NewCommand flow

### DIFF
--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -195,6 +195,10 @@ namespace Microsoft.WingetCreateCLI.Commands
                 try
                 {
                     PackageParser.ParsePackages(installerUpdateList, manifests);
+
+                    // The CLI parses ARP entries uses them in update flow to update existing AppsAndFeaturesEntries in the manifest.
+                    // AppsAndFeaturesEntries should not be set for a new package as they may cause more harm than good.
+                    RemoveARPEntries(manifests.InstallerManifest);
                     DisplayArchitectureWarnings(installerUpdateList);
                 }
                 catch (IOException iOException) when (iOException.HResult == -2147024671)
@@ -505,6 +509,15 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 // Add the installer with the merged nested installer files back to the manifest
                 installerManifest.Installers.Add(installerToMergeInto);
+            }
+        }
+
+        private static void RemoveARPEntries(InstallerManifest installerManifest)
+        {
+            installerManifest.AppsAndFeaturesEntries = null;
+            foreach (var installer in installerManifest.Installers)
+            {
+                installer.AppsAndFeaturesEntries = null;
             }
         }
 


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?
	- Encountered while reviewing https://github.com/microsoft/winget-pkgs/pull/204321 & https://github.com/microsoft/winget-pkgs/pull/203719
	
Related to #550 which allowed the CLI to parse & update ARP entries. PR was intended for UpdateCommand as it had guards to not include / update ARP entries if they didn't exist in the existing manifest, but also affected the NewCommand flow.

The general community opinion is that ARP entries should not be set when it's not needed as there have been incidents where bad ARP values can cause the publish pipeline to break, and also the CLI matching can be affected if bad values (especially `DisplayVersion`) get set. I believe they shouldn't be set in NewCommand flow as it makes the manifest more complex for new contributors (without any real benefit) and can be problematic if bad values get set


## Validation

Test with a manual example

```
wingetcreate new https://zoom.us/client/6.1.0.320/ZoomRemoteControl.msi
```


-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/575)