### PR TITLE
Add securityContext to configuration file

### DIFF
--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -6,13 +6,16 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 (any edition is OK)
-        allowPrerelease: true
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -22,6 +25,8 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        # Requires elevation for the get and set operations
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

Setting developer mode, installing Visual Studio 2022 & fetching and installing VS components all require elevation. Added `securityContext: elevated` for these resources. Removed `allowPrerelease: true` for `Microsoft.WinGet.DSC/WinGetPackage` as it's GA now.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/592)