### PR TITLE
fix: handle resource errors using NativeErrorCode instead of localized message

### DIFF
--- a/src/WingetCreateCore/Common/PackageParser.cs
+++ b/src/WingetCreateCore/Common/PackageParser.cs
@@ -856,10 +856,10 @@ namespace Microsoft.WingetCreateCore
                 }
                 catch (Win32Exception err)
                 {
-                    if ((err.Message == "The specified resource type cannot be found in the image file."
-                        && err.NativeErrorCode == 1813) ||
-                        (err.Message == "The specified image file did not contain a resource section."
-                        && err.NativeErrorCode == 1812))
+                    const int ERROR_RESOURCE_DATA_NOT_FOUND = 1812;
+                    const int ERROR_RESOURCE_TYPE_NOT_FOUND = 1813;
+                    if (err.NativeErrorCode == ERROR_RESOURCE_DATA_NOT_FOUND ||
+                        err.NativeErrorCode == ERROR_RESOURCE_TYPE_NOT_FOUND)
                     {
                         installerTypeEnum = (baseInstaller.InstallerType == InstallerType.Portable ||
                                 baseInstaller.NestedInstallerType == NestedInstallerType.Portable) ?


### PR DESCRIPTION
This PR fixes an issue resource error were not handled correctly on non-English environments.

Previously, the code checked both `err.Message` and `err.NativeErrorCode`, which caused the logic to fail when the error message was localized.  
The screenshot below demonstrates that, on my environment, `err.Message` is displayed in Japanese.

<img width="2498" height="507" alt="2026-01-20 01 43 45" src="https://github.com/user-attachments/assets/2c679d64-b512-4ab3-a87d-b5f6b6bd268a" />

Now, the check relies solely on `err.NativeErrorCode` for the following cases:

- `1812` (`ERROR_RESOURCE_DATA_NOT_FOUND`)
- `1813` (`ERROR_RESOURCE_TYPE_NOT_FOUND`)

This ensures consistent resource error handling regardless of the system language.


- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [] Are you working against an Issue?

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/646)