### PR TITLE
Use OneBranch for signing

### DIFF
--- a/NuGet.Internal.config
+++ b/NuGet.Internal.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <packageSources>
+    <clear />
+      <add key="PublicPackages" value="https://pkgs.dev.azure.com/microsoft/Apps/_packaging/Apps_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+  <config>
+    <clear />
+    <add key="globalPackagesFolder" value="..\packages" />
+  </config>
+  <config>
+    <add key="dependencyversion" value="Highest" />
+  </config>
+</configuration>

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -167,7 +167,6 @@ extends:
                   /p:AppxPackageSigningEnabled=false'
 
             - task: onebranch.pipeline.signing@1
-              continueOnError: true
               displayName: 'CodeSigning'
               inputs:
                 command: 'sign'

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -77,6 +77,7 @@ extends:
             exeDirFrameworkDependent: '$(appxPackageDir)\dependent'
             exePathFrameworkDependent: '$(exeDirFrameworkDependent)\WingetCreateCLI\wingetcreate.exe'
             ob_outputDirectory: $(Build.ArtifactStagingDirectory)
+            ob_symbolsPublishing_enabled: true
 
           steps:
             - task: PowerShell@2

--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -1,6 +1,3 @@
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core
-
 trigger: none
 
 variables:
@@ -22,30 +19,38 @@ variables:
   # Build platform
   buildPlatform: "x64"
 
+  # Docker image which is used to build the project
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+
 resources:
   repositories:
-  - repository: 1ESPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v2/Microsoft.Official.yml@templates
   parameters:
-    pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-2022
-      os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
+    platform:
+      name: 'windows_undocked'
+
+    git:
+      fetchTags: false
 
     stages:
     - stage: __default
 
       jobs:
         - job: GetVersion
+          pool:
+            type: windows
+
           variables:
             runCodesignValidationInjection: ${{ false }}
             skipComponentGovernanceDetection: ${{ true }}
+            ob_outputDirectory: $(Build.ArtifactStagingDirectory)/wingetcreate
+
           steps:
             - task: PowerShell@2
               name: GetVersionStep
@@ -60,6 +65,9 @@ extends:
         - job: Build
           displayName: Build
           dependsOn: GetVersion
+          pool:
+            type: windows
+
           variables:
             majorMinorVersion: $[dependencies.GetVersion.outputs['GetVersionStep.majorMinorVersion']]
             buildVersion: $[counter(variables['majorMinorVersion'], 1)]
@@ -68,11 +76,9 @@ extends:
             appxBundlePath: '$(appxPackageDir)\$(appxBundleFile)'
             exeDirFrameworkDependent: '$(appxPackageDir)\dependent'
             exePathFrameworkDependent: '$(exeDirFrameworkDependent)\WingetCreateCLI\wingetcreate.exe'
+            ob_outputDirectory: $(Build.ArtifactStagingDirectory)
 
           steps:
-            - checkout: self
-              lfs: "true"
-
             - task: PowerShell@2
               name: OutputVersionStep
               displayName: Set output variables for UpdateManifest job
@@ -112,12 +118,12 @@ extends:
                 source: 'minkernel\published\internal\telemetry\TelemetryEventSource.cs'
                 destination: '$(workingDirectory)\WingetCreateCLI\Telemetry\'
 
-            # Copies binary dependencies from VCLibs package to be included in standalone exe     
+            # Copies binary dependencies from VCLibs package to be included in standalone exe
             - task: PowerShell@2
               displayName: Download VCLibs package
               inputs:
                 targetType: 'inline'
-                script: | 
+                script: |
                   iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
 
             - task: ExtractFiles@1
@@ -126,7 +132,11 @@ extends:
                 archiveFilePatterns: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
                 destinationFolder: '$(workingDirectory)\WingetCreateCLI'
                 cleanDestinationFolder: false
-                overwriteExistingFiles: false                 
+                overwriteExistingFiles: false
+
+            - powershell: Move-Item NuGet.Internal.config NuGet.config -Force
+              displayName: Configure internal feed
+              workingDirectory: $(Build.SourcesDirectory)
 
             - task: DotNetCoreCLI@2
               displayName: Restore
@@ -156,50 +166,16 @@ extends:
                   /p:UapAppxPackageBuildMode=SideloadOnly
                   /p:AppxPackageSigningEnabled=false'
 
-            - task: UseDotNet@2
-              displayName: 'Install .NET Core SDK required for ESRPCodeSigning'
+            - task: onebranch.pipeline.signing@1
+              continueOnError: true
+              displayName: 'CodeSigning'
               inputs:
-                packageType: sdk
-                version: '6.x'      
-
-            - task: EsrpCodeSigning@5
-              displayName: 'ESRP CodeSigning'
-              inputs:
-                ConnectedServiceName: 'AppInstallerESRPCodeSigning'
-                AppRegistrationClientId: '32216f16-efc9-4013-9fae-c6a2c54a3fc0'
-                AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-                AuthAKVName: 'PeetDevOpsKeyVault'
-                AuthCertName: 'ESRPAuth'
-                AuthSignCertName: 'ESRPRequestSigning'
-                FolderPath: $(appxPackageDir)
-                Pattern: |
-                  $(appxBundleFile)
-                  **/WingetCreateCLI.exe
-                UseMinimatch: true
-                signConfigType: inlineSignParams
-                inlineOperation: |
-                  [
-                    {
-                        "KeyCode" : "CP-230012",
-                        "OperationCode" : "SigntoolSign",
-                        "Parameters" : {
-                            "OpusName" : "Microsoft",
-                            "OpusInfo" : "http://www.microsoft.com",
-                            "FileDigest" : "/fd \"SHA256\"",
-                            "PageHash" : "/NPH",
-                            "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                        },
-                        "ToolName" : "sign",
-                        "ToolVersion" : "1.0"
-                    },
-                    {
-                        "KeyCode" : "CP-230012",
-                        "OperationCode" : "SigntoolVerify",
-                        "Parameters" : {},
-                        "ToolName" : "sign",
-                        "ToolVersion" : "1.0"
-                    }
-                  ]
+                command: 'sign'
+                cp_code: 400 # CP-230012 - Microsoft Corporation (SHA2 Root - Standard Root)
+                search_root: $(appxPackageDir)
+                files_to_sign: |
+                   $(appxBundlePath);
+                   **\WingetCreateCLI.exe
 
             - task: PowerShell@2
               displayName: "Create hash files"
@@ -213,19 +189,13 @@ extends:
             - task: CopyFiles@2
               displayName: Copy files to be published to staging directory
               inputs:
-                targetFolder: $(Build.ArtifactStagingDirectory)/wingetcreate
+                targetFolder: $(ob_outputDirectory)
                 flattenFolders: true
                 contents: |
                   $(exePathFrameworkDependent)
                   $(exePathFrameworkDependent).txt
                   $(appxBundlePath)
                   $(appxBundlePath).txt
-
-            - task: 1ES.PublishPipelineArtifact@1
-              inputs:
-                targetPath: $(Build.ArtifactStagingDirectory)/wingetcreate
-                artifactName: wingetcreate
-                displayName: Publish appx, exe, and hash files
 
             - task: GitHubRelease@1
               displayName: Create GitHub release
@@ -236,13 +206,16 @@ extends:
                 tag: v$(version)
                 isPreRelease: true
                 isDraft: true # After running this step, visit the new draft release, edit, and publish.
-                assets: $(Build.ArtifactStagingDirectory)/wingetcreate/*
+                assets: $(ob_outputDirectory)
 
         - job: Wait
           displayName: Wait for vanity URL to be manually updated
           dependsOn: Build
-          pool: server
+          pool:
+            type: agentless
+
           timeoutInMinutes: 1440 # job times out in 1 day
+
           steps:
             - task: ManualValidation@0
               timeoutInMinutes: 1440 # task times out in 1 day
@@ -253,6 +226,9 @@ extends:
           dependsOn:
             - Build
             - Wait
+          pool:
+            type: windows
+
           variables:
             runCodesignValidationInjection: ${{ false }}
             skipComponentGovernanceDetection: ${{ true }}
@@ -261,9 +237,10 @@ extends:
             vcLibsBundleFile: "Microsoft.VCLibs.x64.14.00.Desktop.appx"
             msixPackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/$(appxBundleFile)"
             portablePackageUrl: "https://github.com/microsoft/winget-create/releases/download/v$(manifestVersion)/wingetcreate.exe"
+            ob_outputDirectory: $(Build.ArtifactStagingDirectory)
+            ob_git_checkout: false
+
           steps:
-            - checkout: none
-        
             - task: PowerShell@2
               displayName: Update package manifest in the OWC
               inputs:


### PR DESCRIPTION
Change the release pipeline to use OneBranch instead of 1ES Pipeline Templates. This allows us to use their registration for ESRP instead of having our own.

Notable changes:
* Added new NuGet config pointing to an internal feed so we don't have a direct dependency on nuget.org
* We don't explicitly publish any artifacts. OneBranch automatically publishes anything in the `ob_outputDirectory`
* The signing task changes to the OneBranch wrapper, where we only need specify the cp_code
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/583)