### PR TITLE
Bump schema & binary version to 1.12

### DIFF
--- a/src/WingetCreateCLI/WingetCreateCLI.csproj
+++ b/src/WingetCreateCLI/WingetCreateCLI.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
     <AssemblyName>WingetCreateCLI</AssemblyName>
     <RootNamespace>Microsoft.WingetCreateCLI</RootNamespace>
-    <Version>1.10</Version>
+    <Version>1.12</Version>
     <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/DefaultLocaleManifestModels.cs
@@ -133,7 +133,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
     }
 
     /// <summary>
-    /// A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.10.0
+    /// A representation of a multiple-file manifest representing a default app metadata in the OWC. v1.12.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class DefaultLocaleManifest
@@ -335,7 +335,7 @@ namespace Microsoft.WingetCreateCore.Models.DefaultLocale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.10.0";
+        public string ManifestVersion { get; set; } = "1.12.0";
 
 
 

--- a/src/WingetCreateCore/Models/InstallerManifestModels.cs
+++ b/src/WingetCreateCore/Models/InstallerManifestModels.cs
@@ -60,6 +60,10 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         Portable = 10,
 
 
+        [System.Runtime.Serialization.EnumMember(Value = @"font")]
+        Font = 11,
+
+
     }
 
     /// <summary>
@@ -103,6 +107,10 @@ namespace Microsoft.WingetCreateCore.Models.Installer
 
         [System.Runtime.Serialization.EnumMember(Value = @"portable")]
         Portable = 8,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"font")]
+        Font = 9,
 
 
     }
@@ -644,7 +652,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
     }
 
     /// <summary>
-    /// A representation of a single-file manifest representing an app installers in the OWC. v1.10.0
+    /// A representation of a single-file manifest representing an app installers in the OWC. v1.12.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class InstallerManifest
@@ -813,7 +821,7 @@ namespace Microsoft.WingetCreateCore.Models.Installer
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.10.0";
+        public string ManifestVersion { get; set; } = "1.12.0";
 
 
 

--- a/src/WingetCreateCore/Models/LocaleManifestModels.cs
+++ b/src/WingetCreateCore/Models/LocaleManifestModels.cs
@@ -133,7 +133,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
     }
 
     /// <summary>
-    /// A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.10.0
+    /// A representation of a multiple-file manifest representing app metadata in other locale in the OWC. v1.12.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class LocaleManifest
@@ -324,7 +324,7 @@ namespace Microsoft.WingetCreateCore.Models.Locale
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.10.0";
+        public string ManifestVersion { get; set; } = "1.12.0";
 
 
 

--- a/src/WingetCreateCore/Models/SingletonManifestModels.cs
+++ b/src/WingetCreateCore/Models/SingletonManifestModels.cs
@@ -183,6 +183,10 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         Portable = 10,
 
 
+        [System.Runtime.Serialization.EnumMember(Value = @"font")]
+        Font = 11,
+
+
     }
 
     /// <summary>
@@ -226,6 +230,10 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
 
         [System.Runtime.Serialization.EnumMember(Value = @"portable")]
         Portable = 8,
+
+
+        [System.Runtime.Serialization.EnumMember(Value = @"font")]
+        Font = 9,
 
 
     }
@@ -767,7 +775,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
     }
 
     /// <summary>
-    /// A representation of a single-file manifest representing an app in the OWC. v1.10.0
+    /// A representation of a single-file manifest representing an app in the OWC. v1.12.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class SingletonManifest
@@ -1098,7 +1106,7 @@ namespace Microsoft.WingetCreateCore.Models.Singleton
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.10.0";
+        public string ManifestVersion { get; set; } = "1.12.0";
 
 
 

--- a/src/WingetCreateCore/Models/VersionManifestModels.cs
+++ b/src/WingetCreateCore/Models/VersionManifestModels.cs
@@ -10,7 +10,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
     #pragma warning disable // Disable all warnings
 
     /// <summary>
-    /// A representation of a multi-file manifest representing an app version in the OWC. v1.10.0
+    /// A representation of a multi-file manifest representing an app version in the OWC. v1.12.0
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "11.0.0.0 (Newtonsoft.Json v13.0.0.0)")]
     public partial class VersionManifest
@@ -55,7 +55,7 @@ namespace Microsoft.WingetCreateCore.Models.Version
         [Newtonsoft.Json.JsonProperty("ManifestVersion", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
         [System.ComponentModel.DataAnnotations.RegularExpression(@"^(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){2}$")]
-        public string ManifestVersion { get; set; } = "1.10.0";
+        public string ManifestVersion { get; set; } = "1.12.0";
 
 
 

--- a/src/WingetCreateCore/WingetCreateCore.csproj
+++ b/src/WingetCreateCore/WingetCreateCore.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
     <PackageReference Include="Microsoft.Msix.Utils" Version="2.1.1" />
     <!--https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#generatepathproperty-->
-    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.10.340" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="1.12.350" GeneratePathProperty="true" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="NSwag.MSBuild" Version="14.0.3">
@@ -48,11 +48,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.defaultLocale.1.10.0.json" ModelName="DefaultLocale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.installer.1.10.0.json" ModelName="Installer" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.locale.1.10.0.json" ModelName="Locale" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.version.1.10.0.json" ModelName="Version" />
-    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.10.0\manifest.singleton.1.10.0.json" ModelName="Singleton" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.12.0\manifest.defaultLocale.1.12.0.json" ModelName="DefaultLocale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.12.0\manifest.installer.1.12.0.json" ModelName="Installer" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.12.0\manifest.locale.1.12.0.json" ModelName="Locale" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.12.0\manifest.version.1.12.0.json" ModelName="Version" />
+    <SchemaFiles Include="$(PkgMicrosoft_WindowsPackageManager_Utils)\content\schemas\JSON\manifests\v1.12.0\manifest.singleton.1.12.0.json" ModelName="Singleton" />
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Inputs="@(SchemaFiles)" Outputs="@(SchemaFiles -> '$(ProjectDir)Models\%(ModelName)ManifestModels.cs')">

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_12.json
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullJsonSingleton1_12.json
@@ -1,0 +1,157 @@
+﻿{
+  "PackageIdentifier": "TestPublisher.FullYamlSingleton1_12",
+  "PackageVersion": "0.1.2.3",
+  "PackageLocale": "en-US",
+  "DefaultLocale": "en-US",
+  "Publisher": "TestPublisher",
+  "PublisherUrl": "https://fakeTestUrl.com",
+  "PublisherSupportUrl": "https://fakeTestUrl.com",
+  "PrivacyUrl": "https://fakeTestUrl.com",
+  "Author": "fakeAuthor",
+  "PackageName": "Full Singleton 1.12 Test",
+  "PackageUrl": "https://fakeTestUrl.com",
+  "License": "MIT",
+  "LicenseUrl": "https://fakeTestUrl.com",
+  "Copyright": "fakeCopyright",
+  "CopyrightUrl": "https://fakeTestUrl.com",
+  "ShortDescription": "A manifest used to verify that all fields from a full 1.12 singleton manifest can be deserialized and updated.",
+  "Description": "A manifest used to verify that all fields from a full 1.12 singleton manifest can be deserialized and updated.",
+  "Moniker": "testMoniker",
+  "Tags": [
+    "testSingleton"
+  ],
+  "Agreements": [
+    {
+      "AgreementLabel": "fakeAgreementLabel",
+      "AgreementUrl": "https://fakeTestUrl.com",
+      "Agreement": "fakeAgreementContent"
+    }
+  ],
+  "ReleaseNotes": "fakeReleaseNotes",
+  "ReleaseNotesUrl": "https://fakeTestUrl.com",
+  "PurchaseUrl": "https://fakeTestUrl.com",
+  "InstallationNotes": "fakeInstallationNotes",
+  "Documentations": [
+    {
+      "DocumentLabel": "fakeDocumentLabel"
+    },
+    {
+      "DocumentUrl": "fakeDocumentUrl"
+    }
+  ],
+  "Icons": [
+    {
+      "IconUrl": "https://fakeTestIcon",
+      "IconFileType": "png",
+      "IconResolution": "32x32",
+      "IconTheme": "light",
+      "IconSha256": "69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8321"
+    }
+  ],
+  "Installers": [
+    {
+      "MinimumOSVersion": "10.0.0.0",
+      "Architecture": "x64",
+      "InstallerUrl": "https://fakedomain.com/WingetCreateTestExeInstaller.exe",
+      "InstallerType": "exe",
+      "InstallerSha256": "A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC",
+      "ProductCode": "FakeProductCode",
+      "PackageFamilyName": "FakePackageFamilyName",
+      "InstallModes": [
+        "silent"
+      ],
+      "InstallerSwitches": {
+        "Silent": "/s",
+        "Upgrade": "/u",
+        "Repair": "/r"
+      },
+      "InstallerSuccessCodes": [
+        1
+      ],
+      "ExpectedReturnCodes": [
+        {
+          "InstallerReturnCode": 123,
+          "ReturnResponse": "alreadyInstalled",
+          "ReturnResponseUrl": "https://fakeTestUrl.com"
+        }
+      ],
+      "UpgradeBehavior": "install",
+      "Commands": [
+        "fakeCommand"
+      ],
+      "Protocols": [
+        "fakeProtocol"
+      ],
+      "FileExtensions": [
+        ".exe"
+      ],
+      "Dependencies": {
+        "WindowsFeatures": [
+          "fakeValue"
+        ],
+        "WindowsLibraries": [
+          "fakeValue"
+        ],
+        "PackageDependencies": [
+          {
+            "MinimumVersion": "10.0.0.0"
+          }
+        ],
+        "ExternalDependencies": [
+          "fakeValue"
+        ]
+      },
+      "Markets": {
+        "AllowedMarkets": [
+          "fakeAllowedMarket"
+        ],
+        "ExcludedMarkets": [
+          "fakeExcludedMarket"
+        ]
+      },
+      "InstallerAbortsTerminal": true,
+      "InstallLocationRequired": true,
+      "RequireExplicitUpgrade": true,
+      "UnsupportedOSArchitectures": [
+        "arm64"
+      ],
+      "AppsAndFeaturesEntries": [
+        {
+          "DisplayName": "testName",
+          "Publisher": "testPublisher",
+          "DisplayVersion": "testVersion",
+          "UpgradeCode": "fakeProductCode"
+        }
+      ],
+      "ElevationRequirement": "elevationRequired",
+      "ReleaseDate": "2022-01-01",
+      "DisplayInstallWarnings": true,
+      "UnsupportedArguments": [
+        "log",
+        "location"
+      ],
+      "NestedInstallerFiles": [
+        {
+          "RelativeFilePath": "RelativeFilePath",
+          "PortableCommandAlias": "PortableCommandAlias"
+        }
+      ],
+      "InstallationMetadata": {
+        "DefaultInstallLocation": "%ProgramFiles%\\TestApp",
+        "Files": [
+          {
+            "RelativeFilePath": "main.exe",
+            "FileSha256": "69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82",
+            "FileType": "launch",
+            "InvocationParameter": "/arg"
+          }
+        ]
+      },
+      "DownloadCommandProhibited": true,
+      "RepairBehavior": "modify",
+      "ArchiveBinariesDependOnPath": true
+    }
+  ],
+  "ManifestType": "singleton",
+  "ManifestVersion": "1.12.0"
+}

--- a/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_12.yaml
+++ b/src/WingetCreateTests/WingetCreateTests/Resources/TestPublisher.FullYamlSingleton1_12.yaml
@@ -1,0 +1,116 @@
+﻿PackageIdentifier: TestPublisher.FullYamlSingleton1_12
+PackageVersion: 0.1.2.3
+PackageLocale: en-US
+DefaultLocale: en-US
+Publisher: TestPublisher
+PublisherUrl: https://fakeTestUrl.com
+PublisherSupportUrl: https://fakeTestUrl.com
+PrivacyUrl: https://fakeTestUrl.com
+Author: fakeAuthor
+PackageName: Full Singleton 1.12 Test
+PackageUrl: https://fakeTestUrl.com
+License: MIT
+LicenseUrl: https://fakeTestUrl.com
+Copyright: fakeCopyright
+CopyrightUrl: https://fakeTestUrl.com
+ShortDescription: A manifest used to verify that all fields from a full 1.12 singleton manifest can be deserialized and updated.
+Description: A manifest used to verify that all fields from a full 1.12 singleton manifest can be deserialized and updated.
+Moniker: testMoniker
+Tags:
+- testSingleton
+Agreements:
+- AgreementLabel: fakeAgreementLabel
+  AgreementUrl: https://fakeTestUrl.com
+  Agreement: fakeAgreementContent
+ReleaseNotes: fakeReleaseNotes
+ReleaseNotesUrl: https://fakeTestUrl.com
+PurchaseUrl: https://fakeTestUrl.com
+InstallationNotes: fakeInstallationNotes
+Documentations:
+- DocumentLabel: fakeDocumentLabel
+- DocumentUrl: fakeDocumentUrl
+Icons:
+  - IconUrl: https://fakeTestIcon
+    IconFileType: png
+    IconResolution: 32x32
+    IconTheme: light
+    IconSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8321
+Installers:
+- MinimumOSVersion: 10.0.0.0
+  Architecture: x64
+  InstallerUrl: https://fakedomain.com/WingetCreateTestExeInstaller.exe
+  InstallerType: exe
+  InstallerSha256: A7803233EEDB6A4B59B3024CCF9292A6FFFB94507DC998AA67C5B745D197A5DC
+  ProductCode: FakeProductCode
+  PackageFamilyName: FakePackageFamilyName
+  InstallModes:
+  - silent
+  InstallerSwitches:
+    Silent: /s
+    Upgrade: /u
+    Repair: /r
+  InstallerSuccessCodes:
+  - 1
+  ExpectedReturnCodes:
+  - InstallerReturnCode: 123
+    ReturnResponse: alreadyInstalled
+    ReturnResponseUrl: https://fakeTestUrl.com
+  UpgradeBehavior: install
+  Commands:
+  - fakeCommand
+  Protocols:
+  - fakeProtocol
+  FileExtensions:
+  - .exe
+  Dependencies:
+    WindowsFeatures:
+    - fakeValue
+    WindowsLibraries:
+    - fakeValue
+    PackageDependencies:
+    - MinimumVersion: 10.0.0.0
+    ExternalDependencies:
+    - fakeValue
+  Markets:
+    AllowedMarkets:
+    - fakeAllowedMarket
+    ExcludedMarkets:
+    - fakeExcludedMarket
+  InstallerAbortsTerminal: true
+  InstallLocationRequired: true
+  RequireExplicitUpgrade: true
+  UnsupportedOSArchitectures:
+  - arm64
+  AppsAndFeaturesEntries:
+  - DisplayName: testName
+    Publisher: testPublisher
+    DisplayVersion: testVersion
+    UpgradeCode: fakeProductCode
+  ElevationRequirement: elevationRequired
+  ReleaseDate: 1-1-2022
+  DisplayInstallWarnings: true
+  UnsupportedArguments:
+  - log
+  - location
+  NestedInstallerFiles:
+  - RelativeFilePath: RelativeFilePath
+    PortableCommandAlias: PortableCommandAlias
+  InstallationMetadata:
+    DefaultInstallLocation: "%ProgramFiles%\\TestApp"
+    Files:
+    - RelativeFilePath: "main.exe"
+      FileSha256: 69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82
+      FileType: launch
+      InvocationParameter: "/arg"
+  DownloadCommandProhibited: true
+  RepairBehavior: modify
+  ArchiveBinariesDependOnPath: true
+#   `winget validate` fails if this field is used as it requires verified publisher feature
+#   Uncomment when verified publisher feature is implemented
+#   Authentication:
+#     AuthenticationType: microsoftEntraId
+#     MicrosoftEntraIdAuthenticationInfo:
+#       Scope: DefaultScope
+#       Resource: DefaultResource
+ManifestType: singleton
+ManifestVersion: 1.12.0

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/UpdateCommandTests.cs
@@ -993,6 +993,19 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Ensures that all fields from the YAML Singleton v1.12 manifest can be deserialized and updated correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateFullYamlSingletonVersion1_12()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller, TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullYamlSingleton1_12", null, this.tempPath, null);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            ClassicAssert.IsNotNull(updatedManifests, "Command should have succeeded");
+        }
+
+        /// <summary>
         /// Ensures that all fields from the JSON Singleton v1.1 manifest can be deserialized and updated correctly.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
@@ -1097,13 +1110,26 @@ namespace Microsoft.WingetCreateUnitTests
         }
 
         /// <summary>
+        /// Ensures that all fields from the Singleton JSON v1.12 manifest can be deserialized and updated correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Test]
+        public async Task UpdateFullJsonSingletonVersion1_12()
+        {
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller, TestConstants.TestExeInstaller);
+            (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullJsonSingleton1_12", null, this.tempPath, null, manifestFormat: ManifestFormat.Json);
+            var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
+            ClassicAssert.IsNotNull(updatedManifests, "Command should have succeeded");
+        }
+
+        /// <summary>
         /// Ensures that version specific fields are reset after an update when using YAML manifests.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         [Test]
         public async Task UpdateResetsVersionSpecificFields_Yaml()
         {
-            TestUtils.InitializeMockDownloads(TestConstants.TestExeInstaller);
+            TestUtils.InitializeMockDownloads(TestConstants.TestZipInstaller, TestConstants.TestExeInstaller);
             (UpdateCommand command, var initialManifestContent) = GetUpdateCommandAndManifestData("TestPublisher.FullYamlSingleton1_1", null, this.tempPath, null);
             var updatedManifests = await RunUpdateCommand(command, initialManifestContent);
             ClassicAssert.IsNotNull(updatedManifests, "Command should have succeeded");

--- a/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
+++ b/src/WingetCreateTests/WingetCreateTests/WingetCreateTests.csproj
@@ -63,6 +63,12 @@
     <None Update="Resources\Multifile.Json.MsixTest\Multifile.Json.MsixTest.locale.en-US.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\TestPublisher.FullJsonSingleton1_12.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\TestPublisher.FullYamlSingleton1_12.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\TestPublisher.FullJsonSingleton1_10.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

PR bumps winget-create app version & manifest schema version to 1.12.0 & adds the relevant test cases for serialization / de-serialization. This PR does not include the implementation for creation/upgrade of font manifests so that's why `InstallerType|NestedInstallerType: font` is not included in the manifests for 1.12.0 test cases


-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/631)