### PR TITLE
Add agent guidance for issues and PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,6 +49,15 @@ Open `src\WingetCreateCLI.sln` in Visual Studio and build. Command-line `msbuild
 - CI runs on Azure Pipelines (`pipelines/`).
 - Documentation for each command lives under `doc/` (e.g., `doc/new.md`, `doc/update.md`) — update alongside CLI changes.
 
+## Issues and Pull Requests
+
+- Before filing an issue, search existing open and closed issues for duplicates.
+- Use the GitHub issue forms in `.github/ISSUE_TEMPLATE/`; do not file a blank issue unless a maintainer explicitly asks for one.
+- Bug reports should include the form fields for brief description, steps to reproduce, expected behavior, actual behavior, and environment.
+- Feature requests should include the form fields for feature or enhancement description and proposed technical implementation details when known.
+- Keep issue bodies concise and evidence-based. Do not paste large speculative patches into issue bodies; open a pull request or link a branch when code is available.
+- Before opening a pull request, review `CONTRIBUTING.md`, follow the PR template, keep the change focused, and summarize validation performed.
+
 ## Telemetry & Privacy
 
 The built/released `wingetcreate.exe` collects usage/diagnostic telemetry (respecting machine-wide privacy settings and `settings.json`'s `telemetry.disabled`). Locally-built binaries do not have telemetry enabled. See `PRIVACY.md` for details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent instructions
+
+Follow `.github/copilot-instructions.md` for repository-specific development guidance.
+
+## Issues
+
+Before filing a GitHub issue in this repository:
+
+1. Search existing open and closed issues for duplicates.
+2. Use the GitHub issue forms in `.github/ISSUE_TEMPLATE/`; do not file a blank issue unless a maintainer explicitly asks for one.
+3. For bugs, include the same information requested by the Bug Report form: brief description, steps to reproduce, expected behavior, actual behavior, and environment.
+4. For feature requests, include the same information requested by the Feature Request form: description of the new feature or enhancement and proposed technical implementation details when known.
+5. Keep issue bodies concise and evidence-based. Do not paste large speculative patches into issue bodies; open a pull request or link a branch when code is available.
+
+## Pull requests
+
+Before opening a pull request:
+
+1. Review `CONTRIBUTING.md` and follow the repository PR template.
+2. Keep each PR focused on one logical change.
+3. Include or update tests and documentation when the change affects command behavior, manifest generation, submission flow, or user guidance.
+4. Summarize validation performed, or explain why validation was not run.


### PR DESCRIPTION
## 📖 Description
Adds a root AGENTS.md for agent compatibility and mirrors issue/PR guidance in .github/copilot-instructions.md.

This nudges agents to search for duplicates, use the repository issue forms instead of blank issues, keep issue bodies concise, and follow the PR template when opening pull requests.

## 🔗 References
Related cross-repo context: https://github.com/microsoft/winget-cli/issues/6433

## 🔍 Validation
Docs-only change. Reviewed the Markdown content and git diff.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/695)