### PR TITLE
New functionality for managing tokens securely

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,13 @@ Running unit and E2E tests are a great way to ensure that functionality is prese
 * Fill out the test parameters in the `WingetCreateTests/Test.runsettings` file
     *  `WingetPkgsTestRepoOwner`: The repository owner of the winget-pkgs-submission-test repo. (Repo owner must be forked from main "winget-pkgs-submission-test" repo)
     *  `WingetPkgsTestRepo`: The winget-pkgs test repository. (winget-pkgs-submission-test)
-    *  `GitHubApiKey`: GitHub personal access token for testing.
-       *  Instructions on [how to generate your own GitHubApiKey](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
-       *  Direct link to GitHub [Personal Access Tokens page](https://github.com/settings/tokens).
-   * `GitHubAppPrivateKey`: Leave blank, this is only used by the build server.
 
 * Set the solution wide runsettings file for the tests
     * Go to `Test` menu > `Configure Run Settings` -> `Select Solution Wide runsettings File` -> Choose your configured runsettings file
 
-> [!CAUTION]
-> You should treat your access token like a password. To avoid exposing your PAT, be sure to reset changes to the `WingetCreateTests/Test.runsettings` file before committing your changes. You can also use the command `git update-index --skip-worktree src/WingetCreateTests/WingetCreateTests/Test.runsettings` command to untrack changes to the file and prevent it from being committed.
+* Set up your github token:
+    * __[Recommended]__ Run 'wingetcreate token -s` to go through the Github authentication flow
+    * Or create a personal access token with the `repo` permission and set it as an environment variable `WINGET_CREATE_GITHUB_TOKEN`. _(This option is more convenient for CI/CD pipelines.)_
 
 ## Contributing
 

--- a/doc/new-locale.md
+++ b/doc/new-locale.md
@@ -28,7 +28,7 @@ The following arguments are available:
 | **-r, --reference-locale** | Existing locale manifest to be used as reference for default values. If not provided, the default locale manifest will be used.
 | **-o, --out** |  The output directory where the newly created manifests will be saved locally.
 | **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
 | **-?, --help** |  Gets additional help on this command |
 
 Instructions on setting up GitHub Token for Winget-Create can be found [here](../README.md#github-personal-access-token-classic-permissions).

--- a/doc/new.md
+++ b/doc/new.md
@@ -28,7 +28,7 @@ The following arguments are available:
 |--------------|-------------|
 | **-o,--out** |  The output directory where the newly created manifests will be saved locally |
 | **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
 | **-?, --help** |  Gets additional help on this command |
 
 ## Winget-Create New Command flow

--- a/doc/show.md
+++ b/doc/show.md
@@ -28,7 +28,7 @@ The following arguments are available:
 | **-l, --locale-manifests** |  Switch to display all locale manifests.
 | **--version-manifest** |  Switch to display the version manifest.
 | **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t, --token** |  GitHub personal access token used for authenticated access to the GitHub API. It is recommended to provide a token to get a higher [API rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting).
+| **-t, --token** |  GitHub personal access token used for authenticated access to the GitHub API. It is recommended to provide a token to get a higher [API rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting). <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
 | **-?, --help** |  Gets additional help on this command. |
 
 Instructions on setting up GitHub Token for Winget-Create can be found [here](../README.md#github-personal-access-token-classic-permissions).

--- a/doc/submit.md
+++ b/doc/submit.md
@@ -17,7 +17,7 @@ The following arguments are available:
 |--------------|-------------|
 | **-p, --prtitle** |  The title of the pull request submitted to GitHub.
 | **-r, --replace** |  Boolean value for replacing an existing manifest from the Windows Package Manager repo. Optionally provide a version or else the latest version will be replaced. Default is false.
-| **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.
+| **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
 | **-?, --help** |  Gets additional help on this command. |
 
 If you have provided your [GitHub token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) on the command line with the **submit** command and the device is registered with GitHub, **Winget-Create** will submit your PR to [Windows Package Manager repo](https://docs.microsoft.com/windows/package-manager/).

--- a/doc/token.md
+++ b/doc/token.md
@@ -32,5 +32,5 @@ The following arguments are available:
 |----------------  |-------------|
 | **-c, --clear**  | Required. Clear the cached GitHub token
 | **-s, --store**  | Required. Set the cached GitHub token. Can specify token to cache with --token parameter, otherwise will initiate OAuth flow.
-| **-t, --token**   | GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.
+| **-t, --token**   | GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._
 | **-?, --help** |  Gets additional help on this command. |

--- a/doc/token.md
+++ b/doc/token.md
@@ -7,6 +7,13 @@ Instructions on setting up GitHub Token for Winget-Create can be found [here](..
 
 ## Usage
 
+> [!WARNING] 
+> Using the `--token` argument may result in the token being logged.  
+> 
+> For local development, it is recommended to go through the OAuth flow by omitting the `--token` argument.  
+>   
+> For CI/CD scenarios, it is recommended to use the 'WINGET_CREATE_GITHUB_TOKEN' environment variable to store the token.
+
 `wingetcreate.exe token [\<options>]`
 
 ### Store a new GitHub token in your local cache

--- a/doc/update-locale.md
+++ b/doc/update-locale.md
@@ -27,7 +27,7 @@ The following arguments are available:
 | **-l, --locale** |  The package locale to update the manifest for. If not provided, the tool will prompt you a list of existing locales to choose from.
 | **-o, --out** |  The output directory where the newly created manifests will be saved locally.
 | **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo |
+| **-t,--token**  | GitHub personal access token used for direct submission to the Windows Package Manager repo. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
 | **-?, --help** |  Gets additional help on this command |
 
 Instructions on setting up GitHub Token for Winget-Create can be found [here](../README.md#github-personal-access-token-classic-permissions).

--- a/doc/update.md
+++ b/doc/update.md
@@ -119,7 +119,7 @@ The following arguments are available:
 | **-r, --replace** |  Boolean value for replacing an existing manifest from the Windows Package Manager repo. Optionally provide a version or else the latest version will be replaced. Default is false. |
 | **-i, --interactive** |  Boolean value for making the update command interactive. If true, the tool will prompt the user for input. Default is false. |
 | **-f,--format** |  Output format of the manifest. Default is "yaml". |
-| **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. |
+| **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
 | **-?, --help** |  Gets additional help on this command. |
 
 ## Submit

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -134,7 +134,9 @@ extends:
                   testSelector: "testAssemblies"
                   testAssemblyVer2: 'src\WingetCreateTests\WingetCreateTests\bin\$(buildPlatform)\$(buildConfiguration)\$(targetFramework)\WingetCreateTests.dll'
                   runSettingsFile: 'src\WingetCreateTests\WingetCreateTests\Test.runsettings'
-                  overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test -GitHubAppPrivateKey "$(GitHubApp_PrivateKey)"'                    
+                  overrideTestrunParameters: '-WingetPkgsTestRepoOwner microsoft -WingetPkgsTestRepo winget-pkgs-submission-test'
+                env:
+                  WINGET_CREATE_APP_KEY: $(GitHubApp_PrivateKey)
 
               - task: 1ES.PublishPipelineArtifact@1
                 inputs:

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -126,9 +126,9 @@ namespace Microsoft.WingetCreateCLI.Commands
             if (string.IsNullOrEmpty(this.GitHubToken))
             {
                 Logger.Trace("No token parameter, reading cached token");
-                this.GitHubToken = GitHubOAuth.ReadTokenCache();
-                if (string.IsNullOrEmpty(this.GitHubToken))
+                if (GitHubOAuth.TryReadTokenCache(out var token))
                 {
+                    this.GitHubToken = token;
                     if (requireToken)
                     {
                         Logger.Trace("No token found in cache, launching OAuth flow");

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -129,19 +129,16 @@ namespace Microsoft.WingetCreateCLI.Commands
                 if (GitHubOAuth.TryReadTokenCache(out var token))
                 {
                     this.GitHubToken = token;
-                    if (requireToken)
-                    {
-                        Logger.Trace("No token found in cache, launching OAuth flow");
-                        if (!await this.GetTokenFromOAuth())
-                        {
-                            Logger.Trace("Failed to obtain token from OAuth flow.");
-                            return false;
-                        }
-                    }
-                }
-                else
-                {
                     isCacheToken = true;
+                }
+                else if (requireToken)
+                {
+                    Logger.Trace("No token found in cache, launching OAuth flow");
+                    if (!await this.GetTokenFromOAuth())
+                    {
+                        Logger.Trace("Failed to obtain token from OAuth flow.");
+                        return false;
+                    }
                 }
             }
 

--- a/src/WingetCreateCLI/GitHubOAuth.cs
+++ b/src/WingetCreateCLI/GitHubOAuth.cs
@@ -5,9 +5,6 @@ namespace Microsoft.WingetCreateCLI
 {
     using System;
     using System.ComponentModel;
-    using System.IO;
-    using System.Security.Cryptography;
-    using System.Text;
     using System.Text.Json;
     using System.Text.Json.Serialization;
     using System.Threading.Tasks;
@@ -26,48 +23,26 @@ namespace Microsoft.WingetCreateCLI
         private const string GitHubDeviceEndpoint = "https://github.com/login/device/code";
         private const string GitHubTokenEndpoint = "https://github.com/login/oauth/access_token";
         private const string GrantType = "urn:ietf:params:oauth:grant-type:device_code";
-        private static readonly string TokenFile = Path.Combine(Common.LocalAppStatePath, "tokenCache.bin");
 
         /// <summary>
-        /// Create byte array for additional entropy when using Protect method.
+        /// Deletes the token.
         /// </summary>
-        private static readonly byte[] EntropyBytes = Encoding.UTF8.GetBytes(TokenFile);
+        /// <returns>True if the token was deleted, false otherwise.</returns>
+        public static bool DeleteTokenCache() => TokenHelper.Delete();
 
         /// <summary>
-        /// Deletes the cached token.
-        /// </summary>
-        public static void DeleteTokenCache()
-        {
-            File.Delete(TokenFile);
-        }
-
-        /// <summary>
-        /// Reads and decrypts the cached token, if one exists.
-        /// </summary>
-        /// <returns>Decrypted cached token.</returns>
-        public static string ReadTokenCache()
-        {
-            if (File.Exists(TokenFile))
-            {
-                var protectedBytes = File.ReadAllBytes(TokenFile);
-                var bytes = ProtectedData.Unprotect(protectedBytes, EntropyBytes, DataProtectionScope.CurrentUser);
-                return Encoding.UTF8.GetString(bytes);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Encrypts and writes the token to the file cache.
+        /// Writes the token.
         /// </summary>
         /// <param name="token">Token to be cached.</param>
-        public static void WriteTokenCache(string token)
-        {
-            var bytes = ProtectedData.Protect(Encoding.UTF8.GetBytes(token), EntropyBytes, DataProtectionScope.CurrentUser);
-            File.WriteAllBytes(TokenFile, bytes);
-        }
+        /// <returns>True if the token was written, false otherwise.</returns>
+        public static bool WriteTokenCache(string token) => TokenHelper.Write(token);
+
+        /// <summary>
+        /// Reads the token.
+        /// </summary>
+        /// <param name="token">Output token.</param>
+        /// <returns>True if the token was read, false otherwise.</returns>
+        public static bool TryReadTokenCache(out string token) => TokenHelper.TryRead(out token);
 
         /// <summary>
         /// Sends a POST request to GitHub's authorization server to obtain a device code.

--- a/src/WingetCreateCLI/NativeMethods.txt
+++ b/src/WingetCreateCLI/NativeMethods.txt
@@ -1,0 +1,4 @@
+﻿CredDelete
+CredFree
+CredRead
+CredWrite

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -64,6 +64,12 @@ namespace Microsoft.WingetCreateCLI
                 return args.Any() ? 1 : 0;
             }
 
+            // If the user has provided a token via the command line, warn them that it may be logged
+            if (!string.IsNullOrEmpty(command.GitHubToken))
+            {
+                Logger.WarnLocalized(nameof(Resources.GitHubTokenWarning_Message));
+            }
+
             bool commandHandlesToken = command is not CacheCommand and not InfoCommand and not SettingsCommand;
 
             // Do not load github client for commands that do not deal with a GitHub token.

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -1150,11 +1150,22 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials..
+        ///   Looks up a localized string similar to GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.
+        ///
+        ///Warning: Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token..
         /// </summary>
         public static string GitHubToken_HelpText {
             get {
                 return ResourceManager.GetString("GitHubToken_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: Using the --token argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token..
+        /// </summary>
+        public static string GitHubTokenWarning_Message {
+            get {
+                return ResourceManager.GetString("GitHubTokenWarning_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -237,7 +237,9 @@
     <value>GitHub login failed.</value>
   </data>
   <data name="GitHubToken_HelpText" xml:space="preserve">
-    <value>GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.</value>
+    <value>GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials.
+
+Warning: Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token.</value>
   </data>
   <data name="Heading" xml:space="preserve">
     <value>Windows Package Manager Manifest Creator v{0}</value>
@@ -652,6 +654,9 @@
   </data>
   <data name="InvalidGitHubToken_Message" xml:space="preserve">
     <value>Token was invalid. Please generate a new GitHub token and try again.</value>
+  </data>
+  <data name="GitHubTokenWarning_Message" xml:space="preserve">
+    <value>Warning: Using the --token argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token.</value>
   </data>
   <data name="RateLimitExceeded_Message" xml:space="preserve">
     <value>GitHub api rate limit exceeded. To extend your rate limit, provide your GitHub token with the '-t' flag or store one using the 'token --store' command.</value>

--- a/src/WingetCreateCLI/TokenHelper.cs
+++ b/src/WingetCreateCLI/TokenHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.WingetCreateCLI
     public static class TokenHelper
     {
         // Windows credentials manager
-        private const string CredTargetName = "git:https://aka.ms/winget-create";
+        private const string CredTargetName = "winget-create:GitHub [repo]";
         private const string CredUserName = "Personal Access Token";
 
         // Environment variable

--- a/src/WingetCreateCLI/TokenHelper.cs
+++ b/src/WingetCreateCLI/TokenHelper.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using Windows.Win32;
+    using Windows.Win32.Foundation;
+    using Windows.Win32.Security.Credentials;
+
+    /// <summary>
+    /// Provides functionality for caching and retrieving the GitHub OAuth token.
+    /// </summary>
+    public static class TokenHelper
+    {
+        // Windows credentials manager
+        private const string CredTargetName = "git:https://aka.ms/winget-create";
+        private const string CredUserName = "Personal Access Token";
+
+        // Environment variable
+        private const string TokenEnvironmentVariable = "WINGET_CREATE_GITHUB_TOKEN";
+
+        /// <summary>
+        /// Deletes the token.
+        /// </summary>
+        /// <returns>True if the token was deleted, false otherwise.</returns>
+        public static bool Delete()
+        {
+            return PInvoke.CredDelete(CredTargetName, CRED_TYPE.CRED_TYPE_GENERIC);
+        }
+
+        /// <summary>
+        /// Reads the token.
+        /// </summary>
+        /// <param name="token">Output token.</param>
+        /// <returns>True if the token was read, false otherwise.</returns>
+        public static unsafe bool TryRead(out string token) => TryReadFromEnvironmentVariable(out token) || TryReadFromCredentialManager(out token);
+
+        /// <summary>
+        /// Writes the token.
+        /// </summary>
+        /// <param name="token">Token to be cached.</param>
+        /// <returns>True if the token was written, false otherwise.</returns>
+        public static unsafe bool Write(string token)
+        {
+            var tokenBytes = Encoding.Unicode.GetBytes(token);
+            fixed (byte* tokenBytesPtr = tokenBytes)
+            {
+                var credTargetNamePtr = Marshal.StringToHGlobalUni(CredTargetName);
+                var credUserNamePtr = Marshal.StringToHGlobalUni(CredUserName);
+
+                try
+                {
+                    var credential = new CREDENTIALW
+                    {
+                        Type = CRED_TYPE.CRED_TYPE_GENERIC,
+                        TargetName = new PWSTR(credTargetNamePtr),
+                        UserName = new PWSTR(credUserNamePtr),
+                        CredentialBlobSize = (uint)tokenBytes.Length,
+                        CredentialBlob = tokenBytesPtr,
+                        Persist = CRED_PERSIST.CRED_PERSIST_LOCAL_MACHINE,
+                    };
+
+                    return PInvoke.CredWrite(&credential, /* None */ 0);
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(credTargetNamePtr);
+                    Marshal.FreeHGlobal(credUserNamePtr);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tries to read the token from the Windows credentials manager.
+        /// </summary>
+        /// <param name="token">Output token.</param>
+        /// <returns>True if the token was read, false otherwise.</returns>
+        private static unsafe bool TryReadFromCredentialManager(out string token)
+        {
+            PInvoke.CredRead(CredTargetName, CRED_TYPE.CRED_TYPE_GENERIC, out CREDENTIALW* credentialObject);
+            if (credentialObject != null)
+            {
+                var accessTokenInBytes = new byte[credentialObject->CredentialBlobSize];
+                Marshal.Copy((IntPtr)credentialObject->CredentialBlob, accessTokenInBytes, 0, accessTokenInBytes.Length);
+                token = Encoding.Unicode.GetString(accessTokenInBytes);
+                return true;
+            }
+
+            token = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to read the token from the environment variable.
+        /// </summary>
+        /// <param name="token">Output token.</param>
+        /// <returns>True if the token was read, false otherwise.</returns>
+        private static bool TryReadFromEnvironmentVariable(out string token)
+        {
+            var envToken = Environment.GetEnvironmentVariable(TokenEnvironmentVariable);
+            if (!string.IsNullOrEmpty(envToken))
+            {
+                token = envToken;
+                return true;
+            }
+
+            token = null;
+            return false;
+        }
+    }
+}

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -21,6 +21,10 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="DesktopBridge.Helpers" Version="1.2.2" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.183">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NSwag.MSBuild" Version="14.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/WingetCreateTests/WingetCreateTests/Test.runsettings
+++ b/src/WingetCreateTests/WingetCreateTests/Test.runsettings
@@ -5,16 +5,10 @@
   Parameters used by tests at run time. 
        WingetPkgsTestRepoOwner: The repository owner of the winget-pkgs submission test repo. (Repo owner must be forked from main "winget-pkgs-submission-test" repo)
        WingetPkgsTestRepo: The winget-pkgs test repository.
-       GitHubApiKey: GitHub access token for testing.
-       GitHubAppPrivateKey: GitHub app installation access token for the winget-create app.
   -->
   <TestRunParameters>
     <Parameter name="WingetPkgsTestRepoOwner" value="" />
     <Parameter name="WingetPkgsTestRepo" value="winget-pkgs-submission-test" />
-    <Parameter name="GitHubApiKey" value="" />
-    
-    <!-- Leave blank, this is only used by the build server. -->
-    <Parameter name="GitHubAppPrivateKey" value="" />
   </TestRunParameters>
 
   <RunConfiguration>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/TokenCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/TokenCommandTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.WingetCreateUnitTests
         public async Task TokenClearAndReadFromEnvironmentVariable()
         {
             await this.ExecuteTokenClearCommand();
-            ClassicAssert.IsFalse(TokenHelper.TryRead(out var _), "Token cache shouldn't exist before running Token --clear command");
+            ClassicAssert.IsFalse(TokenHelper.TryRead(out var _), "Token cache shouldn't exist");
 
             Environment.SetEnvironmentVariable(TokenEnvironmentVariable, "MockToken");
             ClassicAssert.IsTrue(TokenHelper.TryRead(out var _), "Token cache should exist after setting environment variable");
@@ -68,7 +68,7 @@ namespace Microsoft.WingetCreateUnitTests
         {
             await this.ExecuteTokenStoreCommand();
             await this.ExecuteTokenClearCommand();
-            ClassicAssert.IsFalse(TokenHelper.TryRead(out var _), "Token cache shouldn't exist before running Token --clear command");
+            ClassicAssert.IsFalse(TokenHelper.TryRead(out var _), "Token cache shouldn't exist after running Token --clear command");
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/TokenCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/TokenCommandTests.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.WingetCreateUnitTests
 {
-    using System.IO;
+    using System;
     using System.Threading.Tasks;
     using Microsoft.WingetCreateCLI;
     using Microsoft.WingetCreateCLI.Commands;
@@ -16,28 +16,88 @@ namespace Microsoft.WingetCreateUnitTests
     /// </summary>
     public class TokenCommandTests : GitHubTestsBase
     {
+        private const string TokenEnvironmentVariable = "WINGET_CREATE_GITHUB_TOKEN";
+
         /// <summary>
-        /// Verifies that the Token command works as expected.
+        /// OneTimeSetup method for the unit tests.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Test]
-        public async Task TokenCommand()
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
             Logger.Initialize();
+        }
 
-            // Preemptively clear existing token
+        /// <summary>
+        /// SetUp method for the unit tests.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            TokenHelper.Delete();
+            Environment.SetEnvironmentVariable(TokenEnvironmentVariable, null);
+        }
+
+        /// <summary>
+        /// TearDown method for the unit tests.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            TokenHelper.Delete();
+            Environment.SetEnvironmentVariable(TokenEnvironmentVariable, null);
+        }
+
+        /// <summary>
+        /// Test case for verifying that the "token" can be read from the environment variable after clearing the token cache.
+        /// </summary>
+        [Test]
+        public async Task TokenClearAndReadFromEnvironmentVariable()
+        {
+            await this.ExecuteTokenClearCommand();
+            ClassicAssert.IsFalse(TokenHelper.TryRead(out var _), "Token cache shouldn't exist before running Token --clear command");
+
+            Environment.SetEnvironmentVariable(TokenEnvironmentVariable, "MockToken");
+            ClassicAssert.IsTrue(TokenHelper.TryRead(out var _), "Token cache should exist after setting environment variable");
+        }
+
+        /// <summary>
+        /// Test case for verifying that the "token --clear" command is working as expected.
+        /// </summary>
+        [Test]
+        public async Task TokenClearCommand()
+        {
+            await this.ExecuteTokenStoreCommand();
+            await this.ExecuteTokenClearCommand();
+            ClassicAssert.IsFalse(TokenHelper.TryRead(out var _), "Token cache shouldn't exist before running Token --clear command");
+        }
+
+        /// <summary>
+        /// Test case for verifying that the "token --store" command is working as expected.
+        /// </summary>
+        [Test]
+        public async Task TokenStoreCommand()
+        {
+            await this.ExecuteTokenClearCommand();
+            await this.ExecuteTokenStoreCommand();
+            ClassicAssert.IsTrue(TokenHelper.TryRead(out var _), "Token cache should exist after running Token --store command");
+        }
+
+        /// <summary>
+        /// Executes the token clear command.
+        /// </summary>
+        private async Task ExecuteTokenClearCommand()
+        {
             var command = new TokenCommand { Clear = true };
             ClassicAssert.IsTrue(await command.Execute(), "Command should have succeeded");
+        }
 
-            string tokenCacheFile = Path.Combine(Common.LocalAppStatePath, "tokenCache.bin");
-            FileAssert.DoesNotExist(tokenCacheFile, "Token cache file shouldn't exist before running Token --store command");
-            command = new TokenCommand { Store = true, GitHubToken = this.GitHubApiKey };
+        /// <summary>
+        /// Executes the token store command.
+        /// </summary>
+        private async Task ExecuteTokenStoreCommand()
+        {
+            var command = new TokenCommand { Store = true, GitHubToken = this.GitHubApiKey };
             ClassicAssert.IsTrue(await command.Execute(), "Command should have succeeded");
-            FileAssert.Exists(tokenCacheFile, "Token cache file should exist after storing token");
-
-            command = new TokenCommand { Clear = true };
-            ClassicAssert.IsTrue(await command.Execute(), "Command should have succeeded");
-            FileAssert.DoesNotExist(tokenCacheFile, "Token cache file shouldn't exist after running Token --clear command");
         }
     }
 }


### PR DESCRIPTION
## Summary of Changes

🟢 New URL: https://aka.ms/winget-create-token

This pull request includes multiple changes focused on improving the handling and documentation of GitHub tokens in the Winget-Create CLI. The changes include updates to documentation files and the addition of new functionality for managing tokens securely.

### Screenshots
```
...
-t, --token                GitHub personal access token used for direct submission to the Windows
                           Package Manager repo. If no token is provided, tool will prompt for
                           GitHub login credentials.

                           Warning: Using this argument may result in the token being logged.
                           Consider an alternative approach https://aka.ms/winget-create-token.
...
```
---
```
PS c:\> wingetcreate submit -p "Example" 'C:\' --token "Example"
Warning: Using the --token argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token.
...
```

### Documentation Updates:
* Added warnings to various documentation files (`doc/new-locale.md`, `doc/new.md`, `doc/show.md`, `doc/submit.md`, `doc/token.md`, `doc/update-locale.md`, `doc/update.md`) about the potential logging of GitHub tokens when using the `--token` argument, and recommended alternative approaches. [[1]](diffhunk://#diff-30b300cef4090666665eafbe63ba6b0aed7c2feb5fd13a761be264ac183a038dL31-R31) [[2]](diffhunk://#diff-8c54cef5dac570af0231c26b9e4554a57bd717cb7308bd400bbc5cbd6787274cL31-R31) [[3]](diffhunk://#diff-51175c8583d5af42330ffc9ac8f9d46204e9324b4aa7647887453bbaee8207efL31-R31) [[4]](diffhunk://#diff-8d29ec3c4f7b457f9181b1ab19a2c0c034f9f0e4d10d916cfb7b52bd7fce79ecL20-R20) [[5]](diffhunk://#diff-332f522d60a32ba426a6f9edf260b7ba9dfcc04a6be4e32f6423fb0da5903e60R10-R16) [[6]](diffhunk://#diff-332f522d60a32ba426a6f9edf260b7ba9dfcc04a6be4e32f6423fb0da5903e60L28-R35) [[7]](diffhunk://#diff-2830bef1a691fd494d9821f4f0bceae7202010ecc8f5b989c706147f701e8cd5L30-R30) [[8]](diffhunk://#diff-339a9e32cc0186fefe370a6223e1ea9b807f2156ba0aabf2ded05c8bdb8b451fL122-R122)

### New Functionality:
* Introduced the `TokenHelper` class to handle token operations using the Windows credentials manager and environment variables, enhancing security and flexibility.

> [!WARNING] 
> For local development, it is recommended to go through the OAuth flow by omitting the `--token` argument.  
>   
> For CI/CD scenarios, it is recommended to use the 'WINGET_CREATE_GITHUB_TOKEN' environment variable to store the token.

### Logging Improvements:
* Added a warning message (in the `Program.cs` file) to notify users when a token is provided via the command line, highlighting the risk of token logging.

### Resource Updates:
* Updated resource files (`Resources.Designer.cs`, `Resources.resx`) to include new warning messages related to token usage. [[1]](diffhunk://#diff-e5e2e57cc5626012548a63aeba024772e7343b6c30176de0e5fd84ce95f95212L1153-R1171) [[2]](diffhunk://#diff-e3e22d3a3e3dd1ad1661a0c0a25dc5e452f5c2d6e305b2199997be6662254c86L240-R242) [[3]](diffhunk://#diff-e3e22d3a3e3dd1ad1661a0c0a25dc5e452f5c2d6e305b2199997be6662254c86R658-R660)

### Related links:
- http://task.ms/56098121
- http://task.ms/56098207

These changes collectively enhance the security and user awareness regarding the handling of GitHub tokens within the Winget-Create CLI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/584)