### PR TITLE
Fix more positional function args

### DIFF
--- a/src/WingetCreateCLI/Commands/BaseCommand.cs
+++ b/src/WingetCreateCLI/Commands/BaseCommand.cs
@@ -741,12 +741,12 @@ namespace Microsoft.WingetCreateCLI.Commands
         /// Submits a pull request with multifile manifests using the user's GitHub access token.
         /// </summary>
         /// <param name="manifests">Wrapper object for manifest object models to be submitted.</param>
-        /// <param name="manifestRoot">Manifest root name.</param>
         /// <param name="prTitle">Optional parameter specifying the title for the pull request.</param>
         /// <param name="shouldReplace">Optional parameter specifying whether the new submission should replace an existing manifest.</param>
         /// <param name="replaceVersion">Optional parameter specifying the version of the manifest to be replaced.</param>
+        /// <param name="manifestRoot">Manifest root name.</param>
         /// <returns>A <see cref="Task"/> representing the success of the asynchronous operation.</returns>
-        protected async Task<bool> GitHubSubmitManifests(Manifests manifests, string manifestRoot = Constants.WingetManifestRoot, string prTitle = null, bool shouldReplace = false, string replaceVersion = null)
+        protected async Task<bool> GitHubSubmitManifests(Manifests manifests, string prTitle = null, bool shouldReplace = false, string replaceVersion = null, string manifestRoot = Constants.WingetManifestRoot)
         {
             // Community repo only supports yaml submissions.
             if (this.WingetRepo == DefaultWingetRepo &&
@@ -768,7 +768,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
             try
             {
-                Octokit.PullRequest pullRequest = await this.GitHubClient.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, manifestRoot, prTitle, shouldReplace, replaceVersion);
+                Octokit.PullRequest pullRequest = await this.GitHubClient.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, prTitle, shouldReplace, replaceVersion, manifestRoot);
                 this.PullRequestNumber = pullRequest.Number;
                 PullRequestEvent pullRequestEvent = new PullRequestEvent { IsSuccessful = true, PullRequestNumber = pullRequest.Number };
                 TelemetryManager.Log.WriteEvent(pullRequestEvent);

--- a/src/WingetCreateCLI/Commands/SubmitCommand.cs
+++ b/src/WingetCreateCLI/Commands/SubmitCommand.cs
@@ -131,7 +131,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 // TODO: Add Font Root Support
                 // See issue: See issue https://github.com/microsoft/winget-create/issues/647
-                return await this.GitHubSubmitManifests(manifests, this.PRTitle, WingetCreateCore.Common.Constants.WingetManifestRoot, this.Replace, this.ReplaceVersion);
+                return await this.GitHubSubmitManifests(manifests, this.PRTitle, this.Replace, this.ReplaceVersion, WingetCreateCore.Common.Constants.WingetManifestRoot);
             }
             else if (Directory.Exists(expandedPath) && ValidateManifest(expandedPath, this.Format))
             {
@@ -145,7 +145,7 @@ namespace Microsoft.WingetCreateCLI.Commands
 
                 // TODO: Add Font Root Support
                 // See issue: See issue https://github.com/microsoft/winget-create/issues/647
-                return await this.GitHubSubmitManifests(manifests, this.PRTitle, WingetCreateCore.Common.Constants.WingetManifestRoot, this.Replace, this.ReplaceVersion);
+                return await this.GitHubSubmitManifests(manifests, this.PRTitle, this.Replace, this.ReplaceVersion, WingetCreateCore.Common.Constants.WingetManifestRoot);
             }
             else
             {

--- a/src/WingetCreateCLI/Commands/UpdateCommand.cs
+++ b/src/WingetCreateCLI/Commands/UpdateCommand.cs
@@ -321,10 +321,10 @@ namespace Microsoft.WingetCreateCLI.Commands
                     return await this.LoadGitHubClient(true)
                         ? (commandEvent.IsSuccessful = await this.GitHubSubmitManifests(
                             updatedManifests,
-                            Constants.WingetManifestRoot,
                             this.GetPRTitle(updatedManifests, originalManifests),
                             this.Replace,
-                            this.ReplaceVersion))
+                            this.ReplaceVersion,
+                            Constants.WingetManifestRoot))
                         : false;
                 }
 

--- a/src/WingetCreateCore/Common/GitHub.cs
+++ b/src/WingetCreateCore/Common/GitHub.cs
@@ -137,12 +137,12 @@ namespace Microsoft.WingetCreateCore.Common
         /// </summary>
         /// <param name="manifests">Wrapper object for manifest object models to be submitted in the PR.</param>
         /// <param name="submitToFork">Bool indicating whether or not to submit the PR via a fork.</param>
-        /// <param name="manifestRoot">The manifest root name.</param>
         /// <param name="prTitle">Optional parameter specifying the title for the pull request.</param>
         /// <param name="shouldReplace">Optional parameter specifying whether the new submission should replace an existing manifest.</param>
         /// <param name="replaceVersion">Optional parameter specifying the version of the manifest to be replaced.</param>
+        /// <param name="manifestRoot">The manifest root name.</param>
         /// <returns>Pull request object.</returns>
-        public Task<PullRequest> SubmitPullRequestAsync(Manifests manifests, bool submitToFork, string manifestRoot = Constants.WingetManifestRoot, string prTitle = null, bool shouldReplace = false, string replaceVersion = null)
+        public Task<PullRequest> SubmitPullRequestAsync(Manifests manifests, bool submitToFork, string prTitle = null, bool shouldReplace = false, string replaceVersion = null, string manifestRoot = Constants.WingetManifestRoot)
         {
             Dictionary<string, string> contents = new Dictionary<string, string>();
             string id;
@@ -189,6 +189,16 @@ namespace Microsoft.WingetCreateCore.Common
             // Close PR and delete its branch.
             await this.github.PullRequest.Update(this.wingetRepoOwner, this.wingetRepo, pullRequestId, new PullRequestUpdate() { State = ItemState.Closed });
             await this.DeletePullRequestBranch(pullRequestId);
+        }
+
+        /// <summary>
+        /// Retrieves a pull request based on the provided pull request id.
+        /// </summary>
+        /// <param name="pullRequestId">The pull request number.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<Octokit.PullRequest> GetPullRequest(int pullRequestId)
+        {
+            return await this.github.PullRequest.Get(this.wingetRepoOwner, this.wingetRepo, pullRequestId);
         }
 
         /// <summary>

--- a/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/E2ETests/E2ETests.cs
@@ -84,6 +84,7 @@ namespace Microsoft.WingetCreateE2ETests
             };
             ClassicAssert.IsTrue(await submitCommand.Execute(), "Command should have succeeded");
             this.AssertValidationOutput(format);
+            await this.AssertPRTitle(submitCommand.PullRequestNumber, pullRequestTitle);
 
             // Clear output for the next command
             this.sw.GetStringBuilder().Clear();
@@ -118,6 +119,7 @@ namespace Microsoft.WingetCreateE2ETests
 
             // Since SubmitToGitHub is true, the command will first validate the manifest & then submit the PR
             this.AssertValidationOutput(format);
+            await this.AssertPRTitle(submitCommand.PullRequestNumber, pullRequestTitle);
             await this.gitHub.ClosePullRequest(updateCommand.PullRequestNumber);
         }
 
@@ -132,6 +134,12 @@ namespace Microsoft.WingetCreateE2ETests
             {
                 Assert.That(output, Does.Contain(Resources.SkippingManifestValidation_Message), "Skipping manifest validation message should be shown");
             }
+        }
+
+        private async Task AssertPRTitle(int pullRequestNumber, string expectedTitle)
+        {
+            Octokit.PullRequest pr = await this.gitHub.GetPullRequest(pullRequestNumber);
+            Assert.That(pr.Title, Is.EqualTo(expectedTitle), "PR title should match the expected title");
         }
     }
 }

--- a/src/WingetCreateTests/WingetCreateTests/UnitTests/GitHubTests.cs
+++ b/src/WingetCreateTests/WingetCreateTests/UnitTests/GitHubTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.WingetCreateUnitTests
             manifests.SingletonManifest = Serialization.DeserializeFromString<SingletonManifest>(latestManifest.First());
             Assert.That(manifests.SingletonManifest.PackageIdentifier, Is.EqualTo(TestConstants.TestPackageIdentifier), FailedToRetrieveManifestFromId);
 
-            Octokit.PullRequest pullRequest = await this.gitHub.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, root, TestConstants.TestPRTitle);
+            Octokit.PullRequest pullRequest = await this.gitHub.SubmitPullRequestAsync(manifests, this.SubmitPRToFork, TestConstants.TestPRTitle, false, null, root);
             Assert.That(TestConstants.TestPRTitle, Is.EqualTo(pullRequest.Title), TitleMismatch);
             await this.gitHub.ClosePullRequest(pullRequest.Number);
             StringAssert.StartsWith(string.Format(GitHubPullRequestBaseUrl, this.WingetPkgsTestRepoOwner, this.WingetPkgsTestRepo), pullRequest.HtmlUrl, PullRequestFailedToGenerate);


### PR DESCRIPTION
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Are you working against an Issue?

## Change

There was another release regression where the value of `--prtitle` was being ignored and set to the manifestRoot value `manifests` because of the order of function args. This only affects the `wingetcreate submit` command. The issue can be seen in the PR title of the test runs

- https://github.com/microsoft/winget-pkgs-submission-test/pull/6344
- https://github.com/microsoft/winget-pkgs-submission-test/pull/6346
- https://github.com/microsoft/winget-pkgs-submission-test/pull/6348

## Validation

I've updated the E2E tests to cover this case, so that future such regressions can be avoided.

To test, one can try and submit a test manifest and provide the `--prtitle` value as

```pwsh
wingetcreate submit "<path>" --prtitle "Some title"
```

-----
