### PR TITLE
Remove the space in "# yaml-language-server:" to slightly reduce filesizes.

### DIFF
--- a/src/WingetCreateCore/Serializers/YamlSerializer.cs
+++ b/src/WingetCreateCore/Serializers/YamlSerializer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.WingetCreateCore.Serializers
                 serialized.AppendLine($"# Created using {Serialization.ProducedBy}");
             }
 
-            string schemaTemplate = "# yaml-language-server: $schema=https://aka.ms/winget-manifest.{0}.{1}.schema.json";
+            string schemaTemplate = "#yaml-language-server: $schema=https://aka.ms/winget-manifest.{0}.{1}.schema.json";
 
             switch (value)
             {


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

I've been able to confirm through a large number of `winget validate (...)` usages for recent packages to Winget-pkgs of mine that Winget is fully able to handle `#yaml-language-server:` without a space.

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/641)