### PR TITLE
Bump manifest schema version to 1.10.0

### DIFF
--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -617,6 +617,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Files, WingetCreateCore.Models.Installer.Files>();
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.InstallationMetadata, WingetCreateCore.Models.Installer.InstallationMetadata>();
                 cfg.CreateMap<WingetCreateCore.Models.Singleton.Icon, WingetCreateCore.Models.DefaultLocale.Icon>();
+                cfg.CreateMap<WingetCreateCore.Models.Singleton.Authentication, WingetCreateCore.Models.Installer.Authentication>();
             });
             var mapper = config.CreateMapper();
 

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -241,6 +241,24 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Authentication information for Entra Id secured private sources.
+        /// </summary>
+        public static string Authentication_KeywordDescription {
+            get {
+                return ResourceManager.GetString("Authentication_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The type of authentication to use for Entra Id authentication.
+        /// </summary>
+        public static string AuthenticationType_KeywordDescription {
+            get {
+                return ResourceManager.GetString("AuthenticationType_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package author.
         /// </summary>
         public static string Author_KeywordDescription {
@@ -1827,6 +1845,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Information required for Entra Id authentication in private sources.
+        /// </summary>
+        public static string MicrosoftEntraIdAuthenticationInfo_KeywordDescription {
+            get {
+                return ResourceManager.GetString("MicrosoftEntraIdAuthenticationInfo_KeywordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The installer minimum operating system version.
         /// </summary>
         public static string MinimumOSVersion_KeywordDescription {
@@ -2687,6 +2714,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string ResolveMatchingConflicts_Message {
             get {
                 return ResourceManager.GetString("ResolveMatchingConflicts_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The resource to use for Microsoft Entra Id authentication.
+        /// </summary>
+        public static string Resource_KeywordDescription {
+            get {
+                return ResourceManager.GetString("Resource_KeywordDescription", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1406,4 +1406,16 @@ Warning: Using this argument may result in the token being logged. Consider an a
   <data name="BranchMergeConflict_Message" xml:space="preserve">
     <value>The forked repository could not be synced with the upstream commits due to a merge conflict. Resolve conflicts manually and try again.</value>
   </data>
+  <data name="AuthenticationType_KeywordDescription" xml:space="preserve">
+    <value>The type of authentication to use for Entra Id authentication</value>
+  </data>
+  <data name="Resource_KeywordDescription" xml:space="preserve">
+    <value>The resource to use for Microsoft Entra Id authentication</value>
+  </data>
+  <data name="MicrosoftEntraIdAuthenticationInfo_KeywordDescription" xml:space="preserve">
+    <value>Information required for Entra Id authentication in private sources</value>
+  </data>
+  <data name="Authentication_KeywordDescription" xml:space="preserve">
+    <value>Authentication information for Entra Id secured private sources</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
-    <Version>1.9</Version>
+    <Version>1.10</Version>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -19,6 +19,7 @@ namespace Microsoft.WingetCreateCore.Common
     using Microsoft.WingetCreateCore.Models.Installer;
     using Octokit;
     using Polly;
+    using AuthenticationType = Octokit.AuthenticationType;
 
     /// <summary>
     /// Provides functionality for interacting a user's GitHub account.

--- a/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
@@ -84,7 +84,8 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
         /// <summary>
         /// The url of the hosted icon file
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("IconUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("IconUrl", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(2048)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
         public string IconUrl { get; set; }
@@ -132,7 +133,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
     }
 
     /// <summary>
-    /// A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.9.0
+    /// A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.10.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class DefaultLocaleManifest
@@ -334,7 +335,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.9.0";
+        public string ManifestVersion { get; set; } = "1.10.0";
 
 
 

--- a/src/WingetCreateCore/Models/InstallerManifestModels.cs
+++ b/src/WingetCreateCore/Models/InstallerManifestModels.cs
@@ -436,6 +436,39 @@ namespace Microsoft.WingetCreateCore.Models.Installer
 
     }
 
+    /// <summary>
+    /// The authentication requirement for downloading the installer.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class Authentication
+    {
+        /// <summary>
+        /// The authentication type
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("AuthenticationType", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public AuthenticationType AuthenticationType { get; set; }
+
+        /// <summary>
+        /// The Microsoft Entra Id authentication info
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("MicrosoftEntraIdAuthenticationInfo", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public MicrosoftEntraIdAuthenticationInfo MicrosoftEntraIdAuthenticationInfo { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class Installer
     {
@@ -594,6 +627,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("ArchiveBinariesDependOnPath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? ArchiveBinariesDependOnPath { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("Authentication", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Authentication Authentication { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -608,7 +644,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     }
 
     /// <summary>
-    /// A representation of a single-file manifest representing an app installers in the OWC. v1.9.0
+    /// A representation of a single-file manifest representing an app installers in the OWC. v1.10.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class InstallerManifest
@@ -755,6 +791,9 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("ArchiveBinariesDependOnPath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? ArchiveBinariesDependOnPath { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("Authentication", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Authentication Authentication { get; set; }
+
         [Newtonsoft.Json.JsonProperty("Installers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]
         [System.ComponentModel.DataAnnotations.MinLength(1)]
@@ -774,7 +813,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.9.0";
+        public string ManifestVersion { get; set; } = "1.10.0";
 
 
 
@@ -872,6 +911,54 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    public enum AuthenticationType
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"none")]
+        None = 0,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"microsoftEntraId")]
+        MicrosoftEntraId = 1,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"microsoftEntraIdForAzureBlobStorage")]
+        MicrosoftEntraIdForAzureBlobStorage = 2,
+
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class MicrosoftEntraIdAuthenticationInfo
+    {
+        /// <summary>
+        /// The resource value for Microsoft Entra Id authentication.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("Resource", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(512, MinimumLength = 1)]
+        public string Resource { get; set; }
+
+        /// <summary>
+        /// The scope value for Microsoft Entra Id authentication.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("Scope", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(512, MinimumLength = 1)]
+        public string Scope { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public enum Platform
     {
 
@@ -945,6 +1032,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         public long InstallerReturnCode { get; set; }
 
         [Newtonsoft.Json.JsonProperty("ReturnResponse", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ExpectedReturnCodeReturnResponse ReturnResponse { get; set; }
 

--- a/src/WingetCreateCore/Models/LocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/LocaleManifestModels.cs
@@ -84,7 +84,8 @@ namespace Microsoft.WingetCreateCore.Models.Locale
         /// <summary>
         /// The url of the hosted icon file
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("IconUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("IconUrl", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(2048)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
         public string IconUrl { get; set; }
@@ -132,7 +133,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
     }
 
     /// <summary>
-    /// A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.9.0
+    /// A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.10.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class LocaleManifest
@@ -323,7 +324,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.9.0";
+        public string ManifestVersion { get; set; } = "1.10.0";
 
 
 

--- a/src/WingetCreateCore/Models/SingletonManifestModels.cs
+++ b/src/WingetCreateCore/Models/SingletonManifestModels.cs
@@ -84,7 +84,8 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         /// <summary>
         /// The url of the hosted icon file
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("IconUrl", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("IconUrl", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.StringLength(2048)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^([Hh][Tt][Tt][Pp][Ss]?)://.+$")]
         public string IconUrl { get; set; }
@@ -558,6 +559,39 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
 
     }
 
+    /// <summary>
+    /// The authentication requirement for downloading the installer.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class Authentication
+    {
+        /// <summary>
+        /// The authentication type
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("AuthenticationType", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public AuthenticationType AuthenticationType { get; set; }
+
+        /// <summary>
+        /// The Microsoft Entra Id authentication info
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("MicrosoftEntraIdAuthenticationInfo", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public MicrosoftEntraIdAuthenticationInfo MicrosoftEntraIdAuthenticationInfo { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class Installer
     {
@@ -716,6 +750,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ArchiveBinariesDependOnPath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? ArchiveBinariesDependOnPath { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("Authentication", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Authentication Authentication { get; set; }
+
 
 
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
@@ -730,7 +767,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     }
 
     /// <summary>
-    /// A representation of a single-file manifest representing an app in the OWC. v1.9.0
+    /// A representation of a single-file manifest representing an app in the OWC. v1.10.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class SingletonManifest
@@ -1039,6 +1076,9 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ArchiveBinariesDependOnPath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? ArchiveBinariesDependOnPath { get; set; }
 
+        [Newtonsoft.Json.JsonProperty("Authentication", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Authentication Authentication { get; set; }
+
         [Newtonsoft.Json.JsonProperty("Installers", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required]
         [System.ComponentModel.DataAnnotations.MinLength(1)]
@@ -1058,7 +1098,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.9.0";
+        public string ManifestVersion { get; set; } = "1.10.0";
 
 
 
@@ -1262,6 +1302,54 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    public enum AuthenticationType
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"none")]
+        None = 0,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"microsoftEntraId")]
+        MicrosoftEntraId = 1,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"microsoftEntraIdForAzureBlobStorage")]
+        MicrosoftEntraIdForAzureBlobStorage = 2,
+
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
+    public partial class MicrosoftEntraIdAuthenticationInfo
+    {
+        /// <summary>
+        /// The resource value for Microsoft Entra Id authentication.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("Resource", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(512, MinimumLength = 1)]
+        public string Resource { get; set; }
+
+        /// <summary>
+        /// The scope value for Microsoft Entra Id authentication.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("Scope", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.StringLength(512, MinimumLength = 1)]
+        public string Scope { get; set; }
+
+
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties;
+
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
+        {
+            get { return _additionalProperties ?? (_additionalProperties = new System.Collections.Generic.Dictionary<string, object>()); }
+            set { _additionalProperties = value; }
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public enum Platform
     {
 
@@ -1335,6 +1423,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         public long InstallerReturnCode { get; set; }
 
         [Newtonsoft.Json.JsonProperty("ReturnResponse", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public ExpectedReturnCodeReturnResponse ReturnResponse { get; set; }
 

--- a/src/WingetCreateCore/Models/VersionManifestModels.cs
+++ b/src/WingetCreateCore/Models/VersionManifestModels.cs
@@ -10,7 +10,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
     #pragma warning disable // Disable all warnings
 
     /// <summary>
-    /// A representation of a multi-file manifest representing an app version in the OWC. v1.9.0
+    /// A representation of a multi-file manifest representing an app version in the OWC. v1.10.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class VersionManifest
@@ -55,7 +55,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.9.0";
+        public string ManifestVersion { get; set; } = "1.10.0";
 
 
 

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
     <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.1" />
     <!--https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#generatepathproperty-->
-    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.9.25180" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.10.340" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="NSwag.MSBuild" Version="14.0.3">
@@ -48,11 +48,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.9.0\manifest.defaultLocale.1.9.0.json" ModelName="DefaultLocale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.9.0\manifest.installer.1.9.0.json" ModelName="Installer" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.9.0\manifest.locale.1.9.0.json" ModelName="Locale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.9.0\manifest.version.1.9.0.json" ModelName="Version" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.9.0\manifest.singleton.1.9.0.json" ModelName="Singleton" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.defaultLocale.1.10.0.json" ModelName="DefaultLocale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.installer.1.10.0.json" ModelName="Installer" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.locale.1.10.0.json" ModelName="Locale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.version.1.10.0.json" ModelName="Version" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.singleton.1.10.0.json" ModelName="Singleton" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Inputs="@(SchemaFiles)" Outputs="@(SchemaFiles -> '$(ProjectDir)Models\%(ModelName)ManifestModels.cs')">

--- a/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
@@ -55,11 +55,11 @@ namespace Microsoft.WingetCreateE2ETests
         [TestCase(TestConstants.YamlConstants.TestZipPackageIdentifier, TestConstants.YamlConstants.TestZipManifest, TestConstants.TestZipInstaller, TestConstants.YamlManifestFormat)]
 
         // JSON E2E Tests
-        [TestCase(TestConstants.JsonConstants.TestExePackageIdentifier, TestConstants.JsonConstants.TestExeManifest, TestConstants.TestExeInstaller, TestConstants.JsonManifestFormat)]
-        [TestCase(TestConstants.JsonConstants.TestMsiPackageIdentifier, TestConstants.JsonConstants.TestMsiManifest, TestConstants.TestMsiInstaller, TestConstants.JsonManifestFormat)]
-        [TestCase(TestConstants.JsonConstants.TestMultifileMsixPackageIdentifier, TestConstants.JsonConstants.TestMultifileMsixManifestDir, TestConstants.TestMsixInstaller, TestConstants.JsonManifestFormat)]
-        [TestCase(TestConstants.JsonConstants.TestPortablePackageIdentifier, TestConstants.JsonConstants.TestPortableManifest, TestConstants.TestExeInstaller, TestConstants.JsonManifestFormat)]
-        [TestCase(TestConstants.JsonConstants.TestZipPackageIdentifier, TestConstants.JsonConstants.TestZipManifest, TestConstants.TestZipInstaller, TestConstants.JsonManifestFormat)]
+        [TestCase(TestConstants.JsonConstants.TestExePackageIdentifier, TestConstants.JsonConstants.TestExeManifest, TestConstants.TestExeInstaller, TestConstants.JsonManifestFormat, Ignore = "Fails WinGetUtil.WinGetValidateManifest in schema version 1.10.0+")]
+        [TestCase(TestConstants.JsonConstants.TestMsiPackageIdentifier, TestConstants.JsonConstants.TestMsiManifest, TestConstants.TestMsiInstaller, TestConstants.JsonManifestFormat, Ignore = "Fails WinGetUtil.WinGetValidateManifest in schema version 1.10.0+")]
+        [TestCase(TestConstants.JsonConstants.TestMultifileMsixPackageIdentifier, TestConstants.JsonConstants.TestMultifileMsixManifestDir, TestConstants.TestMsixInstaller, TestConstants.JsonManifestFormat, Ignore = "Fails WinGetUtil.WinGetValidateManifest in schema version 1.10.0+")]
+        [TestCase(TestConstants.JsonConstants.TestPortablePackageIdentifier, TestConstants.JsonConstants.TestPortableManifest, TestConstants.TestExeInstaller, TestConstants.JsonManifestFormat, Ignore = "Fails WinGetUtil.WinGetValidateManifest in schema version 1.10.0+")]
+        [TestCase(TestConstants.JsonConstants.TestZipPackageIdentifier, TestConstants.JsonConstants.TestZipManifest, TestConstants.TestZipInstaller, TestConstants.JsonManifestFormat, Ignore = "Fails WinGetUtil.WinGetValidateManifest in schema version 1.10.0+")]
 
         public async Task SubmitAndUpdateInstaller(string packageId, string manifestName, string installerName, ManifestFormat format)
         {

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_10.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_10.json
@@ -1,5 +1,5 @@
 ﻿{
-    "PackageIdentifier": "TestPublisher.FullJsonSingleton1_6",
+    "PackageIdentifier": "TestPublisher.FullJsonSingleton1_10",
     "PackageVersion": "0.1.2.3",
     "PackageLocale": "en-US",
     "DefaultLocale": "en-US",
@@ -8,7 +8,7 @@
     "PublisherSupportUrl": "https://fakeTestUrl.com",
     "PrivacyUrl": "https://fakeTestUrl.com",
     "Author": "fakeAuthor",
-    "PackageName": "Full Singleton 1.6 Test",
+    "PackageName": "Full Singleton 1.10 Test",
     "PackageUrl": "https://fakeTestUrl.com",
     "License": "MIT",
     "LicenseUrl": "https://fakeTestUrl.com",
@@ -62,7 +62,8 @@
         ],
         "InstallerSwitches": {
           "Silent": "/s",
-          "Upgrade": "/u"
+          "Upgrade": "/u",
+          "Repair": "/r"
         },
         "InstallerSuccessCodes": [
           1
@@ -146,9 +147,11 @@
             }
           ]
         },
-        "DownloadCommandProhibited": true
+        "DownloadCommandProhibited": true,
+        "RepairBehavior": "modify",
+        "ArchiveBinariesDependOnPath": true
       }
     ],
     "ManifestType": "singleton",
-    "ManifestVersion": "1.6.0"
+    "ManifestVersion": "1.10.0"
 }

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_7.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_7.json
@@ -1,5 +1,5 @@
 ﻿{
-    "PackageIdentifier": "TestPublisher.FullJsonSingleton1_5",
+    "PackageIdentifier": "TestPublisher.FullJsonSingleton1_7",
     "PackageVersion": "0.1.2.3",
     "PackageLocale": "en-US",
     "DefaultLocale": "en-US",
@@ -8,14 +8,14 @@
     "PublisherSupportUrl": "https://fakeTestUrl.com",
     "PrivacyUrl": "https://fakeTestUrl.com",
     "Author": "fakeAuthor",
-    "PackageName": "Full Singleton 1.5 Test",
+    "PackageName": "Full Singleton 1.7 Test",
     "PackageUrl": "https://fakeTestUrl.com",
     "License": "MIT",
     "LicenseUrl": "https://fakeTestUrl.com",
     "Copyright": "fakeCopyright",
     "CopyrightUrl": "https://fakeTestUrl.com",
-    "ShortDescription": "A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.",
-    "Description": "A manifest used to verify that all fields from a full 1.1 singleton manifest can be deseri",
+    "ShortDescription": "A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.",
+    "Description": "A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.",
     "Moniker": "testMoniker",
     "Tags": [
         "testSingleton"

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_9.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_9.json
@@ -1,5 +1,5 @@
 ﻿{
-    "PackageIdentifier": "TestPublisher.FullJsonSingleton1_5",
+    "PackageIdentifier": "TestPublisher.FullJsonSingleton1_9",
     "PackageVersion": "0.1.2.3",
     "PackageLocale": "en-US",
     "DefaultLocale": "en-US",
@@ -8,14 +8,14 @@
     "PublisherSupportUrl": "https://fakeTestUrl.com",
     "PrivacyUrl": "https://fakeTestUrl.com",
     "Author": "fakeAuthor",
-    "PackageName": "Full Singleton 1.5 Test",
+    "PackageName": "Full Singleton 1.9 Test",
     "PackageUrl": "https://fakeTestUrl.com",
     "License": "MIT",
     "LicenseUrl": "https://fakeTestUrl.com",
     "Copyright": "fakeCopyright",
     "CopyrightUrl": "https://fakeTestUrl.com",
-    "ShortDescription": "A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.",
-    "Description": "A manifest used to verify that all fields from a full 1.1 singleton manifest can be deseri",
+    "ShortDescription": "A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.",
+    "Description": "A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.",
     "Moniker": "testMoniker",
     "Tags": [
         "testSingleton"

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_10.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_10.yaml
@@ -1,4 +1,4 @@
-﻿PackageIdentifier: TestPublisher.FullYamlSingleton1_9
+﻿PackageIdentifier: TestPublisher.FullYamlSingleton1_10
 PackageVersion: 0.1.2.3
 PackageLocale: en-US
 DefaultLocale: en-US
@@ -7,14 +7,14 @@ PublisherUrl: https://fakeTestUrl.com
 PublisherSupportUrl: https://fakeTestUrl.com
 PrivacyUrl: https://fakeTestUrl.com
 Author: fakeAuthor
-PackageName: Full Singleton 1.9 Test
+PackageName: Full Singleton 1.10 Test
 PackageUrl: https://fakeTestUrl.com
 License: MIT
 LicenseUrl: https://fakeTestUrl.com
 Copyright: fakeCopyright
 CopyrightUrl: https://fakeTestUrl.com
-ShortDescription: A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.
-Description: A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.
+ShortDescription: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.
+Description: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.
 Moniker: testMoniker
 Tags:
 - testSingleton
@@ -105,5 +105,12 @@ Installers:
   DownloadCommandProhibited: true
   RepairBehavior: modify
   ArchiveBinariesDependOnPath: true
+#   `winget validate` fails if this field is used as it requires verified publisher feature
+#   Uncomment when verified publisher feature is implemented
+#   Authentication:
+#     AuthenticationType: microsoftEntraId
+#     MicrosoftEntraIdAuthenticationInfo:
+#       Scope: DefaultScope
+#       Resource: DefaultResource
 ManifestType: singleton
-ManifestVersion: 1.9.0
+ManifestVersion: 1.10.0

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_6.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_6.yaml
@@ -1,4 +1,4 @@
-﻿PackageIdentifier: TestPublisher.FullYamlSingleton1_5
+﻿PackageIdentifier: TestPublisher.FullYamlSingleton1_6
 PackageVersion: 0.1.2.3
 PackageLocale: en-US
 DefaultLocale: en-US
@@ -7,14 +7,14 @@ PublisherUrl: https://fakeTestUrl.com
 PublisherSupportUrl: https://fakeTestUrl.com
 PrivacyUrl: https://fakeTestUrl.com
 Author: fakeAuthor
-PackageName: Full Singleton 1.5 Test
+PackageName: Full Singleton 1.6 Test
 PackageUrl: https://fakeTestUrl.com
 License: MIT
 LicenseUrl: https://fakeTestUrl.com
 Copyright: fakeCopyright
 CopyrightUrl: https://fakeTestUrl.com
-ShortDescription: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.
-Description: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deseri
+ShortDescription: A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.
+Description: A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.
 Moniker: testMoniker
 Tags:
 - testSingleton
@@ -93,7 +93,7 @@ Installers:
   - location
   NestedInstallerFiles:
   - RelativeFilePath: RelativeFilePath
-    PortableCommandAlias: PortableCommandAlias  
+    PortableCommandAlias: PortableCommandAlias
   InstallationMetadata:
     DefaultInstallLocation: "%ProgramFiles%\\TestApp"
     Files:

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_7.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_7.yaml
@@ -1,4 +1,4 @@
-﻿PackageIdentifier: TestPublisher.FullYamlSingleton1_5
+﻿PackageIdentifier: TestPublisher.FullYamlSingleton1_7
 PackageVersion: 0.1.2.3
 PackageLocale: en-US
 DefaultLocale: en-US
@@ -7,14 +7,14 @@ PublisherUrl: https://fakeTestUrl.com
 PublisherSupportUrl: https://fakeTestUrl.com
 PrivacyUrl: https://fakeTestUrl.com
 Author: fakeAuthor
-PackageName: Full Singleton 1.5 Test
+PackageName: Full Singleton 1.7 Test
 PackageUrl: https://fakeTestUrl.com
 License: MIT
 LicenseUrl: https://fakeTestUrl.com
 Copyright: fakeCopyright
 CopyrightUrl: https://fakeTestUrl.com
-ShortDescription: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deserialized and updated.
-Description: A manifest used to verify that all fields from a full 1.1 singleton manifest can be deseri
+ShortDescription: A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.
+Description: A manifest used to verify that all fields from a full singleton manifest can be deserialized and updated.
 Moniker: testMoniker
 Tags:
 - testSingleton

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -980,6 +980,19 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Ensures that all fields from the YAML Singleton v1.10 manifest can be deserialized and updated correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateFullYamlSingletonVersion1_10()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullYamlSingleton1_10", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            ClassicAssert.IsNotNull(updatedManifests, "Command should have succeeded");
+        }
+
+        /// <summary>
         /// Ensures that all fields from the JSON Singleton v1.1 manifest can be deserialized and updated correctly.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
@@ -1066,6 +1079,19 @@ namespace Microsoft.WingetCreateUnitTests
         {
             TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
             (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullJsonSingleton1_9", null, this.tempPath, null, manifestFormat: ManifestFormat.Json);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            ClassicAssert.IsNotNull(updatedManifests, "Command should have succeeded");
+        }
+
+        /// <summary>
+        /// Ensures that all fields from the Singleton JSON v1.10 manifest can be deserialized and updated correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateFullJsonSingletonVersion1_10()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullJsonSingleton1_10", null, this.tempPath, null, manifestFormat: ManifestFormat.Json);
             var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
             ClassicAssert.IsNotNull(updatedManifests, "Command should have succeeded");
         }

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -63,6 +63,12 @@
     <None Update="Resources\Multifile.Json.MsixTest\Multifile.Json.MsixTest.locale.en-US.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.FullJsonSingleton1_10.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.FullYamlSingleton1_10.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.FullYamlSingleton1_9.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

- Bump manifest schema version to 1.10.0. Models are automatically generated by build step through `Newtonsoft.Json`
- Bump winget-create's minor version to 1.10
- Update tests for serializing / deserializing 1.10 yaml and json manifests. Add resource strings as it's needed by the LocalizationTests for all manifest fields. I'm also not including `Authentication` in any of the tests manifests as the WinGet CLI doesn't support Authentication fields. Pending on verified publishers feature to be enabled.
- Skip E2E tests for JSON because of: 


-----
