### PR TITLE
Set User-Agent for HTTP requests

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -11,6 +11,7 @@ namespace Microsoft.WingetCreateCore
     using System.IO;
     using System.Linq;
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Security.Cryptography;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
@@ -46,7 +47,13 @@ namespace Microsoft.WingetCreateCore
             "nullsoft",
         };
 
-        private static HttpClient httpClient = new HttpClient();
+        private static HttpClient httpClient = new()
+        {
+            DefaultRequestHeaders =
+            {
+                UserAgent = { new ProductInfoHeaderValue("WinGetCreate", Utils.GetEntryAssemblyVersion()) },
+            },
+        };
 
         private enum MachineType
         {


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Are you working against an Issue?
	- Resolves #611 

PR sets the User-Agent request header in the [standard format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent) (`WinGetCreate/<Cli-Version>`)

For reference, the winget-cli user-agent is `winget-cli WindowsPackageManager/<CLI-Version> DesktopAppInstaller/<AppInstaller-Version>`. The comment in the source code mentions that `winget-cli` is there for historical reasons.

https://github.com/microsoft/winget-cli/blob/8115f41de486ef4c4a4cc064be57016ee5cbe44e/src/AppInstallerCommonCore/Runtime.cpp#L533-L543

## Validation

Manually verified that `wingetcreate new https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-9.12.25-x64.exe` works after settings the User-Agent

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/612)