### PR TITLE
Update Sharprompt to 3.1.2 to fix crash in small terminal

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Octokit" Version="9.1.2" />
     <PackageVersion Include="Polly" Version="8.3.0" />
     <PackageVersion Include="RestSharp" Version="112.0.0" />
-    <PackageVersion Include="Sharprompt" Version="2.4.5" />
+    <PackageVersion Include="Sharprompt" Version="3.1.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2062,7 +2062,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---------------------------------------------------------
 
-Sharprompt 2.4.5 - MIT
+Sharprompt 3.1.2 - MIT
 
 
 


### PR DESCRIPTION
## 📖 Description
Upgrades Sharprompt from 2.4.5 to 3.1.2 to fix a crash (`ArgumentOutOfRangeException` at `Console.SetCursorPosition`) that occurs when the terminal window is too small. The upstream fix, shibayan/Sharprompt#373, is included in Sharprompt 3.1.2.

## 🔗 References
Fixes #697

## 🔍 Validation
- Compiled successfully with Sharprompt 3.1.2 (Sharprompt.dll 3.1.2.0 linked into output)
- 113/129 unit tests pass; the 16 failures are all environment-related (14 require CI runsettings `WingetPkgsTestRepoOwner`; 2 are localization-dependent FieldValidationTests on non-English system locale) and unrelated to this change

## ✅ Checklist
- [x] Signed the Contributor License Agreement
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [x] Bug fix

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/winget-create/pull/699)