### PR TITLE
Fix build issues

### DIFF
--- a/pipelines/azure-pipelines.release.yml
+++ b/pipelines/azure-pipelines.release.yml
@@ -32,6 +32,10 @@ resources:
 extends:
   template: v2/Microsoft.Official.yml@templates
   parameters:
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+        Network: R1
     platform:
       name: 'windows_undocked'
 


### PR DESCRIPTION
This pull request introduces a new feature flag configuration for Windows host version in the Azure Pipelines release YAML file. The change adds explicit settings for the Windows host version and its network, which will help ensure consistency and control over the build environment.

Build environment configuration:

* Added a `featureFlags` section specifying `WindowsHostVersion` with `Version: 2022` and `Network: R1` in the `pipelines/azure-pipelines.release.yml` file.- [ ] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

-----

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/649)