### PR TITLE
Support specifying the fork owner

### DIFF
--- a/doc/submit.md
+++ b/doc/submit.md
@@ -18,6 +18,7 @@ The following arguments are available:
 | **-p, --prtitle** |  The title of the pull request submitted to GitHub.
 | **-r, --replace** |  Boolean value for replacing an existing manifest from the Windows Package Manager repo. Optionally provide a version or else the latest version will be replaced. Default is false.
 | **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
+| **--forkowner** |  The name of the owner of the fork to use for the pull request. |
 | **-?, --help** |  Gets additional help on this command. |
 
 If you have provided your [GitHub token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) on the command line with the **submit** command and the device is registered with GitHub, **Winget-Create** will submit your PR to [Windows Package Manager repo](https://docs.microsoft.com/windows/package-manager/).

--- a/doc/update.md
+++ b/doc/update.md
@@ -120,6 +120,7 @@ The following arguments are available:
 | **-i, --interactive** |  Boolean value for making the update command interactive. If true, the tool will prompt the user for input. Default is false. |
 | **-f,--format** |  Output format of the manifest. Default is "yaml". |
 | **--allow-unsecure-downloads** | Allow unsecure downloads (HTTP) for this operation. |
+| **--forkowner** |  The name of the owner of the fork to use for the pull request. |
 | **-t, --token** |  GitHub personal access token used for direct submission to the Windows Package Manager repo. If no token is provided, tool will prompt for GitHub login credentials. <br/>⚠️ _Using this argument may result in the token being logged. Consider an alternative approach https://aka.ms/winget-create-token._ |
 | **-?, --help** |  Gets additional help on this command. |
 

--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -107,6 +107,11 @@ namespace Microsoft.WingetCreateCLI.Commands
         public bool OpenPRInBrowser { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the name of the owner of the fork to use for the pull request.
+        /// </summary>
+        public virtual string ForkOwner { get; set; }
+
+        /// <summary>
         /// Gets the GitHubClient instance to use for interacting with GitHub from the CLI.
         /// </summary>
         internal GitHub GitHubClient { get; private set; }
@@ -742,8 +747,9 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// <param name="prTitle">Optional parameter specifying the title for the pull request.</param>
         /// <param name="shouldReplace">Optional parameter specifying whether the new submission should replace an existing manifest.</param>
         /// <param name="replaceVersion">Optional parameter specifying the version of the manifest to be replaced.</param>
+        /// <param name="forkOwner">Optional parameter specifying the name of the owner of the fork.</param>
         /// <returns>A <see cref="Task"/> representing the success of the asynchronous operation.</returns>
-        protected async Task<bool> GitHubSubmitManifests(Manifests manifests, string prTitle = null, bool shouldReplace = false, string replaceVersion = null)
+        protected async Task<bool> GitHubSubmitManifests(Manifests manifests, string prTitle = null, bool shouldReplace = false, string replaceVersion = null, string forkOwner = null)
         {
             // Community repo only supports yaml submissions.
             if (this.WingetRepo == DefaultWingetRepo &&
@@ -765,7 +771,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             try
             {
-                PullRequest pullRequest = await this.GitHubClient.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, prTitle, shouldReplace, replaceVersion);
+                PullRequest pullRequest = await this.GitHubClient.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, prTitle, shouldReplace, replaceVersion, forkOwner);
                 this.PullRequestNumber = pullRequest.Number;
                 PullRequestEvent pullRequestEvent = new PullRequestEvent { IsSuccessful = true, PullRequestNumber = pullRequest.Number };
                 TelemetryManager.Log.WriteEvent(pullRequestEvent);

--- a/src/WingetCreateCLI/Commands/NewCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewCommand.cs
@@ -284,7 +284,8 @@ namespace Microsoft.WingetCreateCLI.Commands
                     {
                         return commandEvent.IsSuccessful = await this.GitHubSubmitManifests(
                             manifests,
-                            this.GetPRTitle(manifests));
+                            this.GetPRTitle(manifests),
+                            forkOwner: this.ForkOwner);
                     }
 
                     return false;

--- a/src/WingetCreateCLI/Commands/NewLocaleCommand.cs
+++ b/src/WingetCreateCLI/Commands/NewLocaleCommand.cs
@@ -248,7 +248,8 @@ namespace Microsoft.WingetCreateCLI.Commands
                         return await this.LoadGitHubClient(true) ?
                             (commandEvent.IsSuccessful = await this.GitHubSubmitManifests(
                                 originalManifests,
-                                $"Add locale: {originalManifests.VersionManifest.PackageIdentifier} version {originalManifests.VersionManifest.PackageVersion}"))
+                                $"Add locale: {originalManifests.VersionManifest.PackageIdentifier} version {originalManifests.VersionManifest.PackageVersion}",
+                                forkOwner: this.ForkOwner))
                             : false;
                     }
                     else

--- a/src/WingetCreateCLI/Commands/SubmitCommand.cs
+++ b/src/WingetCreateCLI/Commands/SubmitCommand.cs
@@ -122,7 +122,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return false;
                 }
 
-                return await this.GitHubSubmitManifests(manifests, this.PRTitle, this.Replace, this.ReplaceVersion);
+                return await this.GitHubSubmitManifests(manifests, this.PRTitle, this.Replace, this.ReplaceVersion, this.ForkOwner);
             }
             else if (Directory.Exists(expandedPath) && ValidateManifest(expandedPath, this.Format))
             {
@@ -134,7 +134,7 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return false;
                 }
 
-                return await this.GitHubSubmitManifests(manifests, this.PRTitle, this.Replace, this.ReplaceVersion);
+                return await this.GitHubSubmitManifests(manifests, this.PRTitle, this.Replace, this.ReplaceVersion, this.ForkOwner);
             }
             else
             {

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -310,7 +310,8 @@ namespace Microsoft.WingetCreateCLI.Commands
                             updatedManifests,
                             this.GetPRTitle(updatedManifests, originalManifests),
                             this.Replace,
-                            this.ReplaceVersion))
+                            this.ReplaceVersion,
+                            this.ForkOwner))
                         : false;
                 }
 

--- a/src/WingetCreateCLI/Commands/UpdateLocaleCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateLocaleCommand.cs
@@ -179,7 +179,8 @@ namespace Microsoft.WingetCreateCLI.Commands
                         return await this.LoadGitHubClient(true) ?
                             (commandEvent.IsSuccessful = await this.GitHubSubmitManifests(
                                 originalManifests,
-                                $"Update locale: {originalManifests.VersionManifest.PackageIdentifier} version {originalManifests.VersionManifest.PackageVersion}"))
+                                $"Update locale: {originalManifests.VersionManifest.PackageIdentifier} version {originalManifests.VersionManifest.PackageVersion}",
+                                forkOwner: this.ForkOwner))
                             : false;
                     }
                     else

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -139,8 +139,9 @@ namespace Microsoft.WingetCreateCore.Common
         /// <param name="prTitle">Optional parameter specifying the title for the pull request.</param>
         /// <param name="shouldReplace">Optional parameter specifying whether the new submission should replace an existing manifest.</param>
         /// <param name="replaceVersion">Optional parameter specifying the version of the manifest to be replaced.</param>
+        /// <param name="forkOwner">Optional parameter specifying the name of the owner of the fork.</param>
         /// <returns>Pull request object.</returns>
-        public Task<PullRequest> SubmitPullRequestAsync(Manifests manifests, bool submitToFork, string prTitle = null, bool shouldReplace = false, string replaceVersion = null)
+        public Task<PullRequest> SubmitPullRequestAsync(Manifests manifests, bool submitToFork, string prTitle = null, bool shouldReplace = false, string replaceVersion = null, string forkOwner = null)
         {
             Dictionary<string, string> contents = new Dictionary<string, string>();
             string id;
@@ -164,7 +165,7 @@ namespace Microsoft.WingetCreateCore.Common
                 contents.Add($"{id}.locale.{manifests.DefaultLocaleManifest.PackageLocale}", manifests.DefaultLocaleManifest.ToManifestString());
             }
 
-            return this.SubmitPRAsync(id, version, contents, submitToFork, prTitle, shouldReplace, replaceVersion);
+            return this.SubmitPRAsync(id, version, contents, submitToFork, prTitle, shouldReplace, replaceVersion, forkOwner);
         }
 
         /// <summary>
@@ -301,7 +302,7 @@ namespace Microsoft.WingetCreateCore.Common
             return null;
         }
 
-        private async Task<PullRequest> SubmitPRAsync(string packageId, string version, Dictionary<string, string> contents, bool submitToFork, string prTitle = null, bool shouldReplace = false, string replaceVersion = null)
+        private async Task<PullRequest> SubmitPRAsync(string packageId, string version, Dictionary<string, string> contents, bool submitToFork, string prTitle = null, bool shouldReplace = false, string replaceVersion = null, string forkOwner = null)
         {
             bool createdRepo = false;
             Repository repo;
@@ -310,11 +311,17 @@ namespace Microsoft.WingetCreateCore.Common
             {
                 try
                 {
-                    var user = await this.github.User.Current();
-                    repo = await this.github.Repository.Get(user.Login, this.wingetRepo);
+                    if (forkOwner == null)
+                    {
+                        var user = await this.github.User.Current();
+                        forkOwner = user.Login;
+                    }
+
+                    repo = await this.github.Repository.Get(forkOwner, this.wingetRepo);
                 }
                 catch (NotFoundException)
                 {
+                    // This will only work for GitHub users and not if the GitHub token is associated with a GitHub app
                     repo = await this.github.Repository.Forks.Create(this.wingetRepoOwner, this.wingetRepo, new NewRepositoryFork());
                     createdRepo = true;
                 }


### PR DESCRIPTION
Allow specifying the owner for a fork, instead of assuming the GitHub token is associated with a user, to allow organizations to fork a repository and have a GitHub app installed into that repository to submit pull requests.

The use case here is that we want to fork [microsoft/winget-pkg](https://github.com/microsoft/winget-pkgs) to `grafana/winget-pkg`, and then use a GitHub app installed into that fork to submit pull requests for new manifests.

- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

I haven't yet manually verified this works, and haven't yet added unit tests. Just floating now to see if this is functionality that would be accepted.
