### PR TITLE
Fix command syntax order in update command examples

### DIFF
--- a/doc/update.md
+++ b/doc/update.md
@@ -77,29 +77,29 @@ In some cases, the publisher of the package may use a different marketing versio
 
 Search for an existing manifest and update the version:
 
-`wingetcreate.exe update --version <Version> <PackageIdentifier>`
+`wingetcreate.exe update <PackageIdentifier> --version <Version>`
 
 Search for an existing manifest and update the installer url:
 
-`wingetcreate.exe update --urls <InstallerUrl1> <InstallerUrl2> <PackageIdentifier>`
+`wingetcreate.exe update <PackageIdentifier> --urls <InstallerUrl1> <InstallerUrl2>`
 
 Save and publish updated manifest:
 
-`wingetcreate.exe update --out <OutputDirectory> --token <GitHubPersonalAccessToken> --version <Version> <PackageIdentifier>`
+`wingetcreate.exe update <PackageIdentifier> --out <OutputDirectory> --token <GitHubPersonalAccessToken> --version <Version>`
 
 Override the architecture of an installer:
 
-`wingetcreate.exe update --urls '<InstallerUrl1>|<InstallerArchitecture>' --version <Version> <PackageIdentifier>`
+`wingetcreate.exe update <PackageIdentifier> --urls '<InstallerUrl1>|<InstallerArchitecture>' --version <Version>`
 
 Override the scope of an installer:
-`wingetcreate.exe update --urls '<InstallerUrl1>|<InstallerScope>' --version <Version> <PackageIdentifier>`
+`wingetcreate.exe update <PackageIdentifier> --urls '<InstallerUrl1>|<InstallerScope>' --version <Version>`
 
 > [!NOTE]
 > The <kbd>|</kbd> character is interpreted as the pipeline operator in most shells. To use the overrides, you should wrap the installer url in quotes.
 
 Update an existing manifest and submit PR to GitHub:
 
-`wingetcreate.exe update --submit --token <GitHubPersonalAccessToken> --urls <InstallerUrl1> <InstallerUrl2> --version <Version> <PackageIdentifier>`
+`wingetcreate.exe update <PackageIdentifier> --submit --token <GitHubPersonalAccessToken> --urls <InstallerUrl1> <InstallerUrl2> --version <Version>`
 
 ## Arguments
 


### PR DESCRIPTION
- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

Hello,
I noticed that the `wingetcreate update` command will not accept package id in the end of command despite provided example in its usage output.
See:
```
PS C:\temp> wingetcreate update --urls 'https://download.getupnote.com/app/UpNote%20Setup.exe|x64' UpNotePte.Ltd.UpNote
Windows Package Manager Manifest Creator v1.10.2.0
Copyright (c) Microsoft Corporation. All rights reserved.

The manifest creation command line utility generates manifest for submitting
apps to the Windows Package Manager repo.

The following commands are available:

USAGE:
Search for an existing manifest and update the installer url and version:
  wingetcreate.exe update --urls <InstallerUrl1> <InstallerUrl2> --version <Version>
  <PackageIdentifier>
Save and publish updated manifest:
  wingetcreate.exe update --out <OutputDirectory> --token <GitHubPersonalAccessToken> --version
  <Version> <PackageIdentifier>
Override the architecture of an installer:
  wingetcreate.exe update --urls '<InstallerUrl1>|<InstallerArchitecture>' --version <Version>
  <PackageIdentifier>
Override the scope of an installer:
  wingetcreate.exe update --urls '<InstallerUrl1>|<InstallerScope>' --version <Version>
  <PackageIdentifier>
Update an existing manifest and submit PR to GitHub:
  wingetcreate.exe update --submit --token <GitHubPersonalAccessToken> --urls <InstallerUrl1>
  <InstallerUrl2> --version <Version> <PackageIdentifier>

  -v, --version                 Version to be used when updating the package version field.
  -d, --display-version         Version to be used when updating the display version field. Version
                                provided in the installer URL arguments will take precedence over
                                this value.
  --release-notes-url           URL to be used when updating the release notes url field.
  --release-date                Date to be used when updating the release date field. Expected
                                format is "YYYY-MM-DD".
  -o, --out                     The output directory to store the generated manifests locally.
  -p, --prtitle                 The title of the pull request submitted to GitHub.
  -s, --submit                  Boolean value for submitting to the Windows Package Manager repo. If
                                true, updated manifest will be submitted directly using the provided
                                GitHub Token. Default is false.
  -r, --replace                 Boolean value for replacing an existing manifest from the Windows
                                Package Manager repo. Optionally provide a version or else the
                                latest version will be replaced. Default is false.
  -i, --interactive             Boolean value for making the update command interactive. If true,
                                the tool will prompt the user for input. Default is false.
  -f, --format                  Output format of the manifest. Default is "yaml".
  -t, --token                   GitHub personal access token used for direct submission to the
                                Windows Package Manager repo. If no token is provided, tool will
                                prompt for GitHub login credentials.

                                Warning: Using this argument may result in the token being logged.
                                Consider an alternative approach https://aka.ms/winget-create-token.
  -u, --urls                    Installer Url(s) used to extract relevant metadata for generating a
                                manifest
  PackageIdentifier (pos. 0)    Required. Package identifier used to lookup the existing manifest on
                                the Windows Package Manager repo. Id is case-sensitive.
  ReplaceVersion (pos. 1)       Optional. Package version used in conjunction with the replace
                                argument to replace an older version of the manifest from the
                                Windows Package Manager repo.

More help can be found at: https://aka.ms/winget-create
Privacy statement: https://aka.ms/winget-create-privacy

 A required value not bound to option name is missing.
PS C:\temp> wingetcreate update UpNotePte.Ltd.UpNote --urls 'https://download.getupnote.com/app/UpNote%20Setup.exe|x64' --submit
Retrieving latest manifest for UpNotePte.Ltd.UpNote
...

Manifest saved to C:\temp\manifests\u\UpNotePte\Ltd\UpNote\9.11.11

Manifest validation succeeded: True

Submitting pull request for manifest...

Pull request can be found here: https://github.com/microsoft/winget-pkgs/pull/xxx
```

I looked up the update.md document for clarification and in fact the `update.md` listed id to come as first parameter of winget update (`wingetcreate.exe update <id> [-u <urls>] [-v <version>] [-s] [-t <token>] [-o <output directory>] [-p <pull request title>] [-r] [<replace version>] [-d <display version>] [--release-date <release date> ] [--release-notes-url <release notes url>] [--format <format>] [--interactive] [--help]`) but usage examples section in the below diverges from that practice.

I have corrected the syntax order in the update command examples for clarity and consistency.

Please review and revise as necessary.

Thanks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/619)