### PR TITLE
Fix pipeline NuGet restore failure under network isolation policy

### DIFF
--- a/NuGet.Internal.config
+++ b/NuGet.Internal.config
@@ -5,7 +5,7 @@
   </solution>
   <packageSources>
     <clear />
-      <add key="PublicPackages" value="https://pkgs.dev.azure.com/microsoft/Apps/_packaging/Apps_PublicPackages/nuget/v3/index.json" />
+      <add key="PublicPackages" value="https://pkgs.dev.azure.com/shine-oss/winget-create/_packaging/WinGetCreateDependencies/nuget/v3/index.json" />
   </packageSources>
   <config>
     <clear />

--- a/pipelines/azure-pipelines.yml
+++ b/pipelines/azure-pipelines.yml
@@ -54,6 +54,7 @@ extends:
     - ES365AIMigrationTooling
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive,CFSClean
 
     stages:
       - stage: GetVersion_Build
@@ -117,12 +118,14 @@ extends:
                   workingDirectory: $(Build.SourcesDirectory)
                   performMultiLevelLookup: true
 
+              - task: NuGetAuthenticate@1
+
               - task: DotNetCoreCLI@2
                 displayName: Restore
                 inputs:
                   command: "restore"
                   feedsToUse: "config"
-                  nugetConfigPath: "NuGet.config"
+                  nugetConfigPath: "NuGet.Internal.config"
                   projects: $(workingDirectory)/**/*.csproj
 
               - task: MSBuild@1


### PR DESCRIPTION
## Summary

- Fixes a network isolation compliance issue on the main CI pipeline, which was failing to restore NuGet packages.

`NuGet.config` stays public-facing so external OSS contributors can restore/build locally. The pipeline now uses `NuGet.Internal.config` (an internal-feed-only config, already used by the release pipeline) for its own restore step instead, authenticating via `NuGetAuthenticate@1` against a same-org Azure Artifacts feed.
