### PR TITLE
Handle sync fork failures with useful error messages

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -778,6 +778,24 @@ namespace Microsoft.WingetCreateCLI.Commands
                     Logger.ErrorLocalized(nameof(Resources.SyncForkWithUpstream_Message));
                     return false;
                 }
+                else if (e is BranchMergeConflictException)
+                {
+                    // While attempting to sync fork through the GitHub API, a branch merge conflict was detected.
+                    // The user will need to manually resolve the conflict.
+                    Logger.ErrorLocalized(nameof(Resources.BranchMergeConflict_Message));
+                    return false;
+                }
+                else if (e is GenericSyncFailureException)
+                {
+                    // While attempting to sync fork through the GitHub API, a generic sync failure occurred.
+                    Logger.ErrorLocalized(nameof(Resources.SyncForkFailed_Message));
+                    return false;
+                }
+                else if (e is HttpRequestException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.NetworkConnectionFailure_Message));
+                    return false;
+                }
                 else
                 {
                     throw;

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -268,6 +268,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The forked repository could not be synced with the upstream commits due to a merge conflict..
+        /// </summary>
+        public static string BranchMergeConflict_Message {
+            get {
+                return ResourceManager.GetString("BranchMergeConflict_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Web browser failed to launch: {0}.
         /// </summary>
         public static string BrowserFailedToLaunch_Error {
@@ -3191,6 +3200,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string SwitchToUpdateLocaleFlow_Message {
             get {
                 return ResourceManager.GetString("SwitchToUpdateLocaleFlow_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The forked repository could not be synced with the upstream commits. Sync your fork manually and try again..
+        /// </summary>
+        public static string SyncForkFailed_Message {
+            get {
+                return ResourceManager.GetString("SyncForkFailed_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -268,7 +268,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The forked repository could not be synced with the upstream commits due to a merge conflict..
+        ///   Looks up a localized string similar to The forked repository could not be synced with the upstream commits due to a merge conflict. Resolve conflicts manually and try again..
         /// </summary>
         public static string BranchMergeConflict_Message {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1404,6 +1404,6 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.</value>
   </data>
   <data name="BranchMergeConflict_Message" xml:space="preserve">
-    <value>The forked repository could not be synced with the upstream commits due to a merge conflict.</value>
+    <value>The forked repository could not be synced with the upstream commits due to a merge conflict. Resolve conflicts manually and try again.</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1400,4 +1400,10 @@ Warning: Using this argument may result in the token being logged. Consider an a
   <data name="ConfirmZippedBinary_Message" xml:space="preserve">
     <value>Does this executable depend on DLLs or any other files present in the zip archive?</value>
   </data>
+  <data name="SyncForkFailed_Message" xml:space="preserve">
+    <value>The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.</value>
+  </data>
+  <data name="BranchMergeConflict_Message" xml:space="preserve">
+    <value>The forked repository could not be synced with the upstream commits due to a merge conflict.</value>
+  </data>
 </root>

--- a/src/WingetCreateCore/Common/Exceptions/BranchMergeConflictException.cs
+++ b/src/WingetCreateCore/Common/Exceptions/BranchMergeConflictException.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCore.Common.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when the forked repo's branch has a merge conflict with the upstream branch.
+    /// </summary>
+    public class BranchMergeConflictException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BranchMergeConflictException"/> class.
+        /// </summary>
+        public BranchMergeConflictException()
+        {
+        }
+    }
+}

--- a/src/WingetCreateCore/Common/Exceptions/GenericSyncFailureException.cs
+++ b/src/WingetCreateCore/Common/Exceptions/GenericSyncFailureException.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCore.Common.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when a generic failure occurs while syncing the forked repo with upstream commits.
+    /// </summary>
+    public class GenericSyncFailureException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenericSyncFailureException"/> class.
+        /// </summary>
+        public GenericSyncFailureException()
+        {
+        }
+    }
+}


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	Related to: 
    - https://github.com/microsoft/winget-create/issues/590
    - https://github.com/microsoft/winget-pkgs/discussions/236867
    - https://github.com/microsoft/winget-create/issues/522#issuecomment-2722125336


When we have a failure while syncing fork, show useful messages to the user
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/591)