### PR TITLE
Added --allow-unsecure-downloads option for HTTP downloads

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -308,9 +308,10 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <summary>
         /// Downloads the package file from the provided installer url.
         /// </summary>
-        /// /// <param name="installerUrl"> Installer Url to be downloaded. </param>
+        /// <param name="installerUrl">Installer Url to be downloaded. </param>
+        /// <param name="allowHttp">The flag indicating whether to allow HTTP downloads.</param>
         /// <returns>Package file.</returns>
-        protected static async Task<string> DownloadPackageFile(string installerUrl)
+        protected static async Task<string> DownloadPackageFile(string installerUrl, bool allowHttp)
         {
             Logger.InfoLocalized(nameof(Resources.DownloadInstaller_Message), installerUrl);
 
@@ -332,7 +333,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             try
             {
-                string packageFilePath = await PackageParser.DownloadFileAsync(installerUrl);
+                string packageFilePath = await PackageParser.DownloadFileAsync(installerUrl, allowHttp);
                 TelemetryManager.Log.WriteEvent(new DownloadInstallerEvent { IsSuccessful = true });
                 DownloadedInstallers.Add(installerUrl, packageFilePath);
                 return packageFilePath;
@@ -375,6 +376,16 @@ namespace Microsoft.WingetCreateCLI.Commands
                 else if (e is TaskCanceledException)
                 {
                     Logger.ErrorLocalized(nameof(Resources.DownloadConnectionTimeout_Error));
+                    return null;
+                }
+                else if (e is NotSupportedException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.DownloadProtocolNotSupported_Error));
+                    return null;
+                }
+                else if (e is DownloadHttpsOnlyException)
+                {
+                    Logger.ErrorLocalized(nameof(Resources.DownloadHttpsOnly_Error));
                     return null;
                 }
                 else

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -75,6 +75,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public string OutputDir { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to allow unsecure downloads.
+        /// </summary>
+        [Option("allow-unsecure-downloads", Required = false, HelpText = "AllowUnsecureDownloads_HelpText", ResourceType = typeof(Resources))]
+        public bool AllowUnsecureDownloads { get; set; }
+
+        /// <summary>
         /// Gets or sets the format of the output manifest files.
         /// </summary>
         [Option('f', "format", Required = false, HelpText = "ManifestFormat_HelpText", ResourceType = typeof(Resources))]
@@ -116,7 +122,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 foreach (var installerUrl in this.InstallerUrls)
                 {
-                    string packageFile = await DownloadPackageFile(installerUrl);
+                    string packageFile = await DownloadPackageFile(installerUrl, this.AllowUnsecureDownloads);
                     if (string.IsNullOrEmpty(packageFile))
                     {
                         return false;

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -122,6 +122,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         public override ManifestFormat Format { get => base.Format; set => base.Format = value; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to allow unsecure downloads.
+        /// </summary>
+        [Option("allow-unsecure-downloads", Required = false, HelpText = "AllowUnsecureDownloads_HelpText", ResourceType = typeof(Resources))]
+        public bool AllowUnsecureDownloads { get; set; }
+
+        /// <summary>
         /// Gets or sets the GitHub token used to submit a pull request on behalf of the user.
         /// </summary>
         [Option('t', "token", Required = false, HelpText = "GitHubToken_HelpText", ResourceType = typeof(Resources))]
@@ -406,7 +412,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             foreach (var installerUpdate in installerMetadataList)
             {
-                string packageFile = await DownloadPackageFile(installerUpdate.InstallerUrl);
+                string packageFile = await DownloadPackageFile(installerUpdate.InstallerUrl, this.AllowUnsecureDownloads);
                 if (string.IsNullOrEmpty(packageFile))
                 {
                     return null;
@@ -1005,7 +1011,7 @@ namespace Microsoft.WingetCreateCLI.Commands
             {
                 string url = Prompt.Input<string>(Resources.NewInstallerUrl_Message, null, null, new[] { FieldValidation.ValidateProperty(newInstaller, nameof(Installer.InstallerUrl)) });
 
-                string packageFile = await DownloadPackageFile(url);
+                string packageFile = await DownloadPackageFile(url, this.AllowUnsecureDownloads);
                 string archivePath = null;
 
                 if (string.IsNullOrEmpty(packageFile))

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -169,6 +169,15 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow unsecure downloads (HTTP) for this operation..
+        /// </summary>
+        public static string AllowUnsecureDownloads_HelpText {
+            get {
+                return ResourceManager.GetString("AllowUnsecureDownloads_HelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The manifest creation command line utility generates manifest for submitting apps to the Windows Package Manager repo..
         /// </summary>
         public static string AppDescription_HelpText {
@@ -745,11 +754,29 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Only HTTPS URLs are supported without &quot;--allow-unsecure-downloads&quot;.
+        /// </summary>
+        public static string DownloadHttpsOnly_Error {
+            get {
+                return ResourceManager.GetString("DownloadHttpsOnly_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Downloading and parsing: {0}....
         /// </summary>
         public static string DownloadInstaller_Message {
             get {
                 return ResourceManager.GetString("DownloadInstaller_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only HTTP and HTTPS URLs are supported..
+        /// </summary>
+        public static string DownloadProtocolNotSupported_Error {
+            get {
+                return ResourceManager.GetString("DownloadProtocolNotSupported_Error", resourceCulture);
             }
         }
         
@@ -862,7 +889,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Execute the Schema command.
+        ///   Looks up a localized string similar to Outputs schema of the resource.
         /// </summary>
         public static string DscSchema_HelpText {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -772,7 +772,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Only HTTP and HTTPS URLs are supported..
+        ///   Looks up a localized string similar to Only HTTPS URL are supported for downloads. Use the &quot;--allow-unsecure-downloads&quot; option to allow HTTP URLs..
         /// </summary>
         public static string DownloadProtocolNotSupported_Error {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.Designer.cs
+++ b/src/WingetCreateCLI/Properties/Resources.Designer.cs
@@ -754,7 +754,7 @@ namespace Microsoft.WingetCreateCLI.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Only HTTPS URLs are supported without &quot;--allow-unsecure-downloads&quot;.
+        ///   Looks up a localized string similar to Only HTTPS URLs are supported without &quot;--allow-unsecure-downloads&quot;..
         /// </summary>
         public static string DownloadHttpsOnly_Error {
             get {

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1475,7 +1475,7 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>Only HTTPS URL are supported for downloads. Use the "--allow-unsecure-downloads" option to allow HTTP URLs.</value>
   </data>
   <data name="DownloadHttpsOnly_Error" xml:space="preserve">
-    <value>Only HTTPS URLs are supported without "--allow-unsecure-downloads"</value>
+    <value>Only HTTPS URLs are supported without "--allow-unsecure-downloads".</value>
   </data>
   <data name="AllowUnsecureDownloads_HelpText" xml:space="preserve">
     <value>Allow unsecure downloads (HTTP) for this operation.</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1472,7 +1472,7 @@ Warning: Using this argument may result in the token being logged. Consider an a
     <value>The scope value for Microsoft Entra Id authentication</value>
   </data>
   <data name="DownloadProtocolNotSupported_Error" xml:space="preserve">
-    <value>Only HTTP and HTTPS URLs are supported.</value>
+    <value>Only HTTPS URL are supported for downloads. Use the "--allow-unsecure-downloads" option to allow HTTP URLs.</value>
   </data>
   <data name="DownloadHttpsOnly_Error" xml:space="preserve">
     <value>Only HTTPS URLs are supported without "--allow-unsecure-downloads"</value>

--- a/src/WingetCreateCLI/Properties/Resources.resx
+++ b/src/WingetCreateCLI/Properties/Resources.resx
@@ -1471,4 +1471,13 @@ Warning: Using this argument may result in the token being logged. Consider an a
   <data name="MicrosoftEntraIdAuthenticationInfo_Scope_KeywordDescription" xml:space="preserve">
     <value>The scope value for Microsoft Entra Id authentication</value>
   </data>
+  <data name="DownloadProtocolNotSupported_Error" xml:space="preserve">
+    <value>Only HTTP and HTTPS URLs are supported.</value>
+  </data>
+  <data name="DownloadHttpsOnly_Error" xml:space="preserve">
+    <value>Only HTTPS URLs are supported without "--allow-unsecure-downloads"</value>
+  </data>
+  <data name="AllowUnsecureDownloads_HelpText" xml:space="preserve">
+    <value>Allow unsecure downloads (HTTP) for this operation.</value>
+  </data>
 </root>

--- a/src/WingetCreateCore/Common/Exceptions/DownloadHttpsOnlyException.cs
+++ b/src/WingetCreateCore/Common/Exceptions/DownloadHttpsOnlyException.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Microsoft.WingetCreateCore.Common.Exceptions
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when the download URL is not HTTPS.
+    /// </summary>
+    public class DownloadHttpsOnlyException : Exception
+    {
+    }
+}

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -110,16 +110,19 @@ namespace Microsoft.WingetCreateCore
         /// Download file at specified URL to temp directory, unless it's already present.
         /// </summary>
         /// <param name="url">The URL of the file to be downloaded.</param>
+        /// <param name="allowHttp">Whether to allow HTTP downloads.</param>
         /// <param name="maxDownloadSize">The maximum file size in bytes to download.</param>
         /// <returns>Path of downloaded, or previously downloaded, file.</returns>
-        public static async Task<string> DownloadFileAsync(string url, long? maxDownloadSize = null)
+        public static async Task<string> DownloadFileAsync(string url, bool allowHttp, long? maxDownloadSize = null)
         {
+            ValidateUrl(url, allowHttp);
             var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
 
             int redirectCount = 0;
             while (response.StatusCode == System.Net.HttpStatusCode.Redirect && redirectCount < 2)
             {
                 var redirectUri = response.Headers.Location;
+                ValidateUrl(url, allowHttp);
                 response = await httpClient.GetAsync(redirectUri, HttpCompletionOption.ResponseHeadersRead);
                 redirectCount++;
             }
@@ -1108,6 +1111,24 @@ namespace Microsoft.WingetCreateCore
         private static string RemoveInvalidCharsFromString(string value)
         {
             return Regex.Replace(value, InvalidCharacters, string.Empty);
+        }
+
+        private static void ValidateUrl(string url, bool allowHttp)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri downloadUrl))
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (!allowHttp && downloadUrl.Scheme != Uri.UriSchemeHttps)
+            {
+                throw new DownloadHttpsOnlyException();
+            }
+
+            if (downloadUrl.Scheme != Uri.UriSchemeHttp && downloadUrl.Scheme != Uri.UriSchemeHttps)
+            {
+                throw new NotSupportedException();
+            }
         }
     }
 }

--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -1120,14 +1120,14 @@ namespace Microsoft.WingetCreateCore
                 throw new InvalidOperationException();
             }
 
-            if (!allowHttp && downloadUrl.Scheme != Uri.UriSchemeHttps)
-            {
-                throw new DownloadHttpsOnlyException();
-            }
-
             if (downloadUrl.Scheme != Uri.UriSchemeHttp && downloadUrl.Scheme != Uri.UriSchemeHttps)
             {
                 throw new NotSupportedException();
+            }
+
+            if (!allowHttp && downloadUrl.Scheme != Uri.UriSchemeHttps)
+            {
+                throw new DownloadHttpsOnlyException();
             }
         }
     }

--- a/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
+++ b/src/WingetCreateTests/WingetCreateTests/TestUtils.cs
@@ -139,7 +139,7 @@ namespace Microsoft.WingetCreateTests
         {
             string url = $"https://fakedomain.com/{filename}";
             SetMockHttpResponseContent(filename);
-            string downloadedPath = PackageParser.DownloadFileAsync(url).Result;
+            string downloadedPath = PackageParser.DownloadFileAsync(url, false).Result;
             return downloadedPath;
         }
 

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/NewCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/NewCommandTests.cs
@@ -18,6 +18,15 @@ namespace Microsoft.WingetCreateUnitTests
     public class NewCommandTests
     {
         /// <summary>
+        /// OneTimeSetup method for the New command unit tests.
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Logger.Initialize();
+        }
+
+        /// <summary>
         /// Verifies that the CLI errors out on an invalid installer URL.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -27,11 +36,44 @@ namespace Microsoft.WingetCreateUnitTests
             using StringWriter sw = new StringWriter();
             Console.SetOut(sw);
 
-            Logger.Initialize();
             NewCommand command = new NewCommand { InstallerUrls = new[] { "invalidUrl" } };
             ClassicAssert.IsFalse(await command.Execute(), "Command should have failed");
             string actual = sw.ToString();
             Assert.That(actual, Does.Contain(Resources.DownloadFile_Error), "Failed to catch invalid URL");
+        }
+
+        /// <summary>
+        /// Verifies that the CLI errors out on an invalid protocol.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task InvalidProtocol()
+        {
+            using StringWriter sw = new StringWriter();
+            Console.SetOut(sw);
+
+            NewCommand command = new NewCommand { InstallerUrls = new[] { "ftp://mock" }, AllowUnsecureDownloads = true };
+            ClassicAssert.IsFalse(await command.Execute(), "Command should have failed");
+            string actual = sw.ToString();
+            Assert.That(actual, Does.Contain(Resources.DownloadProtocolNotSupported_Error));
+            Assert.That(command.AllowUnsecureDownloads, Is.True);
+        }
+
+        /// <summary>
+        /// Tests that the command execution fails when using non-HTTPS URLs.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Test]
+        public async Task HttpsOnly()
+        {
+            using StringWriter sw = new StringWriter();
+            Console.SetOut(sw);
+
+            NewCommand command = new NewCommand { InstallerUrls = new[] { "http://mock" } };
+            ClassicAssert.IsFalse(await command.Execute(), "Command should have failed");
+            string actual = sw.ToString();
+            Assert.That(actual, Does.Contain(Resources.DownloadHttpsOnly_Error));
+            Assert.That(command.AllowUnsecureDownloads, Is.False);
         }
     }
 }


### PR DESCRIPTION
By default only HTTPS URL are supported for downloads. Use the "--allow-unsecure-downloads" option to allow HTTP URLs.

### Help message
```
PS C:\> wingetcreate new --help
...
  --allow-unsecure-downloads    Allow unsecure downloads (HTTP) for this operation.
...
```
### Unsecure download
```
PS C:\> wingetcreate new http://mock
Downloading and parsing: http://mock...
Failed to download installer.
Only HTTPS URLs are supported without "--allow-unsecure-downloads"
```
### Unsupported protocol
```
PS C:\> wingetcreate new ftp://mock
Downloading and parsing: ftp://mock...
Failed to download installer.
Only HTTPS URL are supported for downloads. Use the "--allow-unsecure-downloads" option to allow HTTP URLs.
```