### PR TITLE
Added support for optional Authorization and Accept headers via environment variables.

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -47,13 +47,7 @@ namespace Microsoft.WingetCreateCore
             "nullsoft",
         };
 
-        private static HttpClient httpClient = new()
-        {
-            DefaultRequestHeaders =
-            {
-                UserAgent = { new ProductInfoHeaderValue("WinGetCreate", Utils.GetEntryAssemblyVersion()) },
-            },
-        };
+        private static HttpClient httpClient = CreateHttpClient();
 
         private enum MachineType
         {
@@ -85,6 +79,33 @@ namespace Microsoft.WingetCreateCore
         {
             httpClient.Dispose();
             httpClient = httpMessageHandler != null ? new HttpClient(httpMessageHandler) : new HttpClient();
+            SetDefaultHeaders(httpClient);
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient();
+            SetDefaultHeaders(client);
+            return client;
+        }
+
+        private static void SetDefaultHeaders(HttpClient client)
+        {
+            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("WinGetCreate", Utils.GetEntryAssemblyVersion()));
+
+            // Add Authorization header from environment variable, if present
+            string authToken = Environment.GetEnvironmentVariable("WINGET_CREATE_HTTP_CLIENT_AUTH_TOKEN");
+            if (!string.IsNullOrEmpty(authToken))
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+            }
+
+            // Add Accept header from environment variable, if present
+            string acceptHeader = Environment.GetEnvironmentVariable("WINGET_CREATE_HTTP_CLIENT_ACCEPT_HEADER");
+            if (!string.IsNullOrEmpty(acceptHeader))
+            {
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptHeader));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #633.

This allows me to call:
```powershell
$env:WINGET_CREATE_HTTP_CLIENT_AUTH_TOKEN = "{MY_PAT}"
$env:WINGET_CREATE_HTTP_CLIENT_ACCEPT_HEADER = "application/octet-stream"
winget new
```
Then provide an url such as: https://api.github.com/repos/myorg/privaterepo/releases/assets/ID
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/634)