### PR TITLE
Initial support for DSC v3 in WinGet-Create

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ choco install wingetcreate
 | [Settings](doc/settings.md) | Command for editing the settings file configurations |
 | [Cache](doc/cache.md) | Command for managing downloaded installers stored in cache
 | [Info](doc/info.md)      | Displays information about the client |
+| [Dsc](doc/dsc.md)      | DSC v3 resource commands |
 | [-?](doc/help.md)      | Displays command line help |
 
 Click on the individual commands to learn more.

--- a/doc/dsc.md
+++ b/doc/dsc.md
@@ -20,6 +20,6 @@ The following arguments are available:
 | **-g, --get** | Get the resource state
 | **-s, --set** | Set the resource state |
 | **-t, --test** | Test the resource state |
-| **e, --export** | Get all state instances |
+| **-e, --export** | Get all state instances |
 | **--schema** |  Execute the Schema command |
 | **-?, --help** |  Gets additional help on this command. |

--- a/doc/dsc.md
+++ b/doc/dsc.md
@@ -1,0 +1,25 @@
+# dsc command (Winget-Create)
+
+The **dsc** command is the entry point for using DSC (Desired State Coonfiguration) with Winget-Create.
+
+## Usage
+
+`wingetcreate.exe dsc <resource> [<options>]`
+
+## Resources
+| Resource | Type | Description | --get | --set | --test | --export | --schema | Link |
+| ---- | ------ | ------------| ----- | ----- | ----- | ----- | ----- | ----- |
+| `settings` | `Microsoft.WinGetCreate/Settings` | Manage the settings for Winget-Create | ✅ | ✅ | ✅ | ✅ | ✅ | [Details](dsc/settings.md) |
+
+## Arguments
+
+The following arguments are available:
+
+| <div style="width:100px">Argument</div> | Description |
+| --------------------------------------- | ------------|
+| **-g, --get** | Get the resource state
+| **-s, --set** | Set the resource state |
+| **-t, --test** | Test the resource state |
+| **e, --export** | Get all state instances |
+| **--schema** |  Execute the Schema command |
+| **-?, --help** |  Gets additional help on this command. |

--- a/doc/dsc.md
+++ b/doc/dsc.md
@@ -7,7 +7,7 @@ The **dsc** command is the entry point for using DSC (Desired State Coonfigurati
 `wingetcreate.exe dsc <resource> [<options>]`
 
 ## Resources
-| Resource | Type | Description | --get | --set | --test | --export | --schema | Link |
+| Resource | Type | Description | <div style="white-space: nowrap;">--get</div> | <div style="white-space: nowrap;">--set</div> | <div style="white-space: nowrap;">--test</div> | <div style="white-space: nowrap;">--export</div> | <div style="white-space: nowrap;">--schema</div> | Link |
 | ---- | ------ | ------------| ----- | ----- | ----- | ----- | ----- | ----- |
 | `settings` | `Microsoft.WinGetCreate/Settings` | Manage the settings for Winget-Create | ✅ | ✅ | ✅ | ✅ | ✅ | [Details](dsc/settings.md) |
 

--- a/doc/dsc/settings.md
+++ b/doc/dsc/settings.md
@@ -1,0 +1,49 @@
+# Settings resource
+Manage the settings for Winget-Create
+
+## 📄 Get
+```shell
+PS C:\> wingetcreate dsc settings --get
+{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}}}
+```
+
+## 🖨️ Export
+ℹ️ Settings resource Get and Export operation output states are identical.
+```shell
+PS C:\> wingetcreate dsc settings --export
+{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}}}
+```
+
+## 📝 Set
+- Action `Full`: When action is set to Full, the specified settings will be update accordingly and the remaining settings will be set to their default values.
+- Action `Partial`: When action is set to Partial, only the specified settings will be updated, and the remaining settings will remain unchanged.
+### 🌕 Full
+```shell
+PS C:\> wingetcreate dsc settings --set '{"settings": { "Telemetry": { "disable": false }}, "action": "Full"}'
+{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":false},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Full"}
+["settings"]
+```
+
+### 🌗 Partial
+```shell
+PS C:\> wingetcreate dsc settings --set '{"settings": { "Telemetry": { "disable": true }}, "action": "Partial"}'
+{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Partial"}
+["settings"]
+```
+
+## 🧪 Test
+- Action `Full`: When action is set to Full, the specified settings will be tested accordingly, and the remaining settings will be tested against their default values.
+- Action `Partial`: When action is set to Partial, only the specified settings will be tested, and the remaining settings will be omitted from the test.
+### 🌕 Full
+```shell
+PS C:\> wingetcreate dsc settings --test '{"settings": { "Telemetry": { "disable": false }}, "action": "Full"}'
+{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Full","_inDesiredState":false}
+["settings"]
+```
+
+### 🌗 Partial
+```shell
+PS C:\> wingetcreate dsc settings --test '{"settings": { "Telemetry": { "disable": false }}, "action": "Partial"}'
+{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Partial","_inDesiredState":false}
+["settings"]
+```

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -62,6 +62,11 @@ namespace Microsoft.WingetCreateCLI.Commands
         public static string Extension => Serialization.ManifestSerializer.AssociatedFileExtension;
 
         /// <summary>
+        /// Gets a value indicating whether or not the command requires a GitHub token to be set.
+        /// </summary>
+        public virtual bool RequiresGitHubToken { get; } = true;
+
+        /// <summary>
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         public virtual string GitHubToken { get; set; }

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -62,9 +62,9 @@ namespace Microsoft.WingetCreateCLI.Commands
         public static string Extension => Serialization.ManifestSerializer.AssociatedFileExtension;
 
         /// <summary>
-        /// Gets a value indicating whether or not the command requires a GitHub token to be set.
+        /// Gets a value indicating whether or not the command accepts a GitHub token.
         /// </summary>
-        public virtual bool RequiresGitHubToken { get; } = true;
+        public virtual bool AcceptsGitHubToken { get; } = true;
 
         /// <summary>
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.

--- a/src/WingetCreateCLI/Commands/CacheCommand.cs
+++ b/src/WingetCreateCLI/Commands/CacheCommand.cs
@@ -38,6 +38,9 @@ namespace Microsoft.WingetCreateCLI.Commands
         [Option('o', "open", Required = true, SetName = nameof(Open), HelpText = "Open_HelpText", ResourceType = typeof(Resources))]
         public bool Open { get; set; }
 
+        /// <inheritdoc/>
+        public override bool RequiresGitHubToken => false;
+
         /// <summary>
         /// Executes the cache command flow.
         /// </summary>

--- a/src/WingetCreateCLI/Commands/CacheCommand.cs
+++ b/src/WingetCreateCLI/Commands/CacheCommand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.WingetCreateCLI.Commands
         public bool Open { get; set; }
 
         /// <inheritdoc/>
-        public override bool RequiresGitHubToken => false;
+        public override bool AcceptsGitHubToken => false;
 
         /// <summary>
         /// Executes the cache command flow.

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommandLine;
 using Microsoft.WingetCreateCLI.Commands.DscCommands;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 /// <summary>

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -51,6 +51,12 @@ public class DscCommand : BaseCommand
     public string Export { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to execute the schema command.
+    /// </summary>
+    [Option("schema", SetName = "SchemaMethod", HelpText = "Command for the Schema flow.")]
+    public bool Schema { get; set; }
+
+    /// <summary>
     /// Executes the dsc command flow.
     /// </summary>
     /// <returns>Boolean representing success or fail of the command.</returns>
@@ -58,7 +64,7 @@ public class DscCommand : BaseCommand
     {
         BaseDscCommand dscCommand;
         var dscScope = this.UnboundArgs.FirstOrDefault()?.ToLowerInvariant() ?? string.Empty;
-        if (dscScope == DscSettingsCommand.CommandName)
+        if (dscScope == "settings")
         {
             dscCommand = new DscSettingsCommand();
         }
@@ -84,6 +90,10 @@ public class DscCommand : BaseCommand
         else if (this.TryParse(this.Export, out input))
         {
             dscCommand.Export(input);
+        }
+        else if (this.Schema)
+        {
+            dscCommand.Schema();
         }
         else
         {

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -5,6 +5,7 @@ namespace Microsoft.WingetCreateCLI.Commands;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using CommandLine;
@@ -72,11 +73,9 @@ public class DscCommand : BaseCommand
     {
         await Task.CompletedTask;
 
-        List<BaseDscCommand> dscCommands = [new DscSettingsCommand()];
-        var dscCommand = dscCommands.FirstOrDefault(c => c.CommandName.Equals(this.ResourceName, StringComparison.OrdinalIgnoreCase));
-        if (dscCommand == null)
+        if (!BaseDscCommand.TryCreateInstance(this.ResourceName, out var dscCommand))
         {
-            var availableResources = string.Join(", ", dscCommands.Select(c => c.CommandName));
+            var availableResources = string.Join(", ", BaseDscCommand.GetAvailableCommands());
             Logger.ErrorLocalized(nameof(Resources.DscResourceNameNotFound_Message), this.ResourceName, availableResources);
             return false;
         }

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -77,7 +77,7 @@ public class DscCommand : BaseCommand
         if (dscCommand == null)
         {
             var availableResources = string.Join(", ", dscCommands.Select(c => c.CommandName));
-            Logger.ErrorLocalized(nameof(Resources.DscResourceNotFound_Message), this.ResourceName, availableResources);
+            Logger.ErrorLocalized(nameof(Resources.DscResourceNameNotFound_Message), this.ResourceName, availableResources);
             return false;
         }
 
@@ -107,7 +107,7 @@ public class DscCommand : BaseCommand
                 }
             }
 
-            Logger.ErrorLocalized(nameof(Resources.DscResourceOperationInvalid_Message));
+            Logger.ErrorLocalized(nameof(Resources.DscResourceOperationNotSpecified_Message));
             return false;
         }
         catch (Exception ex)

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -68,11 +68,16 @@ public class DscCommand : BaseCommand
 
         List<BaseDscCommand> dscCommands = [new DscSettingsCommand()];
         var argCommandName = this.UnboundArgs.FirstOrDefault();
-        var dscCommand = dscCommands.FirstOrDefault(c => c.CommandName.Equals(argCommandName, StringComparison.OrdinalIgnoreCase));
+        if(string.IsNullOrWhiteSpace(argCommandName))
+        {
+            Logger.ErrorLocalized(nameof(Resources.DscResourceMissing_Message), string.Join(", ", dscCommands.Select(c => c.CommandName)));
+            return false;
+        }
 
+        var dscCommand = dscCommands.FirstOrDefault(c => c.CommandName.Equals(argCommandName, StringComparison.OrdinalIgnoreCase));
         if (dscCommand == null)
         {
-            Logger.ErrorLocalized(Resources.DscResourceNotFound_Message, argCommandName);
+            Logger.ErrorLocalized(nameof(Resources.DscResourceNotFound_Message), argCommandName);
             return false;
         }
 
@@ -85,7 +90,7 @@ public class DscCommand : BaseCommand
             return true;
         }
 
-        Logger.ErrorLocalized(Resources.DscResourceOperationInvalid_Message);
+        Logger.ErrorLocalized(nameof(Resources.DscResourceOperationInvalid_Message));
         return false;
     }
 
@@ -102,7 +107,7 @@ public class DscCommand : BaseCommand
             var input = string.IsNullOrWhiteSpace(arg) ? null : JToken.Parse(arg);
             if (!op(input))
             {
-                Logger.ErrorLocalized(Resources.DscResourceOperationFailed_Message);
+                Logger.ErrorLocalized(nameof(Resources.DscResourceOperationFailed_Message));
                 return false;
             }
 

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI.Commands;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandLine;
+using Microsoft.WingetCreateCLI.Commands.DscCommands;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// Command for managin the application using dsc v3.
+/// </summary>
+[Verb("dsc", HelpText = "Manage the application using dsc v3.")]
+public class DscCommand : BaseCommand
+{
+    /// <inheritdoc/>
+    public override bool RequiresGitHubToken => false;
+
+    /// <summary>
+    /// Gets or sets the unbound arguments that exist after the positional parameters.
+    /// </summary>
+    [Value(2, Hidden = true)]
+    public IList<string> UnboundArgs { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the input for the dsc Get operation.
+    /// </summary>
+    [Option('g', "get", SetName = "GetMethod", HelpText = "Command for the Get flow.")]
+    public string Get { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input for the dsc Set operation.
+    /// </summary>
+    [Option('s', "set", SetName = "SetMethod", HelpText = "Command for the Set flow.")]
+    public string Set { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input for the dsc Test operation.
+    /// </summary>
+    [Option('t', "test", SetName = "TestMethod", HelpText = "Command for the Test flow.")]
+    public string Test { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input for the dsc Export operation.
+    /// </summary>
+    [Option('e', "export", SetName = "ExportMethod", HelpText = "Command for the Export flow.")]
+    public string Export { get; set; }
+
+    /// <summary>
+    /// Executes the dsc command flow.
+    /// </summary>
+    /// <returns>Boolean representing success or fail of the command.</returns>
+    public override async Task<bool> Execute()
+    {
+        BaseDscCommand dscCommand;
+        var dscScope = this.UnboundArgs.FirstOrDefault()?.ToLowerInvariant() ?? string.Empty;
+        if (dscScope == DscSettingsCommand.CommandName)
+        {
+            dscCommand = new DscSettingsCommand();
+        }
+        else
+        {
+            Console.WriteLine($"Unknown DSC scope: {dscScope}");
+            return false;
+        }
+
+        JToken input;
+        if (this.TryParse(this.Get, out input))
+        {
+            dscCommand.Get(input);
+        }
+        else if (this.TryParse(this.Set, out input))
+        {
+            dscCommand.Set(input);
+        }
+        else if (this.TryParse(this.Test, out input))
+        {
+            dscCommand.Test(input);
+        }
+        else if (this.TryParse(this.Export, out input))
+        {
+            dscCommand.Export(input);
+        }
+        else
+        {
+            Console.WriteLine("No valid DSC command provided. Use -g, -s, -t, or -e to specify a command.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool TryParse(string json, out JToken token)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            token = null;
+            return false;
+        }
+
+        try
+        {
+            token = JToken.Parse(json);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error parsing JSON: {ex.Message}");
+            token = null;
+            return false;
+        }
+    }
+}

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -10,12 +10,13 @@ using System.Threading.Tasks;
 using CommandLine;
 using Microsoft.WingetCreateCLI.Commands.DscCommands;
 using Microsoft.WingetCreateCLI.Logging;
+using Microsoft.WingetCreateCLI.Properties;
 using Newtonsoft.Json.Linq;
 
 /// <summary>
 /// Command for managin the application using dsc v3.
 /// </summary>
-[Verb("dsc", HelpText = "Manage the application using dsc v3.")]
+[Verb("dsc", HelpText = "DscCommand_HelpText", ResourceType = typeof(Resources))]
 public class DscCommand : BaseCommand
 {
     /// <inheritdoc/>
@@ -30,31 +31,31 @@ public class DscCommand : BaseCommand
     /// <summary>
     /// Gets or sets the input for the dsc Get operation.
     /// </summary>
-    [Option('g', "get", SetName = "GetMethod", HelpText = "Command for the Get flow.")]
+    [Option('g', "get", SetName = "GetMethod", HelpText = "DscGet_HelpText", ResourceType = typeof(Resources))]
     public string Get { get; set; }
 
     /// <summary>
     /// Gets or sets the input for the dsc Set operation.
     /// </summary>
-    [Option('s', "set", SetName = "SetMethod", HelpText = "Command for the Set flow.")]
+    [Option('s', "set", SetName = "SetMethod", HelpText = "DscSet_HelpText", ResourceType = typeof(Resources))]
     public string Set { get; set; }
 
     /// <summary>
     /// Gets or sets the input for the dsc Test operation.
     /// </summary>
-    [Option('t', "test", SetName = "TestMethod", HelpText = "Command for the Test flow.")]
+    [Option('t', "test", SetName = "TestMethod", HelpText = "DscTest_HelpText", ResourceType = typeof(Resources))]
     public string Test { get; set; }
 
     /// <summary>
     /// Gets or sets the input for the dsc Export operation.
     /// </summary>
-    [Option('e', "export", SetName = "ExportMethod", HelpText = "Command for the Export flow.")]
+    [Option('e', "export", SetName = "ExportMethod", HelpText = "DscExport_HelpText", ResourceType = typeof(Resources))]
     public string Export { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to execute the schema command.
     /// </summary>
-    [Option("schema", SetName = "SchemaMethod", HelpText = "Command for the Schema flow.")]
+    [Option("schema", SetName = "SchemaMethod", HelpText = "DscSchema_HelpText", ResourceType = typeof(Resources))]
     public bool Schema { get; set; }
 
     /// <summary>
@@ -71,7 +72,7 @@ public class DscCommand : BaseCommand
 
         if (dscCommand == null)
         {
-            Logger.Error($"Unknown DSC resource {argCommandName}");
+            Logger.ErrorLocalized(Resources.DscResourceNotFound_Message, argCommandName);
             return false;
         }
 
@@ -84,7 +85,7 @@ public class DscCommand : BaseCommand
             return true;
         }
 
-        Logger.Error("No valid DSC command provided.");
+        Logger.ErrorLocalized(Resources.DscResourceOperationInvalid_Message);
         return false;
     }
 
@@ -98,10 +99,10 @@ public class DscCommand : BaseCommand
 
         try
         {
-            var input = this.GetJsonOrNull(arg);
+            var input = string.IsNullOrWhiteSpace(arg) ? null : JToken.Parse(arg);
             if (!op(input))
             {
-                Logger.Error($"Invalid input for {name} command.");
+                Logger.ErrorLocalized(Resources.DscResourceOperationFailed_Message);
                 return false;
             }
 
@@ -111,24 +112,6 @@ public class DscCommand : BaseCommand
         {
             Logger.Error(ex.Message);
             return false;
-        }
-    }
-
-    private JToken GetJsonOrNull(string json)
-    {
-        if (string.IsNullOrWhiteSpace(json))
-        {
-            return null;
-        }
-
-        try
-        {
-            return JToken.Parse(json);
-        }
-        catch (Exception ex)
-        {
-            Logger.Error(ex.Message);
-            return null;
         }
     }
 }

--- a/src/WingetCreateCLI/Commands/DscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommand.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json.Linq;
 public class DscCommand : BaseCommand
 {
     /// <inheritdoc/>
-    public override bool RequiresGitHubToken => false;
+    public override bool AcceptsGitHubToken => false;
 
     /// <summary>
     /// Gets or sets the name of the resource to be managed by the dsc command.

--- a/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
@@ -22,30 +22,35 @@ public abstract class BaseDscCommand
     /// DSC Get command.
     /// </summary>
     /// <param name="input">Input for the Get command.</param>
-    public abstract void Get(JToken input);
+    /// <returns>True if the command was successful; otherwise, false.</returns>
+    public abstract bool Get(JToken input);
 
     /// <summary>
     /// DSC Set command.
     /// </summary>
     /// <param name="input">Input for the Set command.</param>
-    public abstract void Set(JToken input);
+    /// <returns>True if the command was successful; otherwise, false.</returns>
+    public abstract bool Set(JToken input);
 
     /// <summary>
     /// DSC Test command.
     /// </summary>
     /// <param name="input">Input for the Test command.</param>
-    public abstract void Test(JToken input);
+    /// <returns>True if the command was successful; otherwise, false.</returns>
+    public abstract bool Test(JToken input);
 
     /// <summary>
     /// DSC Export command.
     /// </summary>
     /// <param name="input">Input for the Export command.</param>
-    public abstract void Export(JToken input);
+    /// <returns>True if the command was successful; otherwise, false.</returns>
+    public abstract bool Export(JToken input);
 
     /// <summary>
     /// DSC Schema command.
     /// </summary>
-    public abstract void Schema();
+    /// <returns>True if the command was successful; otherwise, false.</returns>
+    public abstract bool Schema();
 
     /// <summary>
     /// Creates a Json schema for a DSC resource object.

--- a/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
 
+using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 /// <summary>
@@ -33,4 +35,13 @@ public abstract class BaseDscCommand
     /// </summary>
     /// <param name="input">Input for the Export command.</param>
     public abstract void Export(JToken input);
+
+    /// <summary>
+    /// Writes a JSON output line to the console.
+    /// </summary>
+    /// <param name="token">The JSON token to be written.</param>
+    protected void WriteJsonOutputLine(JToken token)
+    {
+        Console.WriteLine(token.ToString(Formatting.None));
+    }
 }

--- a/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
+
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// Base class for DSC commands.
+/// </summary>
+public abstract class BaseDscCommand
+{
+    /// <summary>
+    /// DSC Get command.
+    /// </summary>
+    /// <param name="input">Input for the Get command.</param>
+    public abstract void Get(JToken input);
+
+    /// <summary>
+    /// DSC Set command.
+    /// </summary>
+    /// <param name="input">Input for the Set command.</param>
+    public abstract void Set(JToken input);
+
+    /// <summary>
+    /// DSC Test command.
+    /// </summary>
+    /// <param name="input">Input for the Test command.</param>
+    public abstract void Test(JToken input);
+
+    /// <summary>
+    /// DSC Export command.
+    /// </summary>
+    /// <param name="input">Input for the Export command.</param>
+    public abstract void Export(JToken input);
+}

--- a/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/BaseDscCommand.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
 
 using System;
+using Microsoft.WingetCreateCLI.Models.DscModels;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -12,6 +13,11 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 public abstract class BaseDscCommand
 {
+    /// <summary>
+    /// Gets the name of the command used to access the DSC functionality.
+    /// </summary>
+    public virtual string CommandName { get; }
+
     /// <summary>
     /// DSC Get command.
     /// </summary>
@@ -35,6 +41,30 @@ public abstract class BaseDscCommand
     /// </summary>
     /// <param name="input">Input for the Export command.</param>
     public abstract void Export(JToken input);
+
+    /// <summary>
+    /// DSC Schema command.
+    /// </summary>
+    public abstract void Schema();
+
+    /// <summary>
+    /// Creates a Json schema for a DSC resource object.
+    /// </summary>
+    /// <returns>A Json object representing the schema.</returns>
+    protected JObject CreateSchema<T>()
+    where T : BaseResourceObject, new()
+    {
+        var resourceObject = new T();
+        return new JObject
+        {
+            ["$schema"] = "http://json-schema.org/draft-07/schema#",
+            ["title"] = this.CommandName,
+            ["type"] = "object",
+            ["properties"] = resourceObject.GetProperties(),
+            ["required"] = resourceObject.GetRequiredProperties(),
+            ["additionalProperties"] = false,
+        };
+    }
 
     /// <summary>
     /// Writes a JSON output line to the console.

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -41,7 +41,7 @@ public class DscSettingsCommand : BaseDscCommand
         if (!data.Test())
         {
             data.Output.Settings = data.GetResolvedInput();
-            data.WriteOutput();
+            data.Set();
         }
 
         this.WriteJsonOutputLine(data.Output.ToJson());

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -11,10 +11,8 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 public class DscSettingsCommand : BaseDscCommand
 {
-    /// <summary>
-    /// Represents the name of the command used to access settings functionality.
-    /// </summary>
-    public const string CommandName = "settings";
+    /// <inheritdoc/>
+    public override string CommandName => "settings";
 
     /// <inheritdoc/>
     public override void Get(JToken input)
@@ -61,5 +59,11 @@ public class DscSettingsCommand : BaseDscCommand
         data.Get();
 
         this.WriteJsonOutputLine(data.Output.ToJson());
+    }
+
+    /// <inheritdoc/>
+    public override void Schema()
+    {
+        this.WriteJsonOutputLine(this.CreateSchema<SettingsResourceObject>());
     }
 }

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -3,7 +3,10 @@
 
 namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
 
+using System;
+using Microsoft.WingetCreateCLI.Logging;
 using Microsoft.WingetCreateCLI.Models.DscModels;
+using Microsoft.WingetCreateCLI.Properties;
 using Newtonsoft.Json.Linq;
 
 /// <summary>
@@ -25,6 +28,7 @@ public class DscSettingsCommand : BaseDscCommand
     {
         if (input == null)
         {
+            Logger.ErrorLocalized(nameof(Resources.DscInputRequired_Message), nameof(this.Set));
             return false;
         }
 
@@ -48,8 +52,9 @@ public class DscSettingsCommand : BaseDscCommand
     /// <inheritdoc/>
     public override bool Test(JToken input)
     {
-        if ( input == null)
+        if (input == null)
         {
+            Logger.ErrorLocalized(nameof(Resources.DscInputRequired_Message), nameof(this.Test));
             return false;
         }
 

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -4,7 +4,9 @@
 namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
 
 using System;
+using System.Diagnostics;
 using Microsoft.WingetCreateCLI.Models.Settings;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 /// <summary>
@@ -20,48 +22,157 @@ public class DscSettingsCommand : BaseDscCommand
     /// <inheritdoc/>
     public override void Get(JToken input)
     {
-        Console.WriteLine(UserSettings.ToJson());
+        this.Export(input);
     }
 
     /// <inheritdoc/>
     public override void Set(JToken input)
     {
-        // No-op
+        var data = new UserSettingsFunctionData(input);
+        data.Get();
+
+        // Capture the diff before updating the output
+        var diff = data.DiffJson();
+
+        if (!data.Test())
+        {
+            data.Output.Settings = data.GetResolvedInput();
+            data.WriteOutput();
+        }
+
+        this.WriteJsonOutputLine(data.Output.ToJson());
+        this.WriteJsonOutputLine(diff);
     }
 
     /// <inheritdoc/>
     public override void Test(JToken input)
     {
-        // No-op
+        var data = new UserSettingsFunctionData(input);
+
+        data.Get();
+        data.Output.InDesiredState = data.Test();
+
+        this.WriteJsonOutputLine(data.Output.ToJson());
+        this.WriteJsonOutputLine(data.DiffJson());
     }
 
     /// <inheritdoc/>
     public override void Export(JToken input)
     {
-        // No-op
+        var data = new UserSettingsFunctionData(input);
+
+        data.Get();
+
+        this.WriteJsonOutputLine(data.Output.ToJson());
     }
 
     private class UserSettingsFunctionData
     {
-        public enum ActionType
+        private JObject resolvedInputUserSettings;
+        private JObject userSettings;
+
+        public UserSettingsFunctionData(JToken json = null)
         {
-            Partial,
-            Full,
+            this.Input = json == null ? new() : json.ToObject<UserSettingsResourceObject>();
+            this.Output = new();
         }
 
-        public UserSettingsFunctionData(JToken token)
-        {
+        public UserSettingsResourceObject Input { get; }
 
+        public UserSettingsResourceObject Output { get; }
+
+        public void Get()
+        {
+            this.Output.Settings = this.GetUserSettings();
+        }
+
+        public bool Test()
+        {
+            return JToken.DeepEquals(this.GetResolvedInput(), this.GetValidSettings(this.Output.Settings));
+        }
+
+        public JArray DiffJson()
+        {
+            var diff = new JArray();
+            if (!this.Test())
+            {
+                diff.Add("settings");
+            }
+
+            return diff;
+        }
+
+        public JObject GetResolvedInput()
+        {
+            Debug.Assert(this.Input.Settings != null, "Input settings should not be null.");
+            if (this.resolvedInputUserSettings == null)
+            {
+                if (UserSettingsResourceObject.ActionFull.Equals(this.Input.Action, StringComparison.OrdinalIgnoreCase))
+                {
+                    this.Output.Action = UserSettingsResourceObject.ActionFull;
+                    this.resolvedInputUserSettings = this.GetValidSettings(this.Input.Settings);
+                }
+                else
+                {
+                    this.Output.Action = UserSettingsResourceObject.ActionPartial;
+                    var mergedSettings = this.GetUserSettings();
+                    mergedSettings.Merge(this.Input.Settings);
+                    this.resolvedInputUserSettings = this.GetValidSettings(mergedSettings);
+                }
+            }
+
+            return this.resolvedInputUserSettings;
+        }
+
+        public JObject GetUserSettings()
+        {
+            this.userSettings ??= UserSettings.ToJson();
+            return (JObject)this.userSettings.DeepClone();
+        }
+
+        public void WriteOutput()
+        {
+            Debug.Assert(this.Output.Settings != null, "Output settings should not be null.");
+            UserSettings.SaveSettings(this.Output.Settings.ToObject<SettingsManifest>());
         }
 
         /// <summary>
-        /// Gets or sets the action type for the settings command.
+        /// Validates and converts the provided settings into a structured format.
         /// </summary>
-        public ActionType Action { get; set; } = ActionType.Partial;
+        /// <param name="settings">An object containing settings to be validated.</param>
+        /// <returns>An object representing the validated settings.</returns>
+        public JObject GetValidSettings(JObject settings)
+        {
+            var settingsManifest = settings.ToObject<SettingsManifest>();
+            return JObject.FromObject(settingsManifest);
+        }
+    }
+
+    private class UserSettingsResourceObject
+    {
+        public const string ActionFull = "Full";
+        public const string ActionPartial = "Partial";
+
+        // TODO Make this required
+        [JsonProperty("settings")]
+        public JObject Settings { get; set; }
+
+        [JsonProperty("action", NullValueHandling = NullValueHandling.Ignore)]
+        public string Action { get; set; }
+
+        [JsonProperty("_inDesiredState", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? InDesiredState { get; set; }
 
         /// <summary>
-        /// Gets or sets the settings manifest to be used for the command.
+        /// Converts the current object to a JSON representation.
         /// </summary>
-        public SettingsManifest Settings { get; set; }
+        /// <returns>A Json object representing the current object.</returns>
+        public JObject ToJson()
+        {
+            return JObject.FromObject(this, new JsonSerializer
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+            });
+        }
     }
 }

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
+
+using System;
+using Microsoft.WingetCreateCLI.Models.Settings;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// Command for managing the settings using dsc v3.
+/// </summary>
+public class DscSettingsCommand : BaseDscCommand
+{
+    /// <summary>
+    /// Represents the name of the command used to access settings functionality.
+    /// </summary>
+    public const string CommandName = "settings";
+
+    /// <inheritdoc/>
+    public override void Get(JToken input)
+    {
+        Console.WriteLine(UserSettings.ToJson());
+    }
+
+    /// <inheritdoc/>
+    public override void Set(JToken input)
+    {
+        // No-op
+    }
+
+    /// <inheritdoc/>
+    public override void Test(JToken input)
+    {
+        // No-op
+    }
+
+    /// <inheritdoc/>
+    public override void Export(JToken input)
+    {
+        // No-op
+    }
+
+    private class UserSettingsFunctionData
+    {
+        public enum ActionType
+        {
+            Partial,
+            Full,
+        }
+
+        public UserSettingsFunctionData(JToken token)
+        {
+
+        }
+
+        /// <summary>
+        /// Gets or sets the action type for the settings command.
+        /// </summary>
+        public ActionType Action { get; set; } = ActionType.Partial;
+
+        /// <summary>
+        /// Gets or sets the settings manifest to be used for the command.
+        /// </summary>
+        public SettingsManifest Settings { get; set; }
+    }
+}

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
 
-using System;
 using Microsoft.WingetCreateCLI.Logging;
 using Microsoft.WingetCreateCLI.Models.DscModels;
 using Microsoft.WingetCreateCLI.Properties;
@@ -14,8 +13,10 @@ using Newtonsoft.Json.Linq;
 /// </summary>
 public class DscSettingsCommand : BaseDscCommand
 {
-    /// <inheritdoc/>
-    public override string CommandName => "settings";
+    /// <summary>
+    /// Represents the name of the settings command used to access the DSC functionality.
+    /// </summary>
+    public const string CommandName = "settings";
 
     /// <inheritdoc/>
     public override bool Get(JToken input)
@@ -80,7 +81,7 @@ public class DscSettingsCommand : BaseDscCommand
     /// <inheritdoc/>
     public override bool Schema()
     {
-        this.WriteJsonOutputLine(this.CreateSchema<SettingsResourceObject>());
+        this.WriteJsonOutputLine(this.CreateSchema<SettingsResourceObject>(CommandName));
         return true;
     }
 }

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -15,14 +15,19 @@ public class DscSettingsCommand : BaseDscCommand
     public override string CommandName => "settings";
 
     /// <inheritdoc/>
-    public override void Get(JToken input)
+    public override bool Get(JToken input)
     {
-        this.Export(input);
+        return this.Export(input);
     }
 
     /// <inheritdoc/>
-    public override void Set(JToken input)
+    public override bool Set(JToken input)
     {
+        if (input == null)
+        {
+            return false;
+        }
+
         var data = new SettingsFunctionData(input);
         data.Get();
 
@@ -37,11 +42,17 @@ public class DscSettingsCommand : BaseDscCommand
 
         this.WriteJsonOutputLine(data.Output.ToJson());
         this.WriteJsonOutputLine(diff);
+        return true;
     }
 
     /// <inheritdoc/>
-    public override void Test(JToken input)
+    public override bool Test(JToken input)
     {
+        if ( input == null)
+        {
+            return false;
+        }
+
         var data = new SettingsFunctionData(input);
 
         data.Get();
@@ -49,21 +60,22 @@ public class DscSettingsCommand : BaseDscCommand
 
         this.WriteJsonOutputLine(data.Output.ToJson());
         this.WriteJsonOutputLine(data.DiffJson());
+        return true;
     }
 
     /// <inheritdoc/>
-    public override void Export(JToken input)
+    public override bool Export(JToken input)
     {
         var data = new SettingsFunctionData();
-
         data.Get();
-
         this.WriteJsonOutputLine(data.Output.ToJson());
+        return true;
     }
 
     /// <inheritdoc/>
-    public override void Schema()
+    public override bool Schema()
     {
         this.WriteJsonOutputLine(this.CreateSchema<SettingsResourceObject>());
+        return true;
     }
 }

--- a/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/DscCommands/DscSettingsCommand.cs
@@ -3,10 +3,7 @@
 
 namespace Microsoft.WingetCreateCLI.Commands.DscCommands;
 
-using System;
-using System.Diagnostics;
-using Microsoft.WingetCreateCLI.Models.Settings;
-using Newtonsoft.Json;
+using Microsoft.WingetCreateCLI.Models.DscModels;
 using Newtonsoft.Json.Linq;
 
 /// <summary>
@@ -28,7 +25,7 @@ public class DscSettingsCommand : BaseDscCommand
     /// <inheritdoc/>
     public override void Set(JToken input)
     {
-        var data = new UserSettingsFunctionData(input);
+        var data = new SettingsFunctionData(input);
         data.Get();
 
         // Capture the diff before updating the output
@@ -47,7 +44,7 @@ public class DscSettingsCommand : BaseDscCommand
     /// <inheritdoc/>
     public override void Test(JToken input)
     {
-        var data = new UserSettingsFunctionData(input);
+        var data = new SettingsFunctionData(input);
 
         data.Get();
         data.Output.InDesiredState = data.Test();
@@ -59,120 +56,10 @@ public class DscSettingsCommand : BaseDscCommand
     /// <inheritdoc/>
     public override void Export(JToken input)
     {
-        var data = new UserSettingsFunctionData(input);
+        var data = new SettingsFunctionData();
 
         data.Get();
 
         this.WriteJsonOutputLine(data.Output.ToJson());
-    }
-
-    private class UserSettingsFunctionData
-    {
-        private JObject resolvedInputUserSettings;
-        private JObject userSettings;
-
-        public UserSettingsFunctionData(JToken json = null)
-        {
-            this.Input = json == null ? new() : json.ToObject<UserSettingsResourceObject>();
-            this.Output = new();
-        }
-
-        public UserSettingsResourceObject Input { get; }
-
-        public UserSettingsResourceObject Output { get; }
-
-        public void Get()
-        {
-            this.Output.Settings = this.GetUserSettings();
-        }
-
-        public bool Test()
-        {
-            return JToken.DeepEquals(this.GetResolvedInput(), this.GetValidSettings(this.Output.Settings));
-        }
-
-        public JArray DiffJson()
-        {
-            var diff = new JArray();
-            if (!this.Test())
-            {
-                diff.Add("settings");
-            }
-
-            return diff;
-        }
-
-        public JObject GetResolvedInput()
-        {
-            Debug.Assert(this.Input.Settings != null, "Input settings should not be null.");
-            if (this.resolvedInputUserSettings == null)
-            {
-                if (UserSettingsResourceObject.ActionFull.Equals(this.Input.Action, StringComparison.OrdinalIgnoreCase))
-                {
-                    this.Output.Action = UserSettingsResourceObject.ActionFull;
-                    this.resolvedInputUserSettings = this.GetValidSettings(this.Input.Settings);
-                }
-                else
-                {
-                    this.Output.Action = UserSettingsResourceObject.ActionPartial;
-                    var mergedSettings = this.GetUserSettings();
-                    mergedSettings.Merge(this.Input.Settings);
-                    this.resolvedInputUserSettings = this.GetValidSettings(mergedSettings);
-                }
-            }
-
-            return this.resolvedInputUserSettings;
-        }
-
-        public JObject GetUserSettings()
-        {
-            this.userSettings ??= UserSettings.ToJson();
-            return (JObject)this.userSettings.DeepClone();
-        }
-
-        public void WriteOutput()
-        {
-            Debug.Assert(this.Output.Settings != null, "Output settings should not be null.");
-            UserSettings.SaveSettings(this.Output.Settings.ToObject<SettingsManifest>());
-        }
-
-        /// <summary>
-        /// Validates and converts the provided settings into a structured format.
-        /// </summary>
-        /// <param name="settings">An object containing settings to be validated.</param>
-        /// <returns>An object representing the validated settings.</returns>
-        public JObject GetValidSettings(JObject settings)
-        {
-            var settingsManifest = settings.ToObject<SettingsManifest>();
-            return JObject.FromObject(settingsManifest);
-        }
-    }
-
-    private class UserSettingsResourceObject
-    {
-        public const string ActionFull = "Full";
-        public const string ActionPartial = "Partial";
-
-        // TODO Make this required
-        [JsonProperty("settings")]
-        public JObject Settings { get; set; }
-
-        [JsonProperty("action", NullValueHandling = NullValueHandling.Ignore)]
-        public string Action { get; set; }
-
-        [JsonProperty("_inDesiredState", NullValueHandling = NullValueHandling.Ignore)]
-        public bool? InDesiredState { get; set; }
-
-        /// <summary>
-        /// Converts the current object to a JSON representation.
-        /// </summary>
-        /// <returns>A Json object representing the current object.</returns>
-        public JObject ToJson()
-        {
-            return JObject.FromObject(this, new JsonSerializer
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-            });
-        }
     }
 }

--- a/src/WingetCreateCLI/Commands/InfoCommand.cs
+++ b/src/WingetCreateCLI/Commands/InfoCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.WingetCreateCLI.Commands
     public class InfoCommand : BaseCommand
     {
         /// <inheritdoc/>
-        public override bool RequiresGitHubToken => false;
+        public override bool AcceptsGitHubToken => false;
 
         /// <summary>
         /// Executes the info command flow.

--- a/src/WingetCreateCLI/Commands/InfoCommand.cs
+++ b/src/WingetCreateCLI/Commands/InfoCommand.cs
@@ -20,6 +20,9 @@ namespace Microsoft.WingetCreateCLI.Commands
     [Verb("info", HelpText = "InfoCommand_HelpText", ResourceType = typeof(Resources))]
     public class InfoCommand : BaseCommand
     {
+        /// <inheritdoc/>
+        public override bool RequiresGitHubToken => false;
+
         /// <summary>
         /// Executes the info command flow.
         /// </summary>

--- a/src/WingetCreateCLI/Commands/SettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/SettingsCommand.cs
@@ -22,6 +22,9 @@ namespace Microsoft.WingetCreateCLI.Commands
     [Verb("settings", HelpText = "SettingsCommand_HelpText", ResourceType = typeof(Resources))]
     public class SettingsCommand : BaseCommand
     {
+        /// <inheritdoc/>
+        public override bool RequiresGitHubToken => false;
+
         /// <summary>
         /// Executes the token command flow.
         /// </summary>

--- a/src/WingetCreateCLI/Commands/SettingsCommand.cs
+++ b/src/WingetCreateCLI/Commands/SettingsCommand.cs
@@ -23,7 +23,7 @@ namespace Microsoft.WingetCreateCLI.Commands
     public class SettingsCommand : BaseCommand
     {
         /// <inheritdoc/>
-        public override bool RequiresGitHubToken => false;
+        public override bool AcceptsGitHubToken => false;
 
         /// <summary>
         /// Executes the token command flow.

--- a/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
+++ b/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
@@ -35,7 +35,6 @@
         "executable": "wingetcreate",
         "implementsPretest": true,
         "return": "stateAndDiff",
-        "input": "stdin",
         "args": [
             "dsc",
             "settings",
@@ -48,7 +47,6 @@
     "test": {
         "executable": "wingetcreate",
         "return": "stateAndDiff",
-        "input": "stdin",
         "args": [
             "dsc",
             "settings",

--- a/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
+++ b/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
@@ -39,7 +39,10 @@
         "args": [
             "dsc",
             "settings",
-            "--set"
+            {
+                "jsonInputArg": "--set",
+                "mandatory": true
+            }
         ]
     },
     "test": {
@@ -49,7 +52,10 @@
         "args": [
             "dsc",
             "settings",
-            "--test"
+            {
+                "jsonInputArg": "--test",
+                "mandatory": true
+            }
         ]
     },
     "tags": [

--- a/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
+++ b/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/bundled/resource/manifest.json",
-    "description": "Allows management of settings state via the DSC v3 command line interface protocol. See the help link for details.",
+    "description": "Allows management of settings state via the DSC v3 command line interface protocol.",
     "export": {
         "executable": "wingetcreate",
         "input": "stdin",

--- a/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
+++ b/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/bundled/resource/manifest.json",
+    "description": "Allows management of settings state via the DSC v3 command line interface protocol. See the help link for details.",
+    "export": {
+        "executable": "wingetcreate",
+        "input": "stdin",
+        "args": [
+            "dsc",
+            "settings",
+            "--export",
+            "'{}'"
+        ]
+    },
+    "get": {
+        "executable": "wingetcreate",
+        "input": "stdin",
+        "args": [
+            "dsc",
+            "settings",
+            "--get",
+            "'{}'"
+        ]
+    },
+    "schema": {
+        "command": {
+            "executable": "wingetcreate",
+            "args": [
+                "dsc",
+                "settings",
+                "--schema"
+            ]
+        }
+    },
+    "set": {
+        "executable": "wingetcreate",
+        "implementsPretest": true,
+        "return": "stateAndDiff",
+        "input": "stdin",
+        "args": [
+            "dsc",
+            "settings",
+            "--set"
+        ]
+    },
+    "test": {
+        "executable": "wingetcreate",
+        "return": "stateAndDiff",
+        "input": "stdin",
+        "args": [
+            "dsc",
+            "settings",
+            "--test"
+        ]
+    },
+    "tags": [
+        "WinGetCreate"
+    ],
+    "type": "Microsoft.WinGetCreate/Settings",
+    "version": "1.9.0"
+}

--- a/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
+++ b/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
@@ -7,8 +7,7 @@
         "args": [
             "dsc",
             "settings",
-            "--export",
-            "'{}'"
+            "--export"
         ]
     },
     "get": {
@@ -17,8 +16,7 @@
         "args": [
             "dsc",
             "settings",
-            "--get",
-            "'{}'"
+            "--get"
         ]
     },
     "schema": {

--- a/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
+++ b/src/WingetCreateCLI/DscResources/microsoft.winget-create.settings.dsc.resource.json
@@ -58,5 +58,5 @@
         "WinGetCreate"
     ],
     "type": "Microsoft.WinGetCreate/Settings",
-    "version": "1.9.0"
+    "version": "1.10.0"
 }

--- a/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
@@ -4,15 +4,50 @@
 namespace Microsoft.WingetCreateCLI.Models.DscModels;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 /// <summary>
 /// Represents a base resource object with a property indicating whether the resource is in its desired state.
 /// </summary>
-public class BaseResourceObject
+public abstract class BaseResourceObject
 {
     /// <summary>
     /// Gets or sets a value indicating whether the resource is in its desired state.
     /// </summary>
     [JsonProperty("_inDesiredState", NullValueHandling = NullValueHandling.Ignore)]
     public bool? InDesiredState { get; set; }
+
+    /// <summary>
+    /// Gets the properties of the resource object.
+    /// </summary>
+    /// <returns>A Json object containing the properties of the resource.</returns>
+    public virtual JObject GetProperties()
+    {
+        return new JObject
+        {
+            ["_inDesiredState"] = new JObject
+            {
+                ["description"] = "Indicates whether an instance is in the desired state.",
+                ["type"] = "boolean",
+            },
+        };
+    }
+
+    /// <summary>
+    /// Gets the required properties of the resource object.
+    /// </summary>
+    /// <returns>A Json array containing the required properties.</returns>
+    public abstract JArray GetRequiredProperties();
+
+    /// <summary>
+    /// Converts the current object to a JSON representation.
+    /// </summary>
+    /// <returns>A Json object representing the current object.</returns>
+    public JObject ToJson()
+    {
+        return JObject.FromObject(this, new JsonSerializer
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+        });
+    }
 }

--- a/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.WingetCreateCLI.Models.DscModels;
 
+using Microsoft.WingetCreateCLI.Properties;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -27,7 +28,7 @@ public abstract class BaseResourceObject
         {
             ["_inDesiredState"] = new JObject
             {
-                ["description"] = "Indicates whether an instance is in the desired state.",
+                ["description"] = Resources.DscResourcePropertyDescriptionInDesiredState,
                 ["type"] = "boolean",
             },
         };

--- a/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
@@ -46,9 +46,6 @@ public abstract class BaseResourceObject
     /// <returns>A Json object representing the current object.</returns>
     public JObject ToJson()
     {
-        return JObject.FromObject(this, new JsonSerializer
-        {
-            NullValueHandling = NullValueHandling.Ignore,
-        });
+        return JObject.FromObject(this);
     }
 }

--- a/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/BaseResourceObject.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI.Models.DscModels;
+
+using Newtonsoft.Json;
+
+/// <summary>
+/// Represents a base resource object with a property indicating whether the resource is in its desired state.
+/// </summary>
+public class BaseResourceObject
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the resource is in its desired state.
+    /// </summary>
+    [JsonProperty("_inDesiredState", NullValueHandling = NullValueHandling.Ignore)]
+    public bool? InDesiredState { get; set; }
+}

--- a/src/WingetCreateCLI/Models/DscModels/SettingsFunctionData.cs
+++ b/src/WingetCreateCLI/Models/DscModels/SettingsFunctionData.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI.Models.DscModels;
+
+using System;
+using System.Diagnostics;
+using Microsoft.WingetCreateCLI.Models.Settings;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// Represents the data structure for settings functionality in DSC operations.
+/// </summary>
+public class SettingsFunctionData
+{
+    private JObject resolvedInputUserSettings;
+    private JObject userSettings;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SettingsFunctionData"/> class with default settings.
+    /// </summary>
+    public SettingsFunctionData()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SettingsFunctionData"/> class.
+    /// </summary>
+    /// <param name="json">An optional JSON token used to initialize the input settings.</param>
+    public SettingsFunctionData(JToken json = null)
+    {
+        this.Output = new();
+        this.Input = json == null ? new() : json.ToObject<SettingsResourceObject>();
+    }
+
+    /// <summary>
+    /// Gets the input settings resource object.
+    /// </summary>
+    public SettingsResourceObject Input { get; }
+
+    /// <summary>
+    /// Gets the output settings resource object.
+    /// </summary>
+    public SettingsResourceObject Output { get; }
+
+    /// <summary>
+    /// Loads the user settings into the output object.
+    /// </summary>
+    public void Get()
+    {
+        this.Output.Settings = this.GetUserSettings();
+    }
+
+    /// <summary>
+    /// Gets whether the resolved input settings and output settings are equivalent.
+    /// </summary>
+    /// <returns>>true if the settings are equivalent; otherwise, false.</returns>
+    public bool Test()
+    {
+        return JToken.DeepEquals(this.GetResolvedInput(), this.GetValidSettings(this.Output.Settings));
+    }
+
+    /// <summary>
+    /// Gets the differences between the current settings and the input settings.
+    /// </summary>
+    /// <returns>A Json array containing the differences.</returns>
+    public JArray DiffJson()
+    {
+        var diff = new JArray();
+        if (!this.Test())
+        {
+            diff.Add("settings");
+        }
+
+        return diff;
+    }
+
+    /// <summary>
+    /// Gets the resolved input settings based on the action specified in the input.
+    /// </summary>
+    /// <returns>>A Json object representing the resolved input settings.</returns>
+    public JObject GetResolvedInput()
+    {
+        Debug.Assert(this.Input.Settings != null, "Input settings should not be null.");
+        if (this.resolvedInputUserSettings == null)
+        {
+            if (SettingsResourceObject.ActionFull.Equals(this.Input.Action, StringComparison.OrdinalIgnoreCase))
+            {
+                this.Output.Action = SettingsResourceObject.ActionFull;
+                this.resolvedInputUserSettings = this.GetValidSettings(this.Input.Settings);
+            }
+            else
+            {
+                this.Output.Action = SettingsResourceObject.ActionPartial;
+                var mergedSettings = this.GetUserSettings();
+                mergedSettings.Merge(this.Input.Settings);
+                this.resolvedInputUserSettings = this.GetValidSettings(mergedSettings);
+            }
+        }
+
+        return this.resolvedInputUserSettings;
+    }
+
+    /// <summary>
+    /// Retrieves a deep-cloned JSON representation of the current user settings.
+    /// </summary>
+    /// <returns>A Json object representing the user settings.</returns>
+    public JObject GetUserSettings()
+    {
+        this.userSettings ??= UserSettings.ToJson();
+        return (JObject)this.userSettings.DeepClone();
+    }
+
+    /// <summary>
+    /// Writes the current output settings to persistent storage.
+    /// </summary>
+    public void WriteOutput()
+    {
+        Debug.Assert(this.Output.Settings != null, "Output settings should not be null.");
+        UserSettings.SaveSettings(this.Output.Settings.ToObject<SettingsManifest>());
+    }
+
+    /// <summary>
+    /// Validates and converts the provided settings into a structured format.
+    /// </summary>
+    /// <param name="settings">An object containing settings to be validated.</param>
+    /// <returns>An object representing the validated settings.</returns>
+    public JObject GetValidSettings(JObject settings)
+    {
+        var settingsManifest = settings.ToObject<SettingsManifest>();
+        return JObject.FromObject(settingsManifest);
+    }
+}

--- a/src/WingetCreateCLI/Models/DscModels/SettingsFunctionData.cs
+++ b/src/WingetCreateCLI/Models/DscModels/SettingsFunctionData.cs
@@ -58,7 +58,16 @@ public class SettingsFunctionData
     /// <returns>>true if the settings are equivalent; otherwise, false.</returns>
     public bool Test()
     {
-        return JToken.DeepEquals(this.GetResolvedInput(), this.GetValidSettings(this.Output.Settings));
+        return JToken.DeepEquals(this.GetResolvedInput(), GetValidSettings(this.Output.Settings));
+    }
+
+    /// <summary>
+    /// Writes the current output settings to persistent storage.
+    /// </summary>
+    public void Set()
+    {
+        Debug.Assert(this.Output.Settings != null, "Output settings should not be null.");
+        UserSettings.SaveSettings(this.Output.Settings.ToObject<SettingsManifest>());
     }
 
     /// <summary>
@@ -88,14 +97,14 @@ public class SettingsFunctionData
             if (SettingsResourceObject.ActionFull.Equals(this.Input.Action, StringComparison.OrdinalIgnoreCase))
             {
                 this.Output.Action = SettingsResourceObject.ActionFull;
-                this.resolvedInputUserSettings = this.GetValidSettings(this.Input.Settings);
+                this.resolvedInputUserSettings = GetValidSettings(this.Input.Settings);
             }
             else
             {
                 this.Output.Action = SettingsResourceObject.ActionPartial;
                 var mergedSettings = this.GetUserSettings();
                 mergedSettings.Merge(this.Input.Settings);
-                this.resolvedInputUserSettings = this.GetValidSettings(mergedSettings);
+                this.resolvedInputUserSettings = GetValidSettings(mergedSettings);
             }
         }
 
@@ -103,32 +112,23 @@ public class SettingsFunctionData
     }
 
     /// <summary>
-    /// Retrieves a deep-cloned JSON representation of the current user settings.
-    /// </summary>
-    /// <returns>A Json object representing the user settings.</returns>
-    public JObject GetUserSettings()
-    {
-        this.userSettings ??= UserSettings.ToJson();
-        return (JObject)this.userSettings.DeepClone();
-    }
-
-    /// <summary>
-    /// Writes the current output settings to persistent storage.
-    /// </summary>
-    public void WriteOutput()
-    {
-        Debug.Assert(this.Output.Settings != null, "Output settings should not be null.");
-        UserSettings.SaveSettings(this.Output.Settings.ToObject<SettingsManifest>());
-    }
-
-    /// <summary>
     /// Validates and converts the provided settings into a structured format.
     /// </summary>
     /// <param name="settings">An object containing settings to be validated.</param>
     /// <returns>An object representing the validated settings.</returns>
-    public JObject GetValidSettings(JObject settings)
+    private static JObject GetValidSettings(JObject settings)
     {
         var settingsManifest = settings.ToObject<SettingsManifest>();
         return JObject.FromObject(settingsManifest);
+    }
+
+    /// <summary>
+    /// Retrieves a deep-cloned JSON representation of the current user settings.
+    /// </summary>
+    /// <returns>A Json object representing the user settings.</returns>
+    private JObject GetUserSettings()
+    {
+        this.userSettings ??= UserSettings.ToJson();
+        return (JObject)this.userSettings.DeepClone();
     }
 }

--- a/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCLI.Models.DscModels;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// Represents a settings resource object used in DSC operations.
+/// </summary>
+public class SettingsResourceObject : BaseResourceObject
+{
+    /// <summary>
+    /// Defines the action type for full settings application.
+    /// </summary>
+    public const string ActionFull = "Full";
+
+    /// <summary>
+    /// Defines the action type for partial settings application.
+    /// </summary>
+    public const string ActionPartial = "Partial";
+
+    /// <summary>
+    /// Gets or sets the settings for the resource object.
+    /// </summary>
+    [JsonProperty("settings", Required = Required.Always)]
+    public JObject Settings { get; set; }
+
+    /// <summary>
+    /// Gets or sets the action to be performed on the settings resource object.
+    /// </summary>
+    [JsonProperty("action", NullValueHandling = NullValueHandling.Ignore)]
+    public string Action { get; set; }
+
+    /// <summary>
+    /// Creates a settings resource object with the specified settings and action.
+    /// </summary>
+    /// <param name="json">The JSON representation of the settings resource object.</param>
+    /// <returns>A settings resource object.</returns>
+    public static SettingsResourceObject FromJson(JToken json)
+    {
+        return json.ToObject<SettingsResourceObject>();
+    }
+
+    /// <summary>
+    /// Converts the current object to a JSON representation.
+    /// </summary>
+    /// <returns>A Json object representing the current object.</returns>
+    public JObject ToJson()
+    {
+        return JObject.FromObject(this, new JsonSerializer
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+        });
+    }
+}

--- a/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.WingetCreateCLI.Models.DscModels;
 
+using Microsoft.WingetCreateCLI.Properties;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -39,13 +40,13 @@ public class SettingsResourceObject : BaseResourceObject
         var baseProperties = base.GetProperties();
         baseProperties["settings"] = new JObject
         {
-            ["description"] = "The settings.",
+            ["description"] = Resources.DscResourcePropertyDescriptionSettings,
             ["type"] = "object",
         };
         baseProperties["action"] = new JObject
         {
             ["default"] = ActionPartial,
-            ["description"] = "The action used to apply the settings.",
+            ["description"] = Resources.DscResourcePropertyDescriptionAction,
             ["type"] = "string",
             ["enum"] = new JArray(ActionFull, ActionPartial),
         };

--- a/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
@@ -33,25 +33,28 @@ public class SettingsResourceObject : BaseResourceObject
     [JsonProperty("action", NullValueHandling = NullValueHandling.Ignore)]
     public string Action { get; set; }
 
-    /// <summary>
-    /// Creates a settings resource object with the specified settings and action.
-    /// </summary>
-    /// <param name="json">The JSON representation of the settings resource object.</param>
-    /// <returns>A settings resource object.</returns>
-    public static SettingsResourceObject FromJson(JToken json)
+    /// <inheritdoc/>
+    public override JObject GetProperties()
     {
-        return json.ToObject<SettingsResourceObject>();
+        var baseProperties = base.GetProperties();
+        baseProperties["settings"] = new JObject
+        {
+            ["description"] = "The settings.",
+            ["type"] = "object",
+        };
+        baseProperties["action"] = new JObject
+        {
+            ["default"] = ActionPartial,
+            ["description"] = "The action used to apply the settings.",
+            ["type"] = "string",
+            ["enum"] = new JArray(ActionFull, ActionPartial),
+        };
+        return baseProperties; ;
     }
 
-    /// <summary>
-    /// Converts the current object to a JSON representation.
-    /// </summary>
-    /// <returns>A Json object representing the current object.</returns>
-    public JObject ToJson()
+    /// <inheritdoc/>
+    public override JArray GetRequiredProperties()
     {
-        return JObject.FromObject(this, new JsonSerializer
-        {
-            NullValueHandling = NullValueHandling.Ignore,
-        });
+        return ["settings"];
     }
 }

--- a/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
+++ b/src/WingetCreateCLI/Models/DscModels/SettingsResourceObject.cs
@@ -50,7 +50,7 @@ public class SettingsResourceObject : BaseResourceObject
             ["type"] = "string",
             ["enum"] = new JArray(ActionFull, ActionPartial),
         };
-        return baseProperties; ;
+        return baseProperties;
     }
 
     /// <inheritdoc/>

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -52,6 +52,7 @@ namespace Microsoft.WingetCreateCLI
                 typeof(CacheCommand),
                 typeof(ShowCommand),
                 typeof(InfoCommand),
+                typeof(DscCommand),
             };
             var parserResult = myParser.ParseArguments(args, types);
 
@@ -70,10 +71,8 @@ namespace Microsoft.WingetCreateCLI
                 Logger.WarnLocalized(nameof(Resources.GitHubTokenWarning_Message));
             }
 
-            bool commandHandlesToken = command is not CacheCommand and not InfoCommand and not SettingsCommand;
-
             // Do not load github client for commands that do not deal with a GitHub token.
-            if (commandHandlesToken)
+            if (command.RequiresGitHubToken)
             {
                 if (await command.LoadGitHubClient())
                 {

--- a/src/WingetCreateCLI/Program.cs
+++ b/src/WingetCreateCLI/Program.cs
@@ -72,7 +72,7 @@ namespace Microsoft.WingetCreateCLI
             }
 
             // Do not load github client for commands that do not deal with a GitHub token.
-            if (command.RequiresGitHubToken)
+            if (command.AcceptsGitHubToken)
             {
                 if (await command.LoadGitHubClient())
                 {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -736,6 +736,87 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DSC v3 resource commands..
+        /// </summary>
+        public static string DscCommand_HelpText {
+            get {
+                return ResourceManager.GetString("DscCommand_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Export the resource configuration.
+        /// </summary>
+        public static string DscExport_HelpText {
+            get {
+                return ResourceManager.GetString("DscExport_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Get the resource state.
+        /// </summary>
+        public static string DscGet_HelpText {
+            get {
+                return ResourceManager.GetString("DscGet_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DSC resource not found: {0}.
+        /// </summary>
+        public static string DscResourceNotFound_Message {
+            get {
+                return ResourceManager.GetString("DscResourceNotFound_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DSC resource operation failed.
+        /// </summary>
+        public static string DscResourceOperationFailed_Message {
+            get {
+                return ResourceManager.GetString("DscResourceOperationFailed_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid operation for the DSC resource.
+        /// </summary>
+        public static string DscResourceOperationInvalid_Message {
+            get {
+                return ResourceManager.GetString("DscResourceOperationInvalid_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Execute the Schema command.
+        /// </summary>
+        public static string DscSchema_HelpText {
+            get {
+                return ResourceManager.GetString("DscSchema_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set the resource state.
+        /// </summary>
+        public static string DscSet_HelpText {
+            get {
+                return ResourceManager.GetString("DscSet_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Test the resource state.
+        /// </summary>
+        public static string DscTest_HelpText {
+            get {
+                return ResourceManager.GetString("DscTest_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Would you like to edit your manifests?.
         /// </summary>
         public static string EditManifests_Message {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -736,7 +736,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DSC v3 resource commands..
+        ///   Looks up a localized string similar to DSC v3 resource commands.
         /// </summary>
         public static string DscCommand_HelpText {
             get {
@@ -772,7 +772,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The input for the {0} DSC operation is required..
+        ///   Looks up a localized string similar to The input for the {0} DSC operation is required.
         /// </summary>
         public static string DscInputRequired_Message {
             get {
@@ -817,7 +817,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The action used to apply the settings..
+        ///   Looks up a localized string similar to The action used to apply the settings.
         /// </summary>
         public static string DscResourcePropertyDescriptionAction {
             get {
@@ -826,7 +826,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Indicates whether an instance is in the desired state..
+        ///   Looks up a localized string similar to Indicates whether an instance is in the desired state.
         /// </summary>
         public static string DscResourcePropertyDescriptionInDesiredState {
             get {
@@ -835,7 +835,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The settings content..
+        ///   Looks up a localized string similar to The settings content.
         /// </summary>
         public static string DscResourcePropertyDescriptionSettings {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -763,16 +763,34 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DSC resource is missing: {0}.
+        ///   Looks up a localized string similar to The input for the DSC resource.
         /// </summary>
-        public static string DscResourceMissing_Message {
+        public static string DscInput_HelpText {
             get {
-                return ResourceManager.GetString("DscResourceMissing_Message", resourceCulture);
+                return ResourceManager.GetString("DscInput_HelpText", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DSC resource not found: {0}.
+        ///   Looks up a localized string similar to The input for the {0} DSC operation is required..
+        /// </summary>
+        public static string DscInputRequired_Message {
+            get {
+                return ResourceManager.GetString("DscInputRequired_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of the DSC resource to manage.
+        /// </summary>
+        public static string DscResourceName_HelpText {
+            get {
+                return ResourceManager.GetString("DscResourceName_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DSC resource not found: {0}. Valid resources: {1}.
         /// </summary>
         public static string DscResourceNotFound_Message {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -745,7 +745,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Export the resource configuration.
+        ///   Looks up a localized string similar to Get all state instances.
         /// </summary>
         public static string DscExport_HelpText {
             get {
@@ -786,6 +786,33 @@ namespace Microsoft.WingetCreateCLI.Properties {
         public static string DscResourceOperationInvalid_Message {
             get {
                 return ResourceManager.GetString("DscResourceOperationInvalid_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The action used to apply the settings..
+        /// </summary>
+        public static string DscResourcePropertyDescriptionAction {
+            get {
+                return ResourceManager.GetString("DscResourcePropertyDescriptionAction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Indicates whether an instance is in the desired state..
+        /// </summary>
+        public static string DscResourcePropertyDescriptionInDesiredState {
+            get {
+                return ResourceManager.GetString("DscResourcePropertyDescriptionInDesiredState", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The settings content..
+        /// </summary>
+        public static string DscResourcePropertyDescriptionSettings {
+            get {
+                return ResourceManager.GetString("DscResourcePropertyDescriptionSettings", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -792,9 +792,9 @@ namespace Microsoft.WingetCreateCLI.Properties {
         /// <summary>
         ///   Looks up a localized string similar to DSC resource not found: {0}. Valid resources: {1}.
         /// </summary>
-        public static string DscResourceNotFound_Message {
+        public static string DscResourceNameNotFound_Message {
             get {
-                return ResourceManager.GetString("DscResourceNotFound_Message", resourceCulture);
+                return ResourceManager.GetString("DscResourceNameNotFound_Message", resourceCulture);
             }
         }
         
@@ -808,11 +808,11 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid operation for the DSC resource.
+        ///   Looks up a localized string similar to No operation specified. Use --help to see available operations..
         /// </summary>
-        public static string DscResourceOperationInvalid_Message {
+        public static string DscResourceOperationNotSpecified_Message {
             get {
-                return ResourceManager.GetString("DscResourceOperationInvalid_Message", resourceCulture);
+                return ResourceManager.GetString("DscResourceOperationNotSpecified_Message", resourceCulture);
             }
         }
         

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -763,6 +763,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DSC resource is missing: {0}.
+        /// </summary>
+        public static string DscResourceMissing_Message {
+            get {
+                return ResourceManager.GetString("DscResourceMissing_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DSC resource not found: {0}.
         /// </summary>
         public static string DscResourceNotFound_Message {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1428,6 +1428,10 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>DSC resource not found: {0}</value>
     <comment>{Locked='{0}'} {0} is replaced by the DSC resource name</comment>
   </data>
+  <data name="DscResourceMissing_Message" xml:space="preserve">
+    <value>DSC resource is missing: {0}</value>
+    <comment>{Locked='{0}'} {0} is replaced by the available DSC resource names</comment>
+  </data>
   <data name="DscResourceOperationInvalid_Message" xml:space="preserve">
     <value>Invalid operation for the DSC resource</value>
   </data>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1424,13 +1424,19 @@ Warning: Using this argument may result in the token being logged. Consider an a
   <data name="DscSchema_HelpText" xml:space="preserve">
     <value>Execute the Schema command</value>
   </data>
-  <data name="DscResourceNotFound_Message" xml:space="preserve">
-    <value>DSC resource not found: {0}</value>
-    <comment>{Locked='{0}'} {0} is replaced by the DSC resource name</comment>
+  <data name="DscResourceName_HelpText" xml:space="preserve">
+    <value>The name of the DSC resource to manage</value>
   </data>
-  <data name="DscResourceMissing_Message" xml:space="preserve">
-    <value>DSC resource is missing: {0}</value>
-    <comment>{Locked='{0}'} {0} is replaced by the available DSC resource names</comment>
+  <data name="DscInput_HelpText" xml:space="preserve">
+    <value>The input for the DSC resource</value>
+  </data>
+  <data name="DscInputRequired_Message" xml:space="preserve">
+    <value>The input for the {0} DSC operation is required.</value>
+    <comment>{Locked="{0}"} {0} is replaced by the DSC operation name</comment>
+  </data>
+  <data name="DscResourceNotFound_Message" xml:space="preserve">
+    <value>DSC resource not found: {0}. Valid resources: {1}</value>
+    <comment>{Locked="{0}", "{1}"} {0} is replaced by the DSC resource name, {1} is replaced by the list of valid resources</comment>
   </data>
   <data name="DscResourceOperationInvalid_Message" xml:space="preserve">
     <value>Invalid operation for the DSC resource</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1434,12 +1434,12 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>The input for the {0} DSC operation is required</value>
     <comment>{Locked="{0}"} {0} is replaced by the DSC operation name</comment>
   </data>
-  <data name="DscResourceNotFound_Message" xml:space="preserve">
+  <data name="DscResourceNameNotFound_Message" xml:space="preserve">
     <value>DSC resource not found: {0}. Valid resources: {1}</value>
     <comment>{Locked="{0}", "{1}"} {0} is replaced by the DSC resource name, {1} is replaced by the list of valid resources</comment>
   </data>
-  <data name="DscResourceOperationInvalid_Message" xml:space="preserve">
-    <value>Invalid operation for the DSC resource</value>
+  <data name="DscResourceOperationNotSpecified_Message" xml:space="preserve">
+    <value>No operation specified. Use --help to see available operations.</value>
   </data>
   <data name="DscResourceOperationFailed_Message" xml:space="preserve">
     <value>DSC resource operation failed</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1406,4 +1406,32 @@ Warning: Using this argument may result in the token being logged. Consider an a
   <data name="BranchMergeConflict_Message" xml:space="preserve">
     <value>The forked repository could not be synced with the upstream commits due to a merge conflict. Resolve conflicts manually and try again.</value>
   </data>
+  <data name="DscCommand_HelpText" xml:space="preserve">
+    <value>DSC v3 resource commands.</value>
+  </data>
+  <data name="DscGet_HelpText" xml:space="preserve">
+    <value>Get the resource state</value>
+  </data>
+  <data name="DscSet_HelpText" xml:space="preserve">
+    <value>Set the resource state</value>
+  </data>
+  <data name="DscTest_HelpText" xml:space="preserve">
+    <value>Test the resource state</value>
+  </data>
+  <data name="DscExport_HelpText" xml:space="preserve">
+    <value>Export the resource configuration</value>
+  </data>
+  <data name="DscSchema_HelpText" xml:space="preserve">
+    <value>Execute the Schema command</value>
+  </data>
+  <data name="DscResourceNotFound_Message" xml:space="preserve">
+    <value>DSC resource not found: {0}</value>
+    <comment>{Locked='{0}'} {0} is replaced by the DSC resource name</comment>
+  </data>
+  <data name="DscResourceOperationInvalid_Message" xml:space="preserve">
+    <value>Invalid operation for the DSC resource</value>
+  </data>
+  <data name="DscResourceOperationFailed_Message" xml:space="preserve">
+    <value>DSC resource operation failed</value>
+  </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1419,7 +1419,7 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>Test the resource state</value>
   </data>
   <data name="DscExport_HelpText" xml:space="preserve">
-    <value>Export the resource configuration</value>
+    <value>Get all state instances</value>
   </data>
   <data name="DscSchema_HelpText" xml:space="preserve">
     <value>Execute the Schema command</value>
@@ -1433,5 +1433,14 @@ Warning: Using this argument may result in the token being logged. Consider an a
   </data>
   <data name="DscResourceOperationFailed_Message" xml:space="preserve">
     <value>DSC resource operation failed</value>
+  </data>
+  <data name="DscResourcePropertyDescriptionInDesiredState" xml:space="preserve">
+    <value>Indicates whether an instance is in the desired state.</value>
+  </data>
+  <data name="DscResourcePropertyDescriptionSettings" xml:space="preserve">
+    <value>The settings content.</value>
+  </data>
+  <data name="DscResourcePropertyDescriptionAction" xml:space="preserve">
+    <value>The action used to apply the settings.</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1407,7 +1407,7 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>The forked repository could not be synced with the upstream commits due to a merge conflict. Resolve conflicts manually and try again.</value>
   </data>
   <data name="DscCommand_HelpText" xml:space="preserve">
-    <value>DSC v3 resource commands.</value>
+    <value>DSC v3 resource commands</value>
   </data>
   <data name="DscGet_HelpText" xml:space="preserve">
     <value>Get the resource state</value>
@@ -1431,7 +1431,7 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>The input for the DSC resource</value>
   </data>
   <data name="DscInputRequired_Message" xml:space="preserve">
-    <value>The input for the {0} DSC operation is required.</value>
+    <value>The input for the {0} DSC operation is required</value>
     <comment>{Locked="{0}"} {0} is replaced by the DSC operation name</comment>
   </data>
   <data name="DscResourceNotFound_Message" xml:space="preserve">
@@ -1445,12 +1445,12 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>DSC resource operation failed</value>
   </data>
   <data name="DscResourcePropertyDescriptionInDesiredState" xml:space="preserve">
-    <value>Indicates whether an instance is in the desired state.</value>
+    <value>Indicates whether an instance is in the desired state</value>
   </data>
   <data name="DscResourcePropertyDescriptionSettings" xml:space="preserve">
-    <value>The settings content.</value>
+    <value>The settings content</value>
   </data>
   <data name="DscResourcePropertyDescriptionAction" xml:space="preserve">
-    <value>The action used to apply the settings.</value>
+    <value>The action used to apply the settings</value>
   </data>
 </root>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1422,7 +1422,7 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>Get all state instances</value>
   </data>
   <data name="DscSchema_HelpText" xml:space="preserve">
-    <value>Execute the Schema command</value>
+    <value>Outputs schema of the resource</value>
   </data>
   <data name="DscResourceName_HelpText" xml:space="preserve">
     <value>The name of the DSC resource to manage</value>

--- a/src/WingetCreateCLI/UserSettings.cs
+++ b/src/WingetCreateCLI/UserSettings.cs
@@ -5,11 +5,13 @@ namespace Microsoft.WingetCreateCLI
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using Microsoft.WingetCreateCLI.Logging;
     using Microsoft.WingetCreateCLI.Models.Settings;
     using Microsoft.WingetCreateCLI.Properties;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// UserSettings configuration class for WingetCreate.
@@ -186,10 +188,26 @@ namespace Microsoft.WingetCreateCLI
         /// <summary>
         /// Saves the current settings configurations to the settings.json file.
         /// </summary>
-        public static void SaveSettings()
+        /// <param name="settings">Optional settings manifest to save. If null, the current settings will be saved.</param>
+        public static void SaveSettings(SettingsManifest settings = null)
         {
+            if (settings != null)
+            {
+                Settings = settings;
+            }
+
+            Debug.Assert(Settings != null, "Settings should not be null when saving settings.");
             string output = JsonConvert.SerializeObject(Settings, Formatting.Indented);
             File.WriteAllText(SettingsJsonPath, output);
+        }
+
+        /// <summary>
+        /// Gets the current settings as a Json object.
+        /// </summary>
+        /// <returns>A Json object representing the current settings.</returns>
+        public static JObject ToJson()
+        {
+            return JObject.FromObject(Settings);
         }
 
         /// <summary>
@@ -230,11 +248,6 @@ namespace Microsoft.WingetCreateCLI
                     Visual = new Visual(),
                 };
             }
-        }
-
-        public static string ToJson()
-        {
-            return JsonConvert.SerializeObject(Settings, Formatting.None);
         }
     }
 }

--- a/src/WingetCreateCLI/UserSettings.cs
+++ b/src/WingetCreateCLI/UserSettings.cs
@@ -231,5 +231,10 @@ namespace Microsoft.WingetCreateCLI
                 };
             }
         }
+
+        public static string ToJson()
+        {
+            return JsonConvert.SerializeObject(Settings, Formatting.None);
+        }
     }
 }

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -97,9 +97,12 @@
 
   <ItemGroup>
     <SettingSchema Include="$(ProjectDir)\Schemas\settings.schema.0.1.json" ModelName="Settings" />
-  </ItemGroup>    
+  </ItemGroup>
 
-  
+  <ItemGroup>
+    <Folder Include="Models\" />
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="$(ProjectDir)\DscResources\microsoft.winget-create.*.dsc.resource.json">
       <Link>%(Filename)%(Extension)</Link>

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -81,7 +81,7 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
     </EmbeddedResource>
   </ItemGroup>
-    
+
   <!--Include VCLib binary dependencies-->  
   <ItemGroup Condition="'$(SelfContained)' == true">
     <None Update="msvcp140.dll">
@@ -96,7 +96,16 @@
   </ItemGroup>    
 
   <ItemGroup>
-      <SettingSchema Include="$(ProjectDir)\Schemas\settings.schema.0.1.json" ModelName="Settings" />
+    <SettingSchema Include="$(ProjectDir)\Schemas\settings.schema.0.1.json" ModelName="Settings" />
+  </ItemGroup>    
+
+  
+  <ItemGroup>
+    <Content Include="$(ProjectDir)\DscResources\microsoft.winget-create.*.dsc.resource.json">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
   <!--Generate settings manifest-->

--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -99,10 +99,6 @@
       <SettingSchema Include="$(ProjectDir)\Schemas\settings.schema.0.1.json" ModelName="Settings" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Models\" />
-  </ItemGroup>
-
   <!--Generate settings manifest-->
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Inputs="@(SettingSchema)" Outputs="@(SettingSchema -> '$(ProjectDir)Models\%(ModelName)Model.cs')">
       <Message Importance="high" Text="Rebuilding: %(SettingSchema.ModelName) because $(ProjectDir)Models\%(ModelName)Model.cs is older than %(FullPath)" />

--- a/src/WingetCreatePackage/Package.appxmanifest
+++ b/src/WingetCreatePackage/Package.appxmanifest
@@ -11,7 +11,7 @@
   <Identity
     Name="Microsoft.WindowsPackageManagerManifestCreator"
     Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-    Version="0.0.2.0" />
+    Version="0.0.1.0" />
 
   <Properties>
     <DisplayName>Windows Package Manager Manifest Creator</DisplayName>

--- a/src/WingetCreatePackage/WingetCreatePackage.wapproj
+++ b/src/WingetCreatePackage/WingetCreatePackage.wapproj
@@ -37,8 +37,6 @@
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
-    <AppxPackageDir>C:\win\tmp\wingetcreate-package\</AppxPackageDir>
   </PropertyGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/src/WingetCreateTests/WingetCreateTests/Models/DscExecuteResult.cs
+++ b/src/WingetCreateTests/WingetCreateTests/Models/DscExecuteResult.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateUnitTests.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.WingetCreateCLI.Models.DscModels;
+using Newtonsoft.Json;
+
+/// <summary>
+/// Result of executing a DSC command.
+/// </summary>
+public class DscExecuteResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DscExecuteResult"/> class.
+    /// </summary>
+    /// <param name="success">Value indicating whether the command execution was successful.</param>
+    /// <param name="output">Output of the command execution.</param>
+    public DscExecuteResult(bool success, string output)
+    {
+        this.Success = success;
+        this.Output = output;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the command execution was successful.
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// Gets the output result of the operation.
+    /// </summary>
+    public string Output { get; }
+
+    /// <summary>
+    /// Gets the output as settings state.
+    /// </summary>
+    /// <returns>Settings state.</returns>
+    public SettingsResourceObject OutputState()
+    {
+        var lines = this.Output.Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries);
+        Debug.Assert(lines.Length == 1, "Output should contain exactly one line.");
+        return JsonConvert.DeserializeObject<SettingsResourceObject>(lines[0]);
+    }
+
+    /// <summary>
+    /// Gets the output as settings state and diff.
+    /// </summary>
+    /// <returns>Settings state and diff.</returns>
+    public (SettingsResourceObject State, List<string> Diff) OutputStateAndDiff()
+    {
+        var lines = this.Output.Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries);
+        Debug.Assert(lines.Length == 2, "Output should contain exactly two lines.");
+        var settingsObject = JsonConvert.DeserializeObject<SettingsResourceObject>(lines[0]);
+        var diff = JsonConvert.DeserializeObject<List<string>>(lines[1]);
+        return (settingsObject, diff);
+    }
+}

--- a/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
+++ b/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
@@ -13,7 +13,10 @@ namespace Microsoft.WingetCreateTests
     using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
+    using CommandLine;
+    using Microsoft.WingetCreateCLI.Commands;
     using Microsoft.WingetCreateCore;
+    using Microsoft.WingetCreateUnitTests.Models;
     using Moq;
     using Moq.Protected;
 
@@ -212,6 +215,20 @@ namespace Microsoft.WingetCreateTests
             {
                 File.Delete(Path.Combine(PackageParser.InstallerDownloadPath, fileName));
             }
+        }
+
+        /// <summary>
+        /// Execute the DSC command.
+        /// </summary>
+        /// <param name="args">The arguments to pass to the DSC command.</param>
+        /// <returns>Result of executing the DSC command.</returns>
+        public static async Task<DscExecuteResult> ExecuteDscCommandAsync(List<string> args)
+        {
+            var sw = new StringWriter();
+            Console.SetOut(sw);
+            var executeResult = await Parser.Default.ParseArguments<DscCommand>(args).Value.Execute();
+            var output = sw.ToString();
+            return new(executeResult, output);
         }
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
+++ b/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
@@ -222,7 +222,7 @@ namespace Microsoft.WingetCreateTests
         /// </summary>
         /// <param name="args">The arguments to pass to the DSC command.</param>
         /// <returns>Result of executing the DSC command.</returns>
-        public static async Task<DscExecuteResult> ExecuteDscCommandAsync(List<string> args)
+        public static async Task<DscExecuteResult> ExecuteDscCommandAsync(params string[] args)
         {
             var sw = new StringWriter();
             Console.SetOut(sw);

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
@@ -64,11 +64,11 @@ public class DscCommandTests
     }
 
     /// <summary>
-    /// Tests the error message when an invalid operation is attempted on a DSC resource.
+    /// Tests the error message when a DSC resource operation is not specified.
     /// </summary>
     /// <returns>Async Task.</returns>
     [Test]
-    public async Task DscResourceInvalidOperation_ErrorMessage()
+    public async Task DscResourceOperationNotSpecified_ErrorMessage()
     {
         // Arrange
         var command = new DscSettingsCommand();

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
@@ -37,7 +37,7 @@ public class DscCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get"]);
 
         // Assert
         Assert.That(result.Success, Is.True);
@@ -60,7 +60,7 @@ public class DscCommandTests
 
         // Assert
         Assert.That(result.Success, Is.False);
-        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscResourceNotFound_Message, dscResourceName, availableResources)));
+        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscResourceNameNotFound_Message, dscResourceName, availableResources)));
     }
 
     /// <summary>
@@ -78,7 +78,7 @@ public class DscCommandTests
 
         // Assert
         Assert.That(result.Success, Is.False);
-        Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationInvalid_Message));
+        Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationNotSpecified_Message));
     }
 
     /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
@@ -33,11 +33,8 @@ public class DscCommandTests
     [Test]
     public async Task DscSettingsResource_Success()
     {
-        // Arrange
-        var command = new DscSettingsCommand();
-
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get"]);
+        var result = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--get");
 
         // Assert
         Assert.That(result.Success, Is.True);
@@ -52,11 +49,10 @@ public class DscCommandTests
     {
         // Arrange
         var dscResourceName = "ResourceNotFound";
-        List<BaseDscCommand> dscCommands = [new DscSettingsCommand()];
-        var availableResources = string.Join(", ", dscCommands.Select(c => c.CommandName));
+        var availableResources = string.Join(", ", BaseDscCommand.GetAvailableCommands());
 
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([dscResourceName]);
+        var result = await TestUtils.ExecuteDscCommandAsync(dscResourceName);
 
         // Assert
         Assert.That(result.Success, Is.False);
@@ -70,11 +66,8 @@ public class DscCommandTests
     [Test]
     public async Task DscResourceOperationNotSpecified_ErrorMessage()
     {
-        // Arrange
-        var command = new DscSettingsCommand();
-
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName]);
+        var result = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName);
 
         // Assert
         Assert.That(result.Success, Is.False);
@@ -88,11 +81,8 @@ public class DscCommandTests
     [Test]
     public async Task DscSettingsResourceFailedOperation_ErrorMessage()
     {
-        // Arrange
-        var command = new DscSettingsCommand();
-
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--set", string.Empty);
 
         // Assert
         Assert.That(result.Success, Is.False);

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateUnitTests;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CommandLine;
+using Microsoft.WingetCreateCLI.Commands;
+using Microsoft.WingetCreateCLI.Commands.DscCommands;
+using Microsoft.WingetCreateCLI.Logging;
+using Microsoft.WingetCreateCLI.Properties;
+using NUnit.Framework;
+
+/// <summary>
+/// Unit test class for the DSC Command.
+/// </summary>
+public class DscCommandTests
+{
+    /// <summary>
+    /// Execute the DSC command
+    /// </summary>
+    /// <param name="args">The arguments to pass to the DSC command.</param>
+    /// <returns>Result of executing the DSC command.</returns>
+    public static async Task<ExecuteResult> ExecuteDscCommandAsync(List<string> args)
+    {
+        var sw = new StringWriter();
+        Console.SetOut(sw);
+        var executeResult = await Parser.Default.ParseArguments<DscCommand>(args).Value.Execute();
+        var output = sw.ToString();
+        return new(executeResult, output);
+    }
+
+    /// <summary>
+    /// OneTimeSetup method for the DSC command unit tests.
+    /// </summary>
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        Logger.Initialize();
+    }
+
+    [Test]
+    public async Task DscSettingsResource_Success()
+    {
+        // Arrange
+        var command = new DscSettingsCommand();
+
+        // Act
+        var result = await ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
+
+        // Assert
+        Assert.That(result.Success, Is.True);
+    }
+
+    [Test]
+    public async Task DscResourceMissing_ErrorMessage()
+    {
+        // Arrange
+        List<BaseDscCommand> dscCommands = [new DscSettingsCommand()];
+
+        // Act
+        var result = await ExecuteDscCommandAsync([]);
+
+        // Assert
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscResourceMissing_Message, string.Join(", ", dscCommands.Select(c => c.CommandName)))));
+    }
+
+    [Test]
+    public async Task DscResourceNotFound_ErrorMessage()
+    {
+        // Arrange
+        var dscResourceName = "ResourceNotFound";
+
+        // Act
+        var result = await ExecuteDscCommandAsync([dscResourceName]);
+
+        // Assert
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscResourceNotFound_Message, dscResourceName)));
+    }
+
+    [Test]
+    public async Task DscResourceInvalidOperation_ErrorMessage()
+    {
+        // Arrange
+        var command = new DscSettingsCommand();
+
+        // Act
+        var result = await ExecuteDscCommandAsync([command.CommandName]);
+
+        // Assert
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationInvalid_Message));
+    }
+
+    [Test]
+    public async Task DscSettingsResourceFailedOperation_ErrorMessage()
+    {
+        // Arrange
+        var command = new DscSettingsCommand();
+
+        // Act
+        var result = await ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
+
+        // Assert
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationFailed_Message));
+    }
+
+    /// <summary>
+    /// Result of executing a DSC command.
+    /// </summary>
+    /// <param name="Success">Value indicating whether the command execution was successful.</param>
+    /// <param name="Output">Value containing the output of the command execution.</param>
+    public record class ExecuteResult(bool Success, string Output);
+}

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
@@ -26,6 +26,10 @@ public class DscCommandTests
         Logger.Initialize();
     }
 
+    /// <summary>
+    /// Tests the a successful execution of the dsc command.
+    /// </summary>
+    /// <returns>Async Task.</returns>
     [Test]
     public async Task DscSettingsResource_Success()
     {
@@ -39,34 +43,30 @@ public class DscCommandTests
         Assert.That(result.Success, Is.True);
     }
 
-    [Test]
-    public async Task DscResourceMissing_ErrorMessage()
-    {
-        // Arrange
-        List<BaseDscCommand> dscCommands = [new DscSettingsCommand()];
-
-        // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([]);
-
-        // Assert
-        Assert.That(result.Success, Is.False);
-        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscResourceMissing_Message, string.Join(", ", dscCommands.Select(c => c.CommandName)))));
-    }
-
+    /// <summary>
+    /// Tests the error message when a DSC resource is not found.
+    /// </summary>
+    /// <returns>Async Task.</returns>
     [Test]
     public async Task DscResourceNotFound_ErrorMessage()
     {
         // Arrange
         var dscResourceName = "ResourceNotFound";
+        List<BaseDscCommand> dscCommands = [new DscSettingsCommand()];
+        var availableResources = string.Join(", ", dscCommands.Select(c => c.CommandName));
 
         // Act
         var result = await TestUtils.ExecuteDscCommandAsync([dscResourceName]);
 
         // Assert
         Assert.That(result.Success, Is.False);
-        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscResourceNotFound_Message, dscResourceName)));
+        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscResourceNotFound_Message, dscResourceName, availableResources)));
     }
 
+    /// <summary>
+    /// Tests the error message when an invalid operation is attempted on a DSC resource.
+    /// </summary>
+    /// <returns>Async Task.</returns>
     [Test]
     public async Task DscResourceInvalidOperation_ErrorMessage()
     {
@@ -81,6 +81,10 @@ public class DscCommandTests
         Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationInvalid_Message));
     }
 
+    /// <summary>
+    /// Tests the error message when a DSC resource operation fails.
+    /// </summary>
+    /// <returns>Async Task.</returns>
     [Test]
     public async Task DscSettingsResourceFailedOperation_ErrorMessage()
     {

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscCommandTests.cs
@@ -3,16 +3,13 @@
 
 namespace Microsoft.WingetCreateUnitTests;
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using CommandLine;
-using Microsoft.WingetCreateCLI.Commands;
 using Microsoft.WingetCreateCLI.Commands.DscCommands;
 using Microsoft.WingetCreateCLI.Logging;
 using Microsoft.WingetCreateCLI.Properties;
+using Microsoft.WingetCreateTests;
 using NUnit.Framework;
 
 /// <summary>
@@ -20,20 +17,6 @@ using NUnit.Framework;
 /// </summary>
 public class DscCommandTests
 {
-    /// <summary>
-    /// Execute the DSC command
-    /// </summary>
-    /// <param name="args">The arguments to pass to the DSC command.</param>
-    /// <returns>Result of executing the DSC command.</returns>
-    public static async Task<ExecuteResult> ExecuteDscCommandAsync(List<string> args)
-    {
-        var sw = new StringWriter();
-        Console.SetOut(sw);
-        var executeResult = await Parser.Default.ParseArguments<DscCommand>(args).Value.Execute();
-        var output = sw.ToString();
-        return new(executeResult, output);
-    }
-
     /// <summary>
     /// OneTimeSetup method for the DSC command unit tests.
     /// </summary>
@@ -50,7 +33,7 @@ public class DscCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
 
         // Assert
         Assert.That(result.Success, Is.True);
@@ -63,7 +46,7 @@ public class DscCommandTests
         List<BaseDscCommand> dscCommands = [new DscSettingsCommand()];
 
         // Act
-        var result = await ExecuteDscCommandAsync([]);
+        var result = await TestUtils.ExecuteDscCommandAsync([]);
 
         // Assert
         Assert.That(result.Success, Is.False);
@@ -77,7 +60,7 @@ public class DscCommandTests
         var dscResourceName = "ResourceNotFound";
 
         // Act
-        var result = await ExecuteDscCommandAsync([dscResourceName]);
+        var result = await TestUtils.ExecuteDscCommandAsync([dscResourceName]);
 
         // Assert
         Assert.That(result.Success, Is.False);
@@ -91,7 +74,7 @@ public class DscCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await ExecuteDscCommandAsync([command.CommandName]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName]);
 
         // Assert
         Assert.That(result.Success, Is.False);
@@ -105,17 +88,10 @@ public class DscCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
 
         // Assert
         Assert.That(result.Success, Is.False);
         Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationFailed_Message));
     }
-
-    /// <summary>
-    /// Result of executing a DSC command.
-    /// </summary>
-    /// <param name="Success">Value indicating whether the command execution was successful.</param>
-    /// <param name="Output">Value containing the output of the command execution.</param>
-    public record class ExecuteResult(bool Success, string Output);
 }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
@@ -124,12 +124,31 @@ public class DscSettingsCommandTests
 
         // Assert
         Assert.That(result.Success, Is.False);
-        Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationFailed_Message));
+        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscInputRequired_Message, nameof(DscSettingsCommand.Set))));
+    }
+
+    /// <summary>
+    /// Tests the Test operation with an empty input.
+    /// </summary>
+    /// <returns>Async task.</returns>
+    [Test]
+    public async Task DscSettingsResource_TestEmpty_Fail()
+    {
+        // Arrange
+        var command = new DscSettingsCommand();
+
+        // Act
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", string.Empty]);
+
+        // Assert
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Output, Does.Contain(string.Format(Resources.DscInputRequired_Message, nameof(DscSettingsCommand.Test))));
     }
 
     /// <summary>
     /// Tests the Set operation with diff.
     /// </summary>
+    /// <param name="isPartial">Optional parameter to indicate if the operation is partial.</param>
     /// <returns>Async task.</returns>
     [Test]
     [TestCase(true)]
@@ -173,6 +192,7 @@ public class DscSettingsCommandTests
     /// <summary>
     /// Tests the Set operation without diff.
     /// </summary>
+    /// <param name="isPartial">Optional parameter to indicate if the operation is partial.</param>
     /// <returns>Async task.</returns>
     [Test]
     [TestCase(true)]
@@ -225,6 +245,7 @@ public class DscSettingsCommandTests
     /// <summary>
     /// Tests the Test operation with diff.
     /// </summary>
+    /// <param name="isPartial">Optional parameter to indicate if the operation is partial.</param>
     /// <returns>Async task.</returns>
     [Test]
     [TestCase(true)]
@@ -270,6 +291,7 @@ public class DscSettingsCommandTests
     /// <summary>
     /// Tests the Test operation without diff.
     /// </summary>
+    /// <param name="isPartial">Optional parameter to indicate if the operation is partial.</param>
     /// <returns>Async task.</returns>
     [Test]
     [TestCase(true)]

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
@@ -248,6 +248,7 @@ public class DscSettingsCommandTests
             this.AssertStateAndSettingsAreEqual(this.DefaultSettings, stateAndDiff.State);
             Assert.That(stateAndDiff.Diff, Is.EqualTo(new List<string>() { "settings" }));
             this.AssertStateAction(stateAndDiff.State, isPartial);
+            Assert.That(stateAndDiff.State.InDesiredState, Is.False);
         }
 
         // Part 2: Now test settings repo owner only
@@ -262,6 +263,7 @@ public class DscSettingsCommandTests
             this.AssertStateAndSettingsAreEqual(this.DefaultSettings, stateAndDiff.State);
             Assert.That(stateAndDiff.Diff, Is.EqualTo(new List<string>() { "settings" }));
             this.AssertStateAction(stateAndDiff.State, isPartial);
+            Assert.That(stateAndDiff.State.InDesiredState, Is.False);
         }
     }
 
@@ -293,6 +295,7 @@ public class DscSettingsCommandTests
             this.AssertStateAndSettingsAreEqual(this.CurrentSettings, stateAndDiff.State);
             Assert.That(stateAndDiff.Diff, Is.Empty);
             this.AssertStateAction(stateAndDiff.State, isPartial);
+            Assert.That(stateAndDiff.State.InDesiredState, Is.True);
         }
 
         // Part 2: Now test settings repo owner only
@@ -310,6 +313,7 @@ public class DscSettingsCommandTests
             this.AssertStateAndSettingsAreEqual(this.CurrentSettings, stateAndDiff.State);
             Assert.That(stateAndDiff.Diff, Is.Empty);
             this.AssertStateAction(stateAndDiff.State, isPartial);
+            Assert.That(stateAndDiff.State.InDesiredState, Is.True);
         }
     }
 

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.WingetCreateUnitTests;
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.WingetCreateCLI;
 using Microsoft.WingetCreateCLI.Commands.DscCommands;
@@ -10,6 +11,7 @@ using Microsoft.WingetCreateCLI.Logging;
 using Microsoft.WingetCreateCLI.Models.DscModels;
 using Microsoft.WingetCreateCLI.Models.Settings;
 using Microsoft.WingetCreateCLI.Properties;
+using Microsoft.WingetCreateTests;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -65,6 +67,10 @@ public class DscSettingsCommandTests
         UserSettings.SaveSettings(this.OriginalSettings);
     }
 
+    /// <summary>
+    /// Tests the Get operation.
+    /// </summary>
+    /// <returns>Async task.</returns>
     [Test]
     public async Task DscSettingsResource_Get_Success()
     {
@@ -72,13 +78,20 @@ public class DscSettingsCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
+        var state = result.OutputState();
 
         // Assert
         Assert.That(result.Success, Is.True);
         Assert.That(result.Output, Does.Contain(this.CreateGetResponse()));
+        Assert.That(state.Action, Is.Null);
+        this.AssertStateAndSettingsAreEqual(this.CurrentSettings, state);
     }
 
+    /// <summary>
+    /// Tests the Export operation.
+    /// </summary>
+    /// <returns>Async task.</returns>
     [Test]
     public async Task DscSettingsResource_Export_Success()
     {
@@ -86,13 +99,20 @@ public class DscSettingsCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--export", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--export", string.Empty]);
+        var state = result.OutputState();
 
         // Assert
         Assert.That(result.Success, Is.True);
         Assert.That(result.Output, Does.Contain(this.CreateGetResponse()));
+        Assert.That(state.Action, Is.Null);
+        this.AssertStateAndSettingsAreEqual(this.CurrentSettings, state);
     }
 
+    /// <summary>
+    /// Tests the Set operation with an empty input.
+    /// </summary>
+    /// <returns>Async task.</returns>
     [Test]
     public async Task DscSettingsResource_SetEmpty_Fail()
     {
@@ -100,18 +120,22 @@ public class DscSettingsCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
 
         // Assert
         Assert.That(result.Success, Is.False);
         Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationFailed_Message));
     }
 
+    /// <summary>
+    /// Tests the Set operation with diff.
+    /// </summary>
+    /// <returns>Async task.</returns>
     [Test]
     [TestCase(true)]
     [TestCase(false)]
     [TestCase(null)]
-    public async Task DscSettingsResource_Set_Success(bool? isPartial)
+    public async Task DscSettingsResource_SetWithDiff_Success(bool? isPartial)
     {
         // Arrange
         this.ResetSettingsToDefaultValues();
@@ -120,47 +144,221 @@ public class DscSettingsCommandTests
         // Part 1: Update settings repo name only
         {
             // Act
-            var setRepoName = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var setRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var stateAndDiff = setRepoName.OutputStateAndDiff();
 
             // Assert
             Assert.That(setRepoName.Success, Is.True);
-            this.AssertSettingsRepoHasChanged(name: MockName);
+            this.AssertSettingsHasChanged(name: MockName);
+            this.AssertStateAndSettingsAreEqual(this.CurrentSettings, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.EqualTo(new List<string>() { "settings" }));
+            this.AssertStateAction(stateAndDiff.State, isPartial);
         }
 
         // Part 2: Now update settings repo owner only
         {
             // Act
-            var setRepoOwner = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var setRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var stateAndDiff = setRepoOwner.OutputStateAndDiff();
 
             // Assert
             Assert.That(setRepoOwner.Success, Is.True);
-            this.AssertSettingsRepoHasChanged(name: (isPartial ?? true) ? MockName : null, owner: MockOwner);
+            this.AssertSettingsHasChanged(name: (isPartial ?? true) ? MockName : null, owner: MockOwner);
+            this.AssertStateAndSettingsAreEqual(this.CurrentSettings, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.EqualTo(new List<string>() { "settings" }));
+            this.AssertStateAction(stateAndDiff.State, isPartial);
         }
     }
 
+    /// <summary>
+    /// Tests the Set operation without diff.
+    /// </summary>
+    /// <returns>Async task.</returns>
     [Test]
-    public async Task DscSettingsResource_Test_Success(bool? isPartial)
+    [TestCase(true)]
+    [TestCase(false)]
+    [TestCase(null)]
+    public async Task DscSettingsResource_SetWithoutDiff_Success(bool? isPartial)
     {
         // Arrange
         this.ResetSettingsToDefaultValues();
         var command = new DscSettingsCommand();
-        var currentSettings = this.CurrentSettings;
-        currentSettings.WindowsPackageManagerRepository.Name = MockName;
-        UserSettings.SaveSettings(currentSettings);
 
-        // TODO
+        // Part 1: Update settings repo name only
+        {
+            // Arrange
+            this.UpdateSettings(name: MockName);
+            var currentSettingsBeforeExecute = this.CurrentSettings;
+
+            // Act
+            var setRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var stateAndDiff = setRepoName.OutputStateAndDiff();
+
+            // Assert
+            Assert.That(setRepoName.Success, Is.True);
+            this.AssertSettingsHasChanged(name: MockName);
+            this.AssertStateAndSettingsAreEqual(currentSettingsBeforeExecute, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.Empty);
+            this.AssertStateAction(stateAndDiff.State, isPartial);
+        }
+
+        // Part 2: Now update settings repo owner only
+        {
+            // Arrange
+            var defaultRepoName = this.DefaultSettings.WindowsPackageManagerRepository.Name;
+            this.UpdateSettings(name: (isPartial ?? true) ? null : defaultRepoName, owner: MockOwner);
+            var currentSettingsBeforeExecute = this.CurrentSettings;
+
+            // Act
+            var setRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var stateAndDiff = setRepoOwner.OutputStateAndDiff();
+
+            // Assert
+            Assert.That(setRepoOwner.Success, Is.True);
+            this.AssertSettingsHasChanged(name: (isPartial ?? true) ? MockName : null, owner: MockOwner);
+            this.AssertStateAndSettingsAreEqual(currentSettingsBeforeExecute, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.Empty);
+            this.AssertStateAction(stateAndDiff.State, isPartial);
+        }
     }
 
+    /// <summary>
+    /// Tests the Test operation with diff.
+    /// </summary>
+    /// <returns>Async task.</returns>
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    [TestCase(null)]
+    public async Task DscSettingsResource_TestWithDiff_Success(bool? isPartial)
+    {
+        // Arrange
+        this.ResetSettingsToDefaultValues();
+        var command = new DscSettingsCommand();
+
+        // Part 1: Test settings repo name only
+        {
+            // Act
+            var testRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var stateAndDiff = testRepoName.OutputStateAndDiff();
+
+            // Assert
+            Assert.That(testRepoName.Success, Is.True);
+            this.AssertSettingsAreEqual(this.DefaultSettings, this.CurrentSettings);
+            this.AssertStateAndSettingsAreEqual(this.DefaultSettings, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.EqualTo(new List<string>() { "settings" }));
+            this.AssertStateAction(stateAndDiff.State, isPartial);
+        }
+
+        // Part 2: Now test settings repo owner only
+        {
+            // Act
+            var testRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var stateAndDiff = testRepoOwner.OutputStateAndDiff();
+
+            // Assert
+            Assert.That(testRepoOwner.Success, Is.True);
+            this.AssertSettingsAreEqual(this.DefaultSettings, this.CurrentSettings);
+            this.AssertStateAndSettingsAreEqual(this.DefaultSettings, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.EqualTo(new List<string>() { "settings" }));
+            this.AssertStateAction(stateAndDiff.State, isPartial);
+        }
+    }
+
+    /// <summary>
+    /// Tests the Test operation without diff.
+    /// </summary>
+    /// <returns>Async task.</returns>
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    [TestCase(null)]
+    public async Task DscSettingsResource_TestWithoutDiff_Success(bool? isPartial)
+    {
+        // Arrange
+        this.ResetSettingsToDefaultValues();
+        var command = new DscSettingsCommand();
+
+        // Part 1: Test settings repo name only
+        {
+            // Arrange
+            this.UpdateSettings(name: MockName);
+
+            // Act
+            var testRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var stateAndDiff = testRepoName.OutputStateAndDiff();
+
+            // Assert
+            Assert.That(testRepoName.Success, Is.True);
+            this.AssertStateAndSettingsAreEqual(this.CurrentSettings, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.Empty);
+            this.AssertStateAction(stateAndDiff.State, isPartial);
+        }
+
+        // Part 2: Now test settings repo owner only
+        {
+            // Arrange
+            var defaultRepoName = this.DefaultSettings.WindowsPackageManagerRepository.Name;
+            this.UpdateSettings(name: (isPartial ?? true) ? null : defaultRepoName, owner: MockOwner);
+
+            // Act
+            var testRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var stateAndDiff = testRepoOwner.OutputStateAndDiff();
+
+            // Assert
+            Assert.That(testRepoOwner.Success, Is.True);
+            this.AssertStateAndSettingsAreEqual(this.CurrentSettings, stateAndDiff.State);
+            Assert.That(stateAndDiff.Diff, Is.Empty);
+            this.AssertStateAction(stateAndDiff.State, isPartial);
+        }
+    }
+
+    /// <summary>
+    /// Resets the settings to default values.
+    /// </summary>
     private void ResetSettingsToDefaultValues()
     {
         UserSettings.SaveSettings(this.DefaultSettings);
     }
 
+    /// <summary>
+    /// Updates the settings with the provided name and owner.
+    /// </summary>
+    /// <param name="name">Optional name for the repository.</param>
+    /// <param name="owner">Optional owner for the repository.</param>
+    private void UpdateSettings(string name = null, string owner = null)
+    {
+        var settings = this.CurrentSettings;
+        if (name != null)
+        {
+            settings.WindowsPackageManagerRepository.Name = name;
+        }
+
+        if (owner != null)
+        {
+            settings.WindowsPackageManagerRepository.Owner = owner;
+        }
+
+        UserSettings.SaveSettings(settings);
+    }
+
+    /// <summary>
+    /// Create the response for the Get operation.
+    /// </summary>
+    /// <param name="isPartial">Optional parameter to indicate if the response is partial.</param>
+    /// <returns>A JSON string representing the response.</returns>
     private string CreateGetResponse(bool? isPartial = null)
     {
         return this.CreateResourceObject(UserSettings.ToJson(), isPartial);
     }
 
+    /// <summary>
+    /// Creates the operation input.
+    /// </summary>
+    /// <param name="name">Optional name for the repository.</param>
+    /// <param name="owner">Optional owner for the repository.</param>
+    /// <param name="isPartial">Optional parameter to indicate if the input is partial.</param>
+    /// <returns>A JSON string representing the operation input.</returns>
     private string CreateInput(string name = null, string owner = null, bool? isPartial = null)
     {
         var repo = new JObject();
@@ -182,6 +380,12 @@ public class DscSettingsCommandTests
         return this.CreateResourceObject(input, isPartial);
     }
 
+    /// <summary>
+    /// Create the resource object for the operation.
+    /// </summary>
+    /// <param name="settings">Settings to include in the resource object.</param>
+    /// <param name="isPartial">Optional parameter to indicate if the resource object is partial.</param>
+    /// <returns>A JSON string representing the resource object.</returns>
     private string CreateResourceObject(JObject settings, bool? isPartial)
     {
         var resourceObject = new SettingsResourceObject
@@ -192,7 +396,12 @@ public class DscSettingsCommandTests
         return JObject.FromObject(resourceObject).ToString(Formatting.None);
     }
 
-    private void AssertSettingsRepoHasChanged(string name = null, string owner = null)
+    /// <summary>
+    /// Asserts that the current settings have changed based on the provided name and owner.
+    /// </summary>
+    /// <param name="name">Optional name for the repository.</param>
+    /// <param name="owner">Optional owner for the repository.</param>
+    private void AssertSettingsHasChanged(string name = null, string owner = null)
     {
         var currentSettings = this.CurrentSettings;
         var defaultSettings = this.DefaultSettings;
@@ -206,8 +415,46 @@ public class DscSettingsCommandTests
             defaultSettings.WindowsPackageManagerRepository.Owner = owner;
         }
 
-        var currentSettingsJson = JToken.FromObject(currentSettings);
-        var defaultSettingsJson = JToken.FromObject(defaultSettings);
-        Assert.That(JToken.DeepEquals(currentSettingsJson, defaultSettingsJson), Is.True);
+        this.AssertSettingsAreEqual(defaultSettings, currentSettings);
+    }
+
+    /// <summary>
+    /// Asserts that the state and settings are equal.
+    /// </summary>
+    /// <param name="settings">Settings manifest to compare against.</param>
+    /// <param name="state">Output state to compare.</param>
+    private void AssertStateAndSettingsAreEqual(SettingsManifest settings, SettingsResourceObject state)
+    {
+        var stateSettings = state.Settings.ToObject<SettingsManifest>();
+        this.AssertSettingsAreEqual(settings, stateSettings);
+    }
+
+    /// <summary>
+    /// Asserts that the state action is as expected.
+    /// </summary>
+    /// <param name="state">Output state to check.</param>
+    /// <param name="isPartial">Optional parameter to indicate if the state is partial.</param>
+    private void AssertStateAction(SettingsResourceObject state, bool? isPartial = null)
+    {
+        if (!isPartial.HasValue || isPartial.Value)
+        {
+            Assert.That(state.Action, Is.EqualTo(SettingsResourceObject.ActionPartial));
+        }
+        else
+        {
+            Assert.That(state.Action, Is.EqualTo(SettingsResourceObject.ActionFull));
+        }
+    }
+
+    /// <summary>
+    /// Asserts that two settings manifests are equal.
+    /// </summary>
+    /// <param name="expected">Expected settings manifest.</param>
+    /// <param name="actual">Actual settings manifest.</param>
+    private void AssertSettingsAreEqual(SettingsManifest expected, SettingsManifest actual)
+    {
+        var expectedJson = JToken.FromObject(expected);
+        var actualJson = JToken.FromObject(actual);
+        Assert.That(JToken.DeepEquals(expectedJson, actualJson), Is.True);
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateUnitTests;
+
+using System.Threading.Tasks;
+using Microsoft.WingetCreateCLI;
+using Microsoft.WingetCreateCLI.Commands.DscCommands;
+using Microsoft.WingetCreateCLI.Logging;
+using Microsoft.WingetCreateCLI.Models.DscModels;
+using Microsoft.WingetCreateCLI.Models.Settings;
+using Microsoft.WingetCreateCLI.Properties;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+/// <summary>
+/// Unit test class for the DSC settings Command.
+/// </summary>
+public class DscSettingsCommandTests
+{
+    private const string MockName = "mock_name";
+    private const string MockOwner = "mock_owner";
+    private JToken rawOriginalSettings;
+
+    /// <summary>
+    /// Gets the settings state with default values.
+    /// </summary>
+    private SettingsManifest DefaultSettings => new();
+
+    /// <summary>
+    /// Gets the settings state after the test is run.
+    /// </summary>
+    private SettingsManifest CurrentSettings => UserSettings.ToJson().ToObject<SettingsManifest>();
+
+    /// <summary>
+    /// Gets the settings state before the test is run.
+    /// </summary>
+    private SettingsManifest OriginalSettings => this.rawOriginalSettings.ToObject<SettingsManifest>();
+
+    /// <summary>
+    /// OneTimeSetup method for the DSC command unit tests.
+    /// </summary>
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        Logger.Initialize();
+    }
+
+    /// <summary>
+    /// Setup method for the cache command unit tests.
+    /// </summary>
+    [SetUp]
+    public void SetUp()
+    {
+        this.rawOriginalSettings = UserSettings.ToJson();
+    }
+
+    /// <summary>
+    /// Teardown method for each individual test.
+    /// </summary>
+    [TearDown]
+    public void TearDown()
+    {
+        UserSettings.SaveSettings(this.OriginalSettings);
+    }
+
+    [Test]
+    public async Task DscSettingsResource_Get_Success()
+    {
+        // Arrange
+        var command = new DscSettingsCommand();
+
+        // Act
+        var result = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
+
+        // Assert
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Output, Does.Contain(this.CreateGetResponse()));
+    }
+
+    [Test]
+    public async Task DscSettingsResource_Export_Success()
+    {
+        // Arrange
+        var command = new DscSettingsCommand();
+
+        // Act
+        var result = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--export", string.Empty]);
+
+        // Assert
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Output, Does.Contain(this.CreateGetResponse()));
+    }
+
+    [Test]
+    public async Task DscSettingsResource_SetEmpty_Fail()
+    {
+        // Arrange
+        var command = new DscSettingsCommand();
+
+        // Act
+        var result = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
+
+        // Assert
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Output, Does.Contain(Resources.DscResourceOperationFailed_Message));
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    [TestCase(null)]
+    public async Task DscSettingsResource_Set_Success(bool? isPartial)
+    {
+        // Arrange
+        this.ResetSettingsToDefaultValues();
+        var command = new DscSettingsCommand();
+
+        // Part 1: Update settings repo name only
+        {
+            // Act
+            var setRepoName = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial)]);
+
+            // Assert
+            Assert.That(setRepoName.Success, Is.True);
+            this.AssertSettingsRepoHasChanged(name: MockName);
+        }
+
+        // Part 2: Now update settings repo owner only
+        {
+            // Act
+            var setRepoOwner = await DscCommandTests.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+
+            // Assert
+            Assert.That(setRepoOwner.Success, Is.True);
+            this.AssertSettingsRepoHasChanged(name: (isPartial ?? true) ? MockName : null, owner: MockOwner);
+        }
+    }
+
+    [Test]
+    public async Task DscSettingsResource_Test_Success(bool? isPartial)
+    {
+        // Arrange
+        this.ResetSettingsToDefaultValues();
+        var command = new DscSettingsCommand();
+        var currentSettings = this.CurrentSettings;
+        currentSettings.WindowsPackageManagerRepository.Name = MockName;
+        UserSettings.SaveSettings(currentSettings);
+
+        // TODO
+    }
+
+    private void ResetSettingsToDefaultValues()
+    {
+        UserSettings.SaveSettings(this.DefaultSettings);
+    }
+
+    private string CreateGetResponse(bool? isPartial = null)
+    {
+        return this.CreateResourceObject(UserSettings.ToJson(), isPartial);
+    }
+
+    private string CreateInput(string name = null, string owner = null, bool? isPartial = null)
+    {
+        var repo = new JObject();
+        if (name != null)
+        {
+            repo["name"] = name;
+        }
+
+        if (owner != null)
+        {
+            repo["owner"] = owner;
+        }
+
+        var input = new JObject
+        {
+            [nameof(WindowsPackageManagerRepository)] = repo,
+        };
+
+        return this.CreateResourceObject(input, isPartial);
+    }
+
+    private string CreateResourceObject(JObject settings, bool? isPartial)
+    {
+        var resourceObject = new SettingsResourceObject
+        {
+            Settings = settings,
+            Action = isPartial.HasValue ? (isPartial.Value ? SettingsResourceObject.ActionPartial : SettingsResourceObject.ActionFull) : null,
+        };
+        return JObject.FromObject(resourceObject).ToString(Formatting.None);
+    }
+
+    private void AssertSettingsRepoHasChanged(string name = null, string owner = null)
+    {
+        var currentSettings = this.CurrentSettings;
+        var defaultSettings = this.DefaultSettings;
+        if (name != null)
+        {
+            defaultSettings.WindowsPackageManagerRepository.Name = name;
+        }
+
+        if (owner != null)
+        {
+            defaultSettings.WindowsPackageManagerRepository.Owner = owner;
+        }
+
+        var currentSettingsJson = JToken.FromObject(currentSettings);
+        var defaultSettingsJson = JToken.FromObject(defaultSettings);
+        Assert.That(JToken.DeepEquals(currentSettingsJson, defaultSettingsJson), Is.True);
+    }
+}

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
@@ -74,11 +74,8 @@ public class DscSettingsCommandTests
     [Test]
     public async Task DscSettingsResource_Get_Success()
     {
-        // Arrange
-        var command = new DscSettingsCommand();
-
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get"]);
+        var result = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--get");
         var state = result.OutputState();
 
         // Assert
@@ -95,11 +92,8 @@ public class DscSettingsCommandTests
     [Test]
     public async Task DscSettingsResource_Export_Success()
     {
-        // Arrange
-        var command = new DscSettingsCommand();
-
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--export"]);
+        var result = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--export");
         var state = result.OutputState();
 
         // Assert
@@ -116,11 +110,8 @@ public class DscSettingsCommandTests
     [Test]
     public async Task DscSettingsResource_SetEmpty_Fail()
     {
-        // Arrange
-        var command = new DscSettingsCommand();
-
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--set", string.Empty);
 
         // Assert
         Assert.That(result.Success, Is.False);
@@ -134,11 +125,8 @@ public class DscSettingsCommandTests
     [Test]
     public async Task DscSettingsResource_TestEmpty_Fail()
     {
-        // Arrange
-        var command = new DscSettingsCommand();
-
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--test", string.Empty);
 
         // Assert
         Assert.That(result.Success, Is.False);
@@ -158,12 +146,11 @@ public class DscSettingsCommandTests
     {
         // Arrange
         this.ResetSettingsToDefaultValues();
-        var command = new DscSettingsCommand();
 
         // Part 1: Update settings repo name only
         {
             // Act
-            var setRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var setRepoName = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial));
             var stateAndDiff = setRepoName.OutputStateAndDiff();
 
             // Assert
@@ -177,7 +164,7 @@ public class DscSettingsCommandTests
         // Part 2: Now update settings repo owner only
         {
             // Act
-            var setRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var setRepoOwner = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial));
             var stateAndDiff = setRepoOwner.OutputStateAndDiff();
 
             // Assert
@@ -202,7 +189,6 @@ public class DscSettingsCommandTests
     {
         // Arrange
         this.ResetSettingsToDefaultValues();
-        var command = new DscSettingsCommand();
 
         // Part 1: Update settings repo name only
         {
@@ -211,7 +197,7 @@ public class DscSettingsCommandTests
             var currentSettingsBeforeExecute = this.CurrentSettings;
 
             // Act
-            var setRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var setRepoName = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--set", this.CreateInput(name: MockName, isPartial: isPartial));
             var stateAndDiff = setRepoName.OutputStateAndDiff();
 
             // Assert
@@ -230,7 +216,7 @@ public class DscSettingsCommandTests
             var currentSettingsBeforeExecute = this.CurrentSettings;
 
             // Act
-            var setRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var setRepoOwner = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--set", this.CreateInput(owner: MockOwner, isPartial: isPartial));
             var stateAndDiff = setRepoOwner.OutputStateAndDiff();
 
             // Assert
@@ -255,12 +241,11 @@ public class DscSettingsCommandTests
     {
         // Arrange
         this.ResetSettingsToDefaultValues();
-        var command = new DscSettingsCommand();
 
         // Part 1: Test settings repo name only
         {
             // Act
-            var testRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var testRepoName = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--test", this.CreateInput(name: MockName, isPartial: isPartial));
             var stateAndDiff = testRepoName.OutputStateAndDiff();
 
             // Assert
@@ -275,7 +260,7 @@ public class DscSettingsCommandTests
         // Part 2: Now test settings repo owner only
         {
             // Act
-            var testRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var testRepoOwner = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--test", this.CreateInput(owner: MockOwner, isPartial: isPartial));
             var stateAndDiff = testRepoOwner.OutputStateAndDiff();
 
             // Assert
@@ -301,7 +286,6 @@ public class DscSettingsCommandTests
     {
         // Arrange
         this.ResetSettingsToDefaultValues();
-        var command = new DscSettingsCommand();
 
         // Part 1: Test settings repo name only
         {
@@ -309,7 +293,7 @@ public class DscSettingsCommandTests
             this.UpdateSettings(name: MockName);
 
             // Act
-            var testRepoName = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(name: MockName, isPartial: isPartial)]);
+            var testRepoName = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--test", this.CreateInput(name: MockName, isPartial: isPartial));
             var stateAndDiff = testRepoName.OutputStateAndDiff();
 
             // Assert
@@ -327,7 +311,7 @@ public class DscSettingsCommandTests
             this.UpdateSettings(name: (isPartial ?? true) ? null : defaultRepoName, owner: MockOwner);
 
             // Act
-            var testRepoOwner = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--test", this.CreateInput(owner: MockOwner, isPartial: isPartial)]);
+            var testRepoOwner = await TestUtils.ExecuteDscCommandAsync(DscSettingsCommand.CommandName, "--test", this.CreateInput(owner: MockOwner, isPartial: isPartial));
             var stateAndDiff = testRepoOwner.OutputStateAndDiff();
 
             // Assert

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/DscSettingsCommandTests.cs
@@ -78,7 +78,7 @@ public class DscSettingsCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--get"]);
         var state = result.OutputState();
 
         // Assert
@@ -99,7 +99,7 @@ public class DscSettingsCommandTests
         var command = new DscSettingsCommand();
 
         // Act
-        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--export", string.Empty]);
+        var result = await TestUtils.ExecuteDscCommandAsync([command.CommandName, "--export"]);
         var state = result.OutputState();
 
         // Assert


### PR DESCRIPTION
# ⚙️ Settings DSC resource
## 📄 Get
```shell
PS C:\> wingetcreate dsc settings --get
{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"A","name":"B"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}}}
```

## 🖨️ Export
ℹ️ Settings resource Get and Export operation output states are identical.
```shell
PS C:\> wingetcreate dsc settings --export
{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"A","name":"B"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}}}
```

## 📝 Set
- Action `Full`: When action is set to Full, the specified settings will be update accordingly and the remaining settings will be set to their default values.
- Action `Partial`: When action is set to Partial, only the specified settings will be updated, and the remaining settings will remain unchanged.
### 🌕 Full
```shell
PS C:\> wingetcreate dsc settings --set '{"settings": { "Telemetry": { "disable": false }}, "action": "Full"}'
{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":false},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Full"}
["settings"]
```

### 🌗 Partial
```shell
PS C:\> wingetcreate dsc settings --set '{"settings": { "Telemetry": { "disable": true }}, "action": "Partial"}'
{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Partial"}
["settings"]
```

## 🧪 Test
- Action `Full`: When action is set to Full, the specified settings will be tested accordingly, and the remaining settings will be tested against their default values.
- Action `Partial`: When action is set to Partial, only the specified settings will be tested, and the remaining settings will be omitted from the test.
### 🌕 Full
```shell
PS C:\> wingetcreate dsc settings --test '{"settings": { "Telemetry": { "disable": false }}, "action": "Full"}'
{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Full","_inDesiredState":false}
["settings"]
```

### 🌗 Partial
```shell
PS C:\> wingetcreate dsc settings --test '{"settings": { "Telemetry": { "disable": false }}, "action": "Partial"}'
{"settings":{"$schema":"https://aka.ms/wingetcreate-settings.schema.0.1.json","Telemetry":{"disable":true},"CleanUp":{"intervalInDays":7,"disable":false},"WindowsPackageManagerRepository":{"owner":"microsoft","name":"winget-pkgs"},"Manifest":{"format":"yaml"},"Visual":{"anonymizePaths":true}},"action":"Partial","_inDesiredState":false}
["settings"]
```